### PR TITLE
Add swift-ship external source (Path B auto-sync)

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1745,6 +1745,28 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  - name: swift-ship
+    description: Five Agent Skills for shipping Swift/macOS apps — .icns icons, .app/DMG packaging, CI portability traps, OSS readiness audit, release flow
+    repo: chsistrying/swift-ship-skills
+    source_path: .
+    target_path: plugins/community/swift-ship
+    author:
+      name: chsistrying
+      github: chsistrying
+      email: h431523595@gmail.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - '/.claude-plugin/**'
+      - '/skills/**'
+      - '/README.md'
+      - '/LICENSE'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Closes #1102

## What

Adds a single `sources.yaml` entry registering [chsistrying/swift-ship-skills](https://github.com/chsistrying/swift-ship-skills) as a **Path B (auto-sync)** external source, mirroring to `plugins/community/swift-ship`.

Five Agent Skills for shipping Swift/macOS apps, distilled from shipping a real macOS menu bar app ([TokenScope](https://github.com/chsistrying/TokenScope)):

| Skill | What it does |
|---|---|
| `macos-app-icon` | .icns from one SVG/PNG using only built-in macOS tools |
| `swiftpm-app-bundle` | SwiftPM executable → .app bundle + DMG, no Xcode project |
| `swift-ci-portability` | GitHub Actions setup + catalog of real Foundation version/locale CI traps |
| `oss-readiness-audit` | Language-agnostic pre-publish audit (scope, secrets, LICENSE, README) |
| `swift-release-flow` | Preflight → bump → CHANGELOG → DMG → tag → GitHub Release |

## Validation

Ran your marketplace-tier validator against the upstream content staged at the target path:

```
python3 scripts/validate-skills-schema.py --marketplace --verbose plugins/community/swift-ship/
Skills: 5, Agents: 0 — Average skill score: 84.8/100, zero errors
```

All five SKILL.md files carry the 8-field marketplace frontmatter (scoped `allowed-tools`, no bare Bash) and the 7 required body sections. Upstream repo has `plugin.json` + `marketplace.json`, README, MIT LICENSE, and its own spec-compliance CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)