### PR TITLE
feat: add competitor-ad-intelligence and ad-campaign-analyzer marketing skills

### DIFF
--- a/plugins/community/ad-campaign-analyzer/.claude-plugin/plugin.json
+++ b/plugins/community/ad-campaign-analyzer/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ad-campaign-analyzer",
+  "version": "1.0.0",
+  "description": "Ad spend diagnostics: statistical-significance checks, budget-waste analysis, winners to scale, and multi-channel budget reallocation from campaign exports. Pure reasoning, no tools.",
+  "author": {
+    "name": "GooseWorks",
+    "url": "https://github.com/gooseworks-ai",
+    "email": "himanshu@athina.ai"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/gooseworks-ai/goose-skills"
+}

--- a/plugins/community/ad-campaign-analyzer/.source.json
+++ b/plugins/community/ad-campaign-analyzer/.source.json
@@ -1,0 +1,18 @@
+{
+  "synced_from": {
+    "repo": "gooseworks-ai/goose-skills",
+    "path": "skills/ads/composites/ad-campaign-analyzer",
+    "branch": "main"
+  },
+  "last_sync": "2026-07-16T05:50:00.000Z",
+  "author": {
+    "name": "GooseWorks",
+    "github": "gooseworks-ai",
+    "email": "himanshu@athina.ai"
+  },
+  "license": "MIT",
+  "files_synced": 1,
+  "files": [
+    "SKILL.md"
+  ]
+}

--- a/plugins/community/ad-campaign-analyzer/README.md
+++ b/plugins/community/ad-campaign-analyzer/README.md
@@ -1,0 +1,11 @@
+# ad-campaign-analyzer
+
+Ad spend diagnostics: statistical-significance checks, budget-waste analysis, winners to scale, and multi-channel budget reallocation from campaign exports. Pure reasoning, no tools.
+
+Part of [goose-skills](https://github.com/gooseworks-ai/goose-skills) — an open-source (MIT) library of 125 growth/GTM skills by [GooseWorks](https://gooseworks.ai). Contributed with attribution; fully standalone.
+
+Install in Claude Code:
+
+```
+/plugin install ad-campaign-analyzer@claude-code-plugins-plus
+```

--- a/plugins/community/ad-campaign-analyzer/SKILL.md
+++ b/plugins/community/ad-campaign-analyzer/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: ad-campaign-analyzer
+description: Use when the user shares ad campaign performance data and asks what to cut, scale, or test. Trigger phrases include "analyze my ad campaigns", "where am I wasting ad spend", "reallocate my ad budget", "which ads are actually working", "ROAS analysis", or "optimize my Meta/Google Ads spend". Ingests campaign exports (CSV, paste, or screenshot from Google, Meta, LinkedIn), runs statistical-significance checks and funnel diagnostics, and outputs budget-waste analysis, winners to scale, and a multi-channel budget reallocation plan with dollar-amount shifts. Do NOT trigger for campaign planning or ad creative generation without performance data.
+version: 1.0.0
+author: GooseWorks <himanshu@athina.ai>
+license: MIT
+compatibility: Pure reasoning skill over user-provided campaign exports — no external tools, network calls, or API keys.
+tags: [community, marketing, ads, analytics, budget-optimization]
+---
+
+# Ad Campaign Analyzer
+
+Take raw campaign performance data and turn it into clear decisions. This skill doesn't just summarize metrics — it diagnoses problems, identifies winners, checks statistical significance, and tells you exactly what to cut, scale, and test next. Then it goes further: it compares channels on equal terms, finds where you're over-spending vs under-spending relative to results, and produces a concrete budget reallocation plan.
+
+**Core principle:** Most startup founders check their ad dashboard, see a ROAS number, and either panic or celebrate. This skill gives you the nuanced analysis a paid media specialist would: what's actually significant, what's noise, and where your next dollar should go. It also solves the allocation problem — most startups either spread budget too thin across channels (no channel gets enough to learn) or dump everything into one channel (missing cheaper opportunities elsewhere).
+
+## When to Use
+
+- "Analyze my Google Ads performance"
+- "Which ads should I kill?"
+- "Is this campaign working?"
+- "Where am I wasting ad spend?"
+- "Optimize my Meta Ads"
+- "How should I split my ad budget?"
+- "Should I spend more on Google or Meta?"
+- "Reallocate my ad spend across channels"
+- "Where am I getting the best return?"
+- "I have $X/month for ads — how should I distribute it?"
+
+## Phase 0: Intake
+
+1. **Campaign data** — One of:
+   - CSV export from Google Ads / Meta Ads Manager / LinkedIn Campaign Manager
+   - Pasted performance table
+   - Screenshots of dashboard (we'll extract the data)
+2. **Platform(s)** — Google / Meta / LinkedIn / All
+3. **Time period** — What date range does this cover?
+4. **Monthly budget** — Total ad spend in this period
+5. **Primary goal** — What conversion are you optimizing for? (Demos / Trials / Purchases / Leads)
+6. **Target metrics** — Do you have target CPA or ROAS? (If not, we'll benchmark)
+7. **Any known changes?** — Did you change creative, budget, or targeting during this period?
+8. **Channels currently running** — Google Ads, Meta Ads, LinkedIn Ads, Twitter/X Ads, TikTok Ads, other
+9. **Funnel data** (if available):
+   - Lead → MQL rate
+   - MQL → SQL rate
+   - SQL → Close rate
+   - Average deal size
+10. **Channels you're considering but haven't tried** — Want to test new channels?
+11. **Constraints** — Minimum spend on any channel? Platform you must stay on?
+
+## Phase 1: Data Ingestion & Normalization
+
+### Accepted Data Formats
+
+| Source | Key Columns Expected |
+|--------|---------------------|
+| **Google Ads** | Campaign, Ad Group, Keyword, Impressions, Clicks, CTR, CPC, Conversions, Conv Rate, Cost, Conv Value |
+| **Meta Ads** | Campaign, Ad Set, Ad, Impressions, Reach, Clicks, CTR, CPC, Conversions, Cost Per Result, Amount Spent, ROAS |
+| **LinkedIn Ads** | Campaign, Impressions, Clicks, CTR, CPC, Conversions, Cost, Leads |
+
+Normalize all data into a standard analysis format:
+
+| Dimension | Impressions | Clicks | CTR | CPC | Conversions | Conv Rate | CPA | Spend | Revenue/Value |
+|-----------|------------|--------|-----|-----|-------------|----------|-----|-------|--------------|
+
+### Multi-Channel Normalization
+
+When data spans multiple channels, also produce a channel-level rollup:
+
+| Channel | Monthly Spend | Impressions | Clicks | CTR | CPC | Conversions | Conv Rate | CPA | ROAS | CAC* |
+|---------|-------------|------------|--------|-----|-----|-------------|----------|-----|------|------|
+| Google Search | $[X] | [N] | [N] | [X%] | $[X] | [N] | [X%] | $[X] | [X] | $[X] |
+| Google Display | ... | | | | | | | | | |
+| Meta (FB/IG) | ... | | | | | | | | | |
+| LinkedIn | ... | | | | | | | | | |
+| [Other] | ... | | | | | | | | | |
+| **Total** | $[X] | | | | | [N] | | $[X] avg | [X] avg | $[X] avg |
+
+*CAC = Full customer acquisition cost if funnel data provided (CPA × close-rate adjustment)
+
+### Funnel-Adjusted CAC (If Funnel Data Available)
+
+```
+Channel CAC = CPA ÷ (MQL rate × SQL rate × Close rate)
+```
+
+This reveals which channels produce leads that actually close, not just convert.
+
+## Phase 2: Performance Diagnostics
+
+### 2A: Campaign-Level Health Check
+
+For each campaign:
+
+| Metric | Value | Benchmark | Status |
+|--------|-------|-----------|--------|
+| CTR | [X%] | [Industry avg] | [Good/Okay/Poor] |
+| CPC | $[X] | [Category avg] | [Good/Okay/Poor] |
+| Conv Rate | [X%] | [Benchmark] | [Good/Okay/Poor] |
+| CPA | $[X] | [Target or benchmark] | [Good/Okay/Poor] |
+| ROAS | [X] | [Target or benchmark] | [Good/Okay/Poor] |
+| Impression Share | [X%] | [>60% ideal] | [Good/Okay/Poor] |
+
+### 2B: Budget Waste Detection
+
+Identify spend that produced no or negative return:
+
+| Waste Type | Signal | Action |
+|-----------|--------|--------|
+| **Zero-conversion keywords/ads** | Spend > $[X] with 0 conversions | Pause or add negatives |
+| **High CPA outliers** | CPA > 3x target | Pause or restructure |
+| **Low CTR ads** | CTR < 50% of campaign average | Replace creative |
+| **Broad match bleed** | Search terms report showing irrelevant clicks | Add negative keywords |
+| **Audience overlap** | Same users hit by multiple campaigns | Exclude audiences |
+| **Dayparting waste** | Conversions cluster at certain hours; spend is 24/7 | Set ad schedule |
+
+### 2C: Winner Identification
+
+Find what's actually working:
+
+| Winner Type | Signal | Action |
+|------------|--------|--------|
+| **Top-performing keywords** | Lowest CPA, highest conv rate | Increase bid, add variants |
+| **Winning ads** | Highest CTR + conv rate combo | Scale spend, clone for other groups |
+| **Best audiences** | Lowest CPA segment | Increase budget allocation |
+| **Best times** | Peak conversion hours/days | Concentrate budget |
+
+### 2D: Statistical Significance Check
+
+For any A/B test (ad variants, audiences, landing pages):
+
+```
+Test: [Variant A] vs [Variant B]
+Metric: [Conv Rate / CTR / CPA]
+Variant A: [X%] (n=[sample_size])
+Variant B: [Y%] (n=[sample_size])
+Confidence level: [X%]
+Verdict: [Statistically significant / Not enough data / Too close to call]
+Recommended action: [Pick winner / Continue test / Increase budget to reach significance]
+```
+
+Minimum sample: 100 clicks per variant for CTR tests, 30 conversions per variant for CPA tests.
+
+## Phase 3: Funnel Analysis
+
+### Click → Conversion Path
+
+```
+Impressions: [N] (100%)
+     ↓ CTR: [X%]
+Clicks: [N] ([X%] of impressions)
+     ↓ Landing page → Conversion: [X%]
+Conversions: [N] ([X%] of clicks)
+     ↓ Conversion → Revenue: $[X] avg
+Revenue: $[N]
+```
+
+### Funnel Drop-Off Diagnosis
+
+| Drop-Off Point | Rate | Benchmark | Likely Cause | Fix |
+|----------------|------|-----------|-------------|-----|
+| Impression → Click | [CTR%] | [Benchmark] | [Ad relevance / targeting] | [Copy/targeting change] |
+| Click → Conversion | [Conv%] | [Benchmark] | [Landing page / offer / audience mismatch] | [LP optimization] |
+| Conversion → Revenue | [Close%] | [Benchmark] | [Lead quality / sales process] | [Qualification criteria] |
+
+## Phase 4: Budget Reallocation
+
+When data spans multiple channels, perform cross-channel budget optimization.
+
+### 4A: Channel Efficiency Ranking
+
+| Rank | Channel | CPA | Funnel-Adj CAC | Share of Spend | Share of Conversions | Efficiency Index |
+|------|---------|-----|---------------|----------------|---------------------|-----------------|
+| 1 | [Channel] | $[X] | $[X] | [X%] | [X%] | [Conv share ÷ Spend share] |
+
+**Efficiency Index:**
+- **> 1.0** = Under-invested (getting more than its share of conversions)
+- **= 1.0** = Proportional (fair share)
+- **< 1.0** = Over-invested (getting less than its share)
+
+### 4B: Marginal Return Analysis
+
+For each channel, estimate if additional spend would yield proportional returns:
+
+| Channel | Current CPA | Impression Share / Saturation Signal | Marginal Return Estimate |
+|---------|-------------|-------------------------------------|------------------------|
+| Google Search | $[X] | [X%] impression share — room to grow | Likely positive |
+| Meta | $[X] | Frequency [X] — audience may be saturated | Diminishing |
+| LinkedIn | $[X] | Low volume — limited targeting pool | Ceiling soon |
+
+### 4C: Funnel Stage Coverage
+
+| Funnel Stage | Channels Covering It | Current Spend | Gap? |
+|-------------|---------------------|--------------|------|
+| **Awareness** (top) | [Meta Display, YouTube] | $[X] | [Yes/No] |
+| **Consideration** (mid) | [Google Search, Meta retargeting] | $[X] | [Yes/No] |
+| **Decision** (bottom) | [Google Brand, Google Search] | $[X] | [Yes/No] |
+| **Retargeting** | [Meta, Google Display] | $[X] | [Yes/No] |
+
+### 4D: Budget Shift Recommendations
+
+| Channel | Current Spend | Recommended Spend | Change | Reasoning |
+|---------|-------------|------------------|--------|-----------|
+| Google Search | $[X] | $[Y] | +$[Z] | [Lowest CPA, room to scale] |
+| Meta | $[X] | $[Y] | -$[Z] | [Audience saturation, frequency too high] |
+| LinkedIn | $[X] | $[Y] | $0 | [Maintain — niche but valuable] |
+| [New channel] | $0 | $[Y] | +$[Y] | [Test budget — competitors succeeding here] |
+| **Total** | $[X] | $[X] | $0 | Budget-neutral reallocation |
+
+### 4E: Scenario Modeling
+
+**Scenario 1: Conservative shift (+/- 20%)**
+- Expected conversions: [N] (currently [N]) = [X%] improvement
+- Expected blended CPA: $[X] (currently $[X])
+- Risk: Low
+
+**Scenario 2: Aggressive shift (+/- 40%)**
+- Expected conversions: [N] = [X%] improvement
+- Expected blended CPA: $[X]
+- Risk: Medium — less data on scaled channels
+
+**Scenario 3: Budget increase to $[Y]/mo**
+- Recommended allocation: [table]
+- Expected conversions: [N]
+- New channels to test: [list]
+
+## Phase 5: Output Format
+
+```markdown
+# Ad Campaign Analysis — [Product/Client] — [DATE]
+
+Period: [Date range]
+Total spend: $[X]
+Platform(s): [Google / Meta / LinkedIn]
+Primary goal: [Conversions / Revenue / Leads]
+
+---
+
+## Executive Summary
+
+[3-5 sentences: Overall performance verdict, biggest win, biggest problem, top recommendation including any reallocation moves]
+
+---
+
+## Performance Dashboard
+
+| Campaign | Spend | Impressions | Clicks | CTR | CPC | Conversions | CPA | ROAS | Verdict |
+|----------|-------|------------|--------|-----|-----|-------------|-----|------|---------|
+| [Name] | $[X] | [N] | [N] | [X%] | $[X] | [N] | $[X] | [X] | [Scale/Optimize/Pause] |
+
+---
+
+## Budget Waste Report
+
+**Total estimated waste: $[X] ([X%] of total spend)**
+
+### Wasted on zero-conversion items: $[X]
+[List of keywords/ads/audiences with spend but no conversions]
+
+### Wasted on high-CPA items: $[X]
+[List of items with CPA > 3x target]
+
+### Recommended saves: $[X]/month
+[Specific items to pause]
+
+---
+
+## Winners to Scale
+
+### Top Keywords/Audiences
+| Item | CPA | Conv Rate | Current Spend | Recommended Spend |
+|------|-----|----------|--------------|-------------------|
+
+### Top Ads
+| Ad | CTR | Conv Rate | Why It Works |
+|----|-----|----------|-------------|
+
+---
+
+## A/B Test Results
+
+### [Test Name]
+- Variant A: [Metric] (n=[N])
+- Variant B: [Metric] (n=[N])
+- Confidence: [X%]
+- **Verdict:** [Winner / Continue / Inconclusive]
+
+---
+
+## Budget Reallocation
+
+### Current vs Recommended Allocation
+
+| Channel | Current | Recommended | Change | Why |
+|---------|---------|------------|--------|-----|
+| [Channel] | $[X] | $[Y] | [+/-$Z] | [1-line reason] |
+
+**Projected impact:**
+- Conversions: [N] → [N] (+[X%])
+- Blended CPA: $[X] → $[Y] (-[X%])
+
+### Funnel Stage Coverage
+[Coverage map with gaps identified]
+
+### New Channel Recommendations
+
+#### [Channel Name]
+- **Why test:** [Reasoning]
+- **Recommended test budget:** $[X]/mo for [X weeks]
+- **Success criteria:** CPA < $[X]
+- **Competitors using it:** [Yes/No — who]
+
+---
+
+## Action Plan
+
+### Immediate (This Week)
+- [ ] **Pause:** [Specific items — keywords, ads, audiences]
+- [ ] **Scale:** [Specific items — increase budget/bids]
+- [ ] **Add negatives:** [Specific keywords from search terms]
+- [ ] **Reallocate:** [Specific dollar shifts between channels]
+
+### This Month
+- [ ] **Test:** [New ad angles / audiences / landing pages]
+- [ ] **Restructure:** [Ad groups that need splitting or merging]
+- [ ] **Optimize:** [Bid strategy changes]
+- [ ] **Monitor reallocation:** Track CPA shifts on scaled channels, watch for diminishing returns
+
+### Next Month
+- [ ] **Expand:** [New campaigns / channels to test]
+- [ ] **Re-evaluate:** [Run this analysis again with new data, adjust allocations based on actual results]
+```
+
+Save to `campaign-analysis-[YYYY-MM-DD].md` in the current working directory (or user-specified path).
+
+## Cost
+
+| Component | Cost |
+|-----------|------|
+| Data analysis | Free (LLM reasoning) |
+| Statistical calculations | Free |
+| **Total** | **Free** |
+
+## Tools Required
+
+- No external tools needed — pure reasoning skill
+- User provides campaign data as CSV, paste, or screenshot
+
+## Trigger Phrases
+
+- "Analyze my ad campaign performance"
+- "Which ads should I pause?"
+- "Where am I wasting ad budget?"
+- "Is my Google Ads campaign working?"
+- "Optimize my Meta Ads spend"
+- "How should I allocate my ad budget?"
+- "Should I spend more on Google or Meta?"
+- "Reallocate my ad spend"
+- "Where am I getting the best ROAS?"
+- "Optimize my multi-channel ad budget"

--- a/plugins/community/competitor-ad-intelligence/.claude-plugin/plugin.json
+++ b/plugins/community/competitor-ad-intelligence/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "competitor-ad-intelligence",
+  "version": "1.0.0",
+  "description": "Competitor paid-ads teardown: scrapes Meta Ad Library and Google Ads Transparency Center (no API keys), analyzes creative patterns and funnels, outputs strategic gaps and counter-plays.",
+  "author": {
+    "name": "GooseWorks",
+    "url": "https://github.com/gooseworks-ai",
+    "email": "himanshu@athina.ai"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/gooseworks-ai/goose-skills"
+}

--- a/plugins/community/competitor-ad-intelligence/.source.json
+++ b/plugins/community/competitor-ad-intelligence/.source.json
@@ -1,0 +1,18 @@
+{
+  "synced_from": {
+    "repo": "gooseworks-ai/goose-skills",
+    "path": "skills/ads/composites/competitor-ad-intelligence",
+    "branch": "main"
+  },
+  "last_sync": "2026-07-16T05:50:00.000Z",
+  "author": {
+    "name": "GooseWorks",
+    "github": "gooseworks-ai",
+    "email": "himanshu@athina.ai"
+  },
+  "license": "MIT",
+  "files_synced": 1,
+  "files": [
+    "SKILL.md"
+  ]
+}

--- a/plugins/community/competitor-ad-intelligence/README.md
+++ b/plugins/community/competitor-ad-intelligence/README.md
@@ -1,0 +1,11 @@
+# competitor-ad-intelligence
+
+Competitor paid-ads teardown: scrapes Meta Ad Library and Google Ads Transparency Center (no API keys), analyzes creative patterns and funnels, outputs strategic gaps and counter-plays.
+
+Part of [goose-skills](https://github.com/gooseworks-ai/goose-skills) — an open-source (MIT) library of 125 growth/GTM skills by [GooseWorks](https://gooseworks.ai). Contributed with attribution; fully standalone.
+
+Install in Claude Code:
+
+```
+/plugin install competitor-ad-intelligence@claude-code-plugins-plus
+```

--- a/plugins/community/competitor-ad-intelligence/SKILL.md
+++ b/plugins/community/competitor-ad-intelligence/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: competitor-ad-intelligence
+description: Use when the user asks what ads a competitor is running, wants a competitor ad teardown, or asks for competitive ad analysis. Trigger phrases include "what ads is X running", "tear down X's ad strategy", "competitor ad intelligence", "find ad angles we haven't tried", "reverse-engineer their paid funnel", or "audit the ad landscape for [category]". Scrapes the Meta Ad Library and Google Ads Transparency Center via web search (free public sources, no API keys), analyzes creative patterns and ad longevity, maps landing-page funnels, and outputs a strategic teardown with creative gaps, vulnerabilities, and counter-plays. Do NOT trigger for organic/SEO competitor research, website positioning analysis, or building comparison pages.
+allowed-tools: WebSearch, WebFetch
+version: 1.0.0
+author: GooseWorks <himanshu@athina.ai>
+license: MIT
+compatibility: Uses web search and public ad libraries only — no API keys, credentials, or MCP servers required.
+tags: [community, marketing, ads, competitive-intelligence]
+---
+
+# Competitor Ad Intelligence
+
+Scrape competitor ads from Meta and Google, analyze creative patterns, reverse-engineer landing page funnels, and produce a full strategic teardown — hooks, formats, positioning bets, vulnerabilities, and counter-plays.
+
+**Core principle:** A competitor's ad portfolio is a window into their growth strategy. Long-running ads reveal what converts. New ads reveal what they're testing. Landing pages reveal their positioning bets. The best ad creative teams start with evidence from what's already working, then differentiate.
+
+## When to Use
+
+- "What ads are my competitors running?"
+- "Tear down [competitor]'s ad strategy"
+- "Find new creative angles for our paid campaigns"
+- "Reverse-engineer [competitor]'s paid funnel"
+- "What hooks are working in [our space]?"
+- "Audit the ad landscape before we launch"
+- "Find weaknesses in [competitor]'s ad strategy"
+- "What format — video, image, carousel — is dominant in our category?"
+
+## Phase 0: Intake
+
+Gather from the user:
+
+1. **Competitor names + domains** (e.g., `apollo.io`, `clay.run`)
+2. **Your product/domain** — for comparison framing
+3. **Channels:** Meta only, Google only, or both? (default: both)
+4. **Depth level:**
+   - **Standard:** Ad scrape + creative analysis + landing page analysis
+   - **Deep:** Standard + historical comparison + funnel reconstruction + counter-plays
+5. **Product category** — helps frame analysis
+6. **Known competitor landing pages?** — any URLs already spotted in their ads
+
+## Phase 1: Scrape Meta Ads
+
+For each competitor domain, scrape ads from Meta Ad Library.
+
+Use `web_search` to find competitor ads in the Meta Ad Library (publicly accessible, no API key needed):
+
+```
+web_search: site:facebook.com/ads/library "[competitor_name]"
+web_search: "[competitor_name]" Meta Ad Library active ads
+web_search: "[competitor_name]" facebook ads examples
+```
+
+You can also visit the Meta Ad Library directly: `https://www.facebook.com/ads/library/?active_status=active&ad_type=all&country=US&q=<competitor_name>`
+
+Use `fetch_webpage` on the Ad Library URL to extract ad details if your agent supports it.
+
+> **Note:** Apify actors for Meta Ad Library scraping exist but are unreliable as of April 2026 due to Meta's anti-scraping measures. Use `web_search` as the primary method.
+
+**Collect per ad:**
+- Ad copy (headline + primary text)
+- Visual type (image / video / carousel)
+- CTA button text
+- Landing page URL
+- Active duration (first seen, still running or stopped)
+- Platforms (Facebook, Instagram, Audience Network)
+- Ad variations (A/B tests — same landing page, different creative)
+
+## Phase 2: Scrape Google Ads
+
+For each competitor domain, scrape ads from Google Ads Transparency Center.
+
+Use `web_search` to find competitor ads in Google Ads Transparency Center (publicly accessible):
+
+```
+web_search: site:adstransparency.google.com "[competitor_name]"
+web_search: "[competitor_name]" Google Ads transparency
+web_search: "[competitor_name]" google search ads examples
+```
+
+You can also visit directly: `https://adstransparency.google.com/?search_text=<competitor_name>`
+
+Use `fetch_webpage` on the Transparency Center URL to extract ad details if your agent supports it.
+
+**Collect per ad:**
+- Headline variants (up to 3)
+- Description lines
+- Ad type (Search / Display / YouTube / Shopping)
+- Landing page URL
+- Geographic targeting (if visible)
+
+## Phase 3: Analyze Creative Patterns
+
+After collecting all ads, perform structured analysis.
+
+### Hook Pattern Clustering
+
+Group all ad headlines/openers by hook type:
+
+| Hook Type | Pattern | Example |
+|-----------|---------|---------|
+| **Fear/Loss** | Risk of missing out or falling behind | "Your competitors are already using AI SDRs" |
+| **Outcome** | Direct result promise | "10x your pipeline in 30 days" |
+| **Question** | Challenges current assumption | "Still doing outbound manually?" |
+| **Social proof** | Names customers or numbers | "Join 500+ B2B teams using [product]" |
+| **Contrarian** | Challenges conventional wisdom | "Cold email isn't dead. Your copy is." |
+| **Empathy** | Validates their pain | "We know SDR ramp time is brutal" |
+| **Product-led** | Feature as hook | "[Feature] is live — see what's new" |
+
+Count how many ads per competitor use each hook type. This reveals their primary messaging strategy.
+
+### Format Distribution
+
+| Format | Meta | Google |
+|--------|------|--------|
+| Static image | [N] | N/A |
+| Video | [N] | [N] |
+| Carousel | [N] | N/A |
+| Search text | N/A | [N] |
+| Display banner | N/A | [N] |
+
+### CTA Taxonomy
+
+List all unique CTAs found. Common patterns:
+- **Urgency:** "Start free", "Try now", "Get started today"
+- **Low-friction:** "See how it works", "Watch demo", "Learn more"
+- **Outcome:** "Book a demo", "Get your free audit", "Calculate your ROI"
+
+## Phase 4: Landing Page & Funnel Analysis
+
+For each unique landing page URL found in ads, fetch and analyze:
+
+```
+fetch_webpage: [landing_page_url]
+```
+
+Or use `curl` if `fetch_webpage` is unavailable.
+
+**Extract per landing page:**
+- **Hero headline** — Does it match the ad promise?
+- **Subheadline** — Value prop expansion
+- **Primary CTA** — What action are they driving? (Demo / Free trial / Sign up / Download)
+- **Social proof** — Logos, testimonials, case study metrics
+- **Pricing visibility** — Is pricing shown or hidden?
+- **Form fields** — How much info do they ask for?
+- **Page type** — General homepage / dedicated LP / feature page / use-case page
+- **Message match score** — How well does the LP deliver on the ad's promise? (1-10)
+
+### Campaign Clustering
+
+Group all ads into logical campaigns by:
+- **Landing page destination** — Ads pointing to the same URL = same campaign
+- **Messaging theme** — Similar copy angles = same strategic bet
+- **Audience signal** — Different copy for different personas
+
+### Per-Campaign Funnel Analysis
+
+For each campaign cluster:
+
+| Dimension | Analysis |
+|-----------|----------|
+| **Strategic intent** | What is this campaign trying to achieve? (Awareness / Lead gen / Free trial / Competitive displacement) |
+| **Target persona** | Who is this ad speaking to? (Role, pain, stage) |
+| **Positioning bet** | What market position are they claiming? |
+| **Hook strategy** | Fear / Outcome / Social proof / Contrarian / Product-led |
+| **Conversion path** | Ad → LP → CTA → [Demo call / Free trial / Content download] |
+| **Longevity signal** | How long has this been running? (Longer = likely working) |
+| **A/B tests detected** | Multiple creatives to same LP = active testing |
+
+### Budget Allocation Inference
+
+Based on ad volume and platform distribution, estimate where they're concentrating spend:
+
+| Platform | Ad Count | % of Total | Estimated Focus |
+|----------|----------|-----------|-----------------|
+| Meta (Facebook) | [N] | [X%] | [Awareness / Retargeting] |
+| Meta (Instagram) | [N] | [X%] | [Visual / younger audience] |
+| Google Search | [N] | [X%] | [Bottom-funnel capture] |
+| Google Display | [N] | [X%] | [Awareness / retargeting] |
+| YouTube | [N] | [X%] | [Education / awareness] |
+
+## Phase 5: Strategic Analysis
+
+### Creative Gap Analysis
+
+Identify across all competitors:
+
+1. **Angles nobody is running** — Hook types absent from competitor ads = white space
+2. **Overcrowded angles** — If everyone leads with "save time", avoid it or be more specific
+3. **Format opportunities** — If no one is running video in your space, it may stand out
+4. **Underutilized proof** — Are competitors avoiding specific proof points you could own?
+5. **CTA patterns to test** — What CTAs do the longest-running ads use?
+
+### Vulnerability Analysis
+
+Identify weaknesses in each competitor's ad strategy:
+
+| Vulnerability Type | Description |
+|-------------------|-------------|
+| **Message-LP mismatch** | Ad promises one thing, LP delivers another |
+| **Single-persona dependency** | All ads target the same persona — missing segments |
+| **Platform concentration** | Heavy on one platform, absent from others |
+| **No social proof** | Ads or LPs lack credibility markers |
+| **Weak CTA** | Asking for too much too soon (demo before value) |
+| **Generic positioning** | Claims anyone could make — not differentiated |
+| **Stale creative** | Same ads running unchanged for months — fatigue risk |
+
+### Historical Comparison (Deep Mode)
+
+If Web Archive data exists for their landing pages:
+- Has their positioning changed in the last 6-12 months?
+- What campaigns did they retire? (Possible losers)
+- What campaigns have they scaled up? (Possible winners)
+
+## Phase 6: Output
+
+```markdown
+# Competitor Ad Intelligence Report — [DATE]
+
+## Coverage
+- Competitors analyzed: [list]
+- Meta ads collected: [N]
+- Google ads collected: [N]
+- Unique landing pages analyzed: [N]
+- Estimated active campaigns: [N]
+
+---
+
+## Executive Summary
+
+[3-5 sentence summary: What is the competitive ad landscape? What's working? Where are the gaps and vulnerabilities?]
+
+---
+
+## Meta Ad Analysis
+
+### Hook Distribution
+| Hook Type | [Comp1] | [Comp2] | [Comp3] |
+|-----------|---------|---------|---------|
+| Fear/Loss | 40% | 10% | 0% |
+| Outcome | 30% | 50% | 60% |
+...
+
+### Top Performing Ads (Longest Running)
+**[Competitor] — [Ad Title/Hook]**
+> [Ad copy excerpt]
+- Format: [type]
+- CTA: [text]
+- Running since: [date]
+- Why it likely works: [analysis]
+
+---
+
+## Google Ad Analysis
+
+### Headline Patterns
+[Top headline structures with examples]
+
+### Most Common CTAs
+[ranked list]
+
+---
+
+## Campaign Breakdown
+
+### Campaign 1: [Inferred Campaign Name]
+- **Competitor:** [name]
+- **Ads in cluster:** [N]
+- **Platform(s):** [Meta / Google / Both]
+- **Strategic intent:** [Awareness / Lead gen / Competitive displacement / etc.]
+- **Target persona:** [Description]
+- **Hook strategy:** [Type]
+- **Landing page:** [URL]
+  - Hero: "[Headline text]"
+  - CTA: "[Button text]"
+  - Message match: [Score/10]
+- **Longevity:** [First seen date → status]
+- **A/B tests detected:** [Yes/No — what they're testing]
+
+**Sample ad:**
+> **Headline:** [text]
+> **Body:** [text]
+> **CTA:** [button]
+> **Format:** [Image/Video/Carousel]
+
+**Assessment:** [1-2 sentences — is this working? Why/why not?]
+
+### Campaign 2: ...
+
+---
+
+## Funnel Map
+
+```
+[Ad: Hook/Angle] → [LP: /landing-page-url] → [CTA: Book Demo]
+                                               ↓
+[Ad: Different angle] → [LP: /same-or-different] → [CTA: Free Trial]
+```
+
+---
+
+## Budget Allocation Estimate
+
+| Platform | Share | Focus Area |
+|----------|-------|-----------|
+| [Platform] | [X%] | [Intent] |
+
+---
+
+## Creative Gap Analysis
+
+### Angles Nobody Is Running
+1. [Angle] — Why it could work for you: [reasoning]
+2. [Angle] — ...
+
+### Overcrowded Angles (Avoid or Differentiate)
+- [Angle] — [N] of [N] competitors use this
+
+### Format White Space
+- [Format] is not being used by competitors on [platform]
+
+---
+
+## Vulnerability Report
+
+### 1. [Vulnerability]
+**Competitor:** [name]
+**Evidence:** [What we observed]
+**Your opportunity:** [How to exploit this gap]
+
+### 2. ...
+
+---
+
+## Recommended Counter-Plays
+
+### Counter-Play 1: [Name]
+- **Target their weakness:** [Which vulnerability]
+- **Your ad angle:** [Hook]
+- **Platform:** [Where to run]
+- **Proposed headline:** "[headline]"
+- **Proposed body:** "[copy]"
+- **LP strategy:** [What your landing page should emphasize]
+- **Why test this:** [rationale]
+
+### Counter-Play 2: ...
+```
+
+## Cost
+
+| Component | Cost |
+|-----------|------|
+| Ad library research (web_search) | Free |
+| Landing page fetching | Free |
+| Web Archive lookup (deep mode) | Free |
+| Analysis | Free (LLM reasoning) |
+| **Total** | **Free** |
+
+## Environment Variables
+
+- No API keys required. This skill uses publicly accessible ad libraries and web search.
+
+## Tools Used
+
+- **`web_search`** — query Meta Ad Library and Google Ads Transparency Center
+- **`fetch_webpage`** or **`curl`** — fetch and analyze landing pages
+
+## Trigger Phrases
+
+- "What ads are [competitor] running?"
+- "Tear down [competitor]'s ad strategy"
+- "Audit the ad landscape for [product category]"
+- "Run ad intelligence for [competitors]"
+- "Find new paid ad angles we haven't tried"
+- "Reverse-engineer [competitor]'s paid funnel"
+- "Find weaknesses in [competitor]'s ad strategy"
+- "Deep competitive ad analysis on [competitor]"


### PR DESCRIPTION
Adds two marketing skill-plugins under `plugins/community/`, following the structure of the existing community plugins (plugin.json + SKILL.md + README + .source.json declaring the upstream source):

**`competitor-ad-intelligence`** — competitor paid-ads teardown via the Meta Ad Library and Google Ads Transparency Center (free public sources, WebSearch/WebFetch only, no API keys or MCP servers). Creative-pattern analysis, funnel mapping, vulnerabilities, counter-plays.

**`ad-campaign-analyzer`** — pure reasoning over campaign exports (CSV/paste/screenshot from Google/Meta/LinkedIn): significance checks, budget-waste diagnosis, winners to scale, multi-channel reallocation plan with dollar amounts.

Both synced from [gooseworks-ai/goose-skills](https://github.com/gooseworks-ai/goose-skills) (MIT, 1k+ stars) — `.source.json` declares repo/path/branch so your sync pipeline can track upstream. I deliberately didn't touch generated catalogs (marketplace.json, skills-catalog, search index) — happy to adjust anything to fit your `ccpi` pipeline, or if you'd rather sync them from source directly, the paths are in `.source.json`.

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)