### PR TITLE
Add skillcrossroads - evidence-cited grader for Claude Code skills (resubmission of #1080)

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -2492,6 +2492,17 @@
       }
     },
     {
+      "name": "skillcrossroads",
+      "source": "./plugins/community/skillcrossroads",
+      "description": "Evidence-cited grader for Claude Code artifacts — the audit-skill runs the free skillcrossroads CLI for file:line scorecards, letter grades, and ranked fix lists",
+      "version": "0.11.3",
+      "category": "community",
+      "keywords": ["audit", "quality", "linter", "scorecard"],
+      "author": {
+        "name": "Steve Harlow"
+      }
+    },
+    {
       "name": "feature-engineering-toolkit",
       "source": "./plugins/ai-ml/feature-engineering-toolkit",
       "description": "Feature creation, selection, and transformation tools",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2296,6 +2296,22 @@
       }
     },
     {
+      "name": "skillcrossroads",
+      "source": "./plugins/community/skillcrossroads",
+      "description": "Evidence-cited grader for Claude Code artifacts — the audit-skill runs the free skillcrossroads CLI for file:line scorecards, letter grades, and ranked fix lists",
+      "version": "0.11.3",
+      "category": "community",
+      "keywords": [
+        "audit",
+        "quality",
+        "linter",
+        "scorecard"
+      ],
+      "author": {
+        "name": "Steve Harlow"
+      }
+    },
+    {
       "name": "feature-engineering-toolkit",
       "source": "./plugins/ai-ml/feature-engineering-toolkit",
       "description": "Feature creation, selection, and transformation tools",

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Release](https://img.shields.io/badge/release-v4.33.0-green)](https://github.com/jeremylongshore/tons-of-skills-marketplace/releases/latest)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
-[![Plugins](https://img.shields.io/badge/plugins-439-blue)](https://tonsofskills.com/explore)
-[![Skills](https://img.shields.io/badge/skills-2954-green)](https://tonsofskills.com/skills)
+[![Plugins](https://img.shields.io/badge/plugins-440-blue)](https://tonsofskills.com/explore)
+[![Skills](https://img.shields.io/badge/skills-2955-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/tons-of-skills-marketplace?style=social)](https://github.com/jeremylongshore/tons-of-skills-marketplace)
 [![skills.sh](https://skills.sh/b/jeremylongshore/tons-of-skills-marketplace)](https://skills.sh/jeremylongshore/tons-of-skills-marketplace)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
@@ -61,8 +61,8 @@ Every number below names the cohort it counts and the command that reproduces it
 
 | Count | Cohort                                 | Reproduce with                                                                                                          |
 | ----: | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-|   439 | catalog plugins (catalog-entry cohort) | `node scripts/generate-readme-toc.mjs` over `marketplace.extended.json`                                                 |
-| 2,954 | marketplace-visible skills (distinct)  | `node -e "import('./scripts/corpus-resolver.mjs').then(m=>console.log(m.resolveCorpus('marketplace-visible').length))"` |
+|   440 | catalog plugins (catalog-entry cohort) | `node scripts/generate-readme-toc.mjs` over `marketplace.extended.json`                                                 |
+| 2,955 | marketplace-visible skills (distinct)  | `node -e "import('./scripts/corpus-resolver.mjs').then(m=>console.log(m.resolveCorpus('marketplace-visible').length))"` |
 |   347 | agent definitions in plugins           | `git ls-files 'plugins/**' \| grep '/agents/.*\.md'`                                                                    |
 |    19 | plugin categories                      | `ls -d plugins/*/`                                                                                                      |
 
@@ -123,7 +123,7 @@ The 19 categories below link into the live marketplace. Plugin counts are the ca
 | 🎭  | [AI Agents & Agency](https://tonsofskills.com/plugins#ai-agency)    |       9 |
 | 🔌  | [API Development](https://tonsofskills.com/plugins#api-development) |      26 |
 | 💼  | [Business Tools](https://tonsofskills.com/plugins#business-tools)   |       6 |
-| 👥  | [Community](https://tonsofskills.com/plugins#community)             |      20 |
+| 👥  | [Community](https://tonsofskills.com/plugins#community)             |      21 |
 | ₿   | [Crypto & Web3](https://tonsofskills.com/plugins#crypto)            |      27 |
 | 💾  | [Database](https://tonsofskills.com/plugins#database)               |      26 |
 | 🎨  | [Design](https://tonsofskills.com/plugins#design)                   |       2 |

--- a/plugins/community/skillcrossroads/.claude-plugin/plugin.json
+++ b/plugins/community/skillcrossroads/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "skillcrossroads",
+  "version": "0.11.3",
+  "description": "Audit Claude Code artifacts from inside Claude Code: the audit-skill runs the free skillcrossroads CLI to grade skills, subagents, slash commands, MCP configs, and plugins with an evidence-cited file:line scorecard, then walks the ranked fix list until the grade stops improving.",
+  "author": {
+    "name": "Steve Harlow",
+    "email": "sgharlow@users.noreply.github.com"
+  },
+  "repository": "https://github.com/sgharlow/skillcrossroads",
+  "license": "MIT",
+  "keywords": [
+    "audit",
+    "quality",
+    "linter",
+    "scorecard",
+    "skills",
+    "agent-skills",
+    "ci"
+  ]
+}

--- a/plugins/community/skillcrossroads/.claude-plugin/plugin.json
+++ b/plugins/community/skillcrossroads/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skillcrossroads",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Audit Claude Code artifacts from inside Claude Code: the audit-skill runs the free skillcrossroads CLI to grade skills, subagents, slash commands, MCP configs, and plugins with an evidence-cited file:line scorecard, then walks the ranked fix list until the grade stops improving.",
   "author": {
     "name": "Steve Harlow",

--- a/plugins/community/skillcrossroads/.source.json
+++ b/plugins/community/skillcrossroads/.source.json
@@ -1,0 +1,27 @@
+{
+  "synced_from": {
+    "repo": "sgharlow/skillcrossroads",
+    "path": "plugin",
+    "branch": "main"
+  },
+  "last_sync": "2026-09-03T18:28:47.063Z",
+  "author": {
+    "name": "Steve Harlow",
+    "github": "sgharlow",
+    "email": "sgharlow@users.noreply.github.com"
+  },
+  "license": "MIT",
+  "files_synced": 10,
+  "files": [
+    ".claude-plugin/plugin.json",
+    "LICENSE",
+    "README.md",
+    "docs/PRD.md",
+    "skills/audit-skill/SKILL.md",
+    "skills/audit-skill/evals/audit-and-fix-low-grade-skill.md",
+    "skills/audit-skill/evals/audit-clean-skill.md",
+    "skills/audit-skill/evals/npx-unavailable.md",
+    "skills/audit-skill/references/flags-quick-reference.md",
+    "skills/audit-skill/references/rubric-categories.md"
+  ]
+}

--- a/plugins/community/skillcrossroads/.source.json
+++ b/plugins/community/skillcrossroads/.source.json
@@ -4,7 +4,7 @@
     "path": "plugin",
     "branch": "main"
   },
-  "last_sync": "2026-09-03T18:28:47.063Z",
+  "last_sync": "2026-09-03T19:55:46.248Z",
   "author": {
     "name": "Steve Harlow",
     "github": "sgharlow",

--- a/plugins/community/skillcrossroads/LICENSE
+++ b/plugins/community/skillcrossroads/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Skill Crossroads
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/community/skillcrossroads/LICENSE
+++ b/plugins/community/skillcrossroads/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Skill Crossroads
+Copyright (c) 2026 Steve Harlow
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/plugins/community/skillcrossroads/README.md
+++ b/plugins/community/skillcrossroads/README.md
@@ -1,0 +1,20 @@
+# skillcrossroads
+
+Audit Claude Code artifacts from inside Claude Code.
+
+Installing this plugin adds the **audit-skill**, which runs the free
+[skillcrossroads](https://www.npmjs.com/package/skillcrossroads) CLI (MIT) to grade skills,
+subagents, slash commands, `.mcp.json` configs, and plugins. Every finding in the scorecard
+cites file and line, and the skill walks the ranked fix list until the grade stops improving —
+then offers an embeddable badge.
+
+- Say: *"audit my skill"*, *"grade my skill"*, *"why doesn't my skill trigger"*, or
+  *"lint my SKILL.md"*.
+- Keyless scans score all six rubric categories deterministically; setting
+  `ANTHROPIC_API_KEY` upgrades Triggering to an LLM judge and adds three more checks.
+- Hosted scans, badges, per-check fix docs, and ecosystem reports:
+  [skillcrossroads.com](https://skillcrossroads.com) ·
+  [check reference](https://skillcrossroads.com/docs/checks)
+
+Upstream source: [github.com/sgharlow/skillcrossroads](https://github.com/sgharlow/skillcrossroads)
+(the `skill/` directory is the canonical copy of this skill).

--- a/plugins/community/skillcrossroads/README.md
+++ b/plugins/community/skillcrossroads/README.md
@@ -18,3 +18,15 @@ then offers an embeddable badge.
 
 Upstream source: [github.com/sgharlow/skillcrossroads](https://github.com/sgharlow/skillcrossroads)
 (the `skill/` directory is the canonical copy of this skill).
+
+## Package naming
+
+Two npm packages are involved, with different owners by design:
+
+- **`skillcrossroads`** (un-scoped) — the CLI this skill runs, published and maintained
+  from the upstream source repo above. The skill pins it (`npx skillcrossroads@0.11.3`).
+- **`@intentsolutionsio/skillcrossroads`** — the `package.json` in *this* directory. It is
+  the marketplace's generated tracking/proof artifact (every catalog plugin is scaffolded
+  under the `@intentsolutionsio` scope for npm download tracking) and is not the CLI.
+  Install the plugin via `ccpi install skillcrossroads` or
+  `/plugin install skillcrossroads@claude-code-plugins-plus` — not from that npm package.

--- a/plugins/community/skillcrossroads/README.md
+++ b/plugins/community/skillcrossroads/README.md
@@ -17,7 +17,8 @@ then offers an embeddable badge.
   [check reference](https://skillcrossroads.com/docs/checks)
 
 Upstream source: [github.com/sgharlow/skillcrossroads](https://github.com/sgharlow/skillcrossroads)
-(the `skill/` directory is the canonical copy of this skill).
+(this `plugin/` directory is the canonical copy, mirrored into the marketplace by
+`sources.yaml` - edit it here, never in the mirror).
 
 ## Package naming
 

--- a/plugins/community/skillcrossroads/README.md
+++ b/plugins/community/skillcrossroads/README.md
@@ -25,7 +25,7 @@ Upstream source: [github.com/sgharlow/skillcrossroads](https://github.com/sgharl
 Two npm packages are involved, with different owners by design:
 
 - **`skillcrossroads`** (un-scoped) — the CLI this skill runs, published and maintained
-  from the upstream source repo above. The skill pins it (`npx skillcrossroads@0.11.3`).
+  from the upstream source repo above. The skill pins it (`npx skillcrossroads@0.11.4`).
 - **`@intentsolutionsio/skillcrossroads`** — the `package.json` in *this* directory. It is
   the marketplace's generated tracking/proof artifact (every catalog plugin is scaffolded
   under the `@intentsolutionsio` scope for npm download tracking) and is not the CLI.

--- a/plugins/community/skillcrossroads/docs/PRD.md
+++ b/plugins/community/skillcrossroads/docs/PRD.md
@@ -23,7 +23,7 @@ it by hand.
 
 ## Success criteria
 
-1. `npx skillcrossroads@0.11.3 <skill-dir> --markdown` runs from inside Claude Code and
+1. `npx skillcrossroads@0.11.4 <skill-dir> --markdown` runs from inside Claude Code and
    returns a letter grade plus findings, each cited with file and line — no hand-estimated
    grades, ever (the skill stops and reports the error verbatim if the CLI fails).
 2. The audit-fix-re-audit loop measurably raises the grade (before → after reported to the
@@ -36,7 +36,7 @@ it by hand.
 
 ## Functional requirements
 
-- **FR-1:** Grade a skill directory via the pinned CLI (`npx skillcrossroads@0.11.3`) and
+- **FR-1:** Grade a skill directory via the pinned CLI (`npx skillcrossroads@0.11.4`) and
   present the scorecard and ranked Top fixes list.
 - **FR-2:** Apply the smallest edit that resolves each confirmed finding, re-run the audit,
   and iterate until the grade stops improving.

--- a/plugins/community/skillcrossroads/docs/PRD.md
+++ b/plugins/community/skillcrossroads/docs/PRD.md
@@ -42,6 +42,14 @@ it by hand.
   surface it to the user.
 - **FR-4:** Offer an embeddable SVG badge (`--badge`) once the final grade is reported.
 
+## Package naming
+
+The upstream CLI is the un-scoped `skillcrossroads` npm package, maintained at
+[github.com/sgharlow/skillcrossroads](https://github.com/sgharlow/skillcrossroads). The
+`package.json` in this plugin directory is the marketplace's generated tracking/proof
+artifact and follows the repo-wide convention of publishing catalog plugins under the
+`@intentsolutionsio` npm scope; it is not the CLI and not an ownership claim over it.
+
 ## Out of scope
 
 - Grading artifacts other than by delegating to the CLI (no hand-rolled rubric in the skill).

--- a/plugins/community/skillcrossroads/docs/PRD.md
+++ b/plugins/community/skillcrossroads/docs/PRD.md
@@ -1,0 +1,51 @@
+# PRD: skillcrossroads
+
+**Author:** Steve Harlow
+**Date:** 2026-07-23
+**Status:** Active
+
+## Problem
+
+Skill authors ship SKILL.md files that never trigger, over-grant tools, or leak secrets —
+and only find out after publishing, when users report the skill "does nothing" or a review
+flags a safety issue. There is no in-editor feedback loop: the author's only options today
+are manual review against scattered best-practice docs, or publishing and waiting. The
+skillcrossroads CLI exists (npm, MIT) but requires leaving Claude Code to run and interpret
+it by hand.
+
+## Target users
+
+| User                 | Context                                                | Primary need                                              |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| Skill author         | Writing or revising a SKILL.md before publishing        | An evidence-cited grade and ranked fix list, in one step   |
+| Plugin maintainer    | Reviewing contributed skills in a marketplace repo      | A repeatable, deterministic quality bar with file:line receipts |
+| Claude Code power user | A personal skill stopped triggering after edits       | Diagnosis of why the description no longer matches intent  |
+
+## Success criteria
+
+1. `npx skillcrossroads@0.11.3 <skill-dir> --markdown` runs from inside Claude Code and
+   returns a letter grade plus findings, each cited with file and line — no hand-estimated
+   grades, ever (the skill stops and reports the error verbatim if the CLI fails).
+2. The audit-fix-re-audit loop measurably raises the grade (before → after reported to the
+   user) or terminates with each residual finding explicitly acknowledged as an intentional
+   trade-off.
+3. Keyless runs score all six rubric categories deterministically; with `ANTHROPIC_API_KEY`
+   set, the LLM-judge upgrade is used and the mode that ran is reported.
+
+## Functional requirements
+
+- **FR-1:** Grade a skill directory via the pinned CLI (`npx skillcrossroads@0.11.3`) and
+  present the scorecard and ranked Top fixes list.
+- **FR-2:** Apply the smallest edit that resolves each confirmed finding, re-run the audit,
+  and iterate until the grade stops improving.
+- **FR-3:** Never suppress or mask a SAFETY-* finding — fix the underlying problem or
+  surface it to the user.
+- **FR-4:** Offer an embeddable SVG badge (`--badge`) once the final grade is reported.
+
+## Out of scope
+
+- Grading artifacts other than by delegating to the CLI (no hand-rolled rubric in the skill).
+- Auto-publishing, badge hosting, or any network call beyond fetching the pinned CLI from
+  the npm registry.
+- Editing skills without the user's awareness — every fix is applied from a cited finding
+  the user can inspect.

--- a/plugins/community/skillcrossroads/docs/PRD.md
+++ b/plugins/community/skillcrossroads/docs/PRD.md
@@ -29,8 +29,10 @@ it by hand.
 2. The audit-fix-re-audit loop measurably raises the grade (before → after reported to the
    user) or terminates with each residual finding explicitly acknowledged as an intentional
    trade-off.
-3. Keyless runs score all six rubric categories deterministically; with `ANTHROPIC_API_KEY`
-   set, the LLM-judge upgrade is used and the mode that ran is reported.
+3. Runs are deterministic and local by default: every command passes `--no-llm`, scoring all
+   six rubric categories without contacting any model, whether or not `ANTHROPIC_API_KEY` is
+   set. The LLM-judge upgrade is reachable only through the consented `--suggest` path in
+   SKILL.md step 4, and the mode that ran is reported either way.
 
 ## Functional requirements
 
@@ -53,7 +55,19 @@ artifact and follows the repo-wide convention of publishing catalog plugins unde
 ## Out of scope
 
 - Grading artifacts other than by delegating to the CLI (no hand-rolled rubric in the skill).
-- Auto-publishing, badge hosting, or any network call beyond fetching the pinned CLI from
-  the npm registry.
+- Auto-publishing or badge hosting.
+- Any network call the user has not agreed to. Two are possible, and both are named here
+  rather than implied: fetching the pinned CLI from the npm registry (every run), and the
+  opt-in `--suggest` in SKILL.md step 4, which sends up to 24,000 characters of the target
+  skill's entry file to Anthropic's Messages API under the user's own `ANTHROPIC_API_KEY`
+  after explicit consent. Every other command this skill issues passes `--no-llm` and is
+  fully local.
+
+  > Corrected 2026-09-03. This bullet previously read "any network call beyond fetching the
+  > pinned CLI from the npm registry", which was not true of the CLI's behaviour: without
+  > `--no-llm` it contacts Anthropic whenever `ANTHROPIC_API_KEY` is set in the environment,
+  > without prompting. The skill now passes `--no-llm` everywhere except the consented
+  > `--suggest` path, so the boundary this document describes is the one the commands
+  > actually enforce.
 - Editing skills without the user's awareness — every fix is applied from a cited finding
   the user can inspect.

--- a/plugins/community/skillcrossroads/package.json
+++ b/plugins/community/skillcrossroads/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@intentsolutionsio/skillcrossroads",
+  "version": "0.11.3",
+  "description": "Audit Claude Code artifacts from inside Claude Code: the audit-skill runs the free skillcrossroads CLI to grade skills, subagents, slash commands, MCP configs, and plugins with an evidence-cited file:",
+  "keywords": [
+    "audit",
+    "quality",
+    "linter",
+    "scorecard",
+    "skills",
+    "agent-skills",
+    "ci",
+    "claude-code",
+    "claude-plugin",
+    "tonsofskills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git",
+    "directory": "plugins/community/skillcrossroads"
+  },
+  "homepage": "https://tonsofskills.com/plugins/skillcrossroads",
+  "bugs": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Steve Harlow",
+    "email": "sgharlow@users.noreply.github.com"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "README.md",
+    ".claude-plugin",
+    "skills"
+  ],
+  "scripts": {
+    "postinstall": "node -e \"console.log(\\\"\\\\n→ This npm package is a tracking/proof artifact. Install the plugin via:\\\\n  ccpi install skillcrossroads\\\\n  or /plugin install skillcrossroads@claude-code-plugins-plus in Claude Code\\\\n\\\")\""
+  }
+}

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -5,6 +5,7 @@ description: 'Audit and improve a Claude Code skill using Skill Crossroads. Use 
   trigger", or "lint my SKILL.md" — or before publishing any skill, to get an evidence-cited
   quality score, ranked fix list, and badge. Trigger with "audit my skill".'
 allowed-tools: Read, Edit, Grep, Glob, Bash(npx:*)
+disable-model-invocation: true
 argument-hint: <skill-dir — path to the directory containing SKILL.md>
 version: 0.11.3
 author: Steve Harlow <sgharlow@users.noreply.github.com>
@@ -38,10 +39,20 @@ the grade stops improving.
 - Node.js 18+ with `npx` available, and network access to the npm registry (the CLI is
   fetched on demand; the version is pinned below for reproducibility).
 - A skill directory containing a `SKILL.md` file.
-- Authentication is optional: keyless runs score all six rubric categories
-  deterministically. Setting the `ANTHROPIC_API_KEY` environment variable (an Anthropic
-  API key — treat it as a credential, never echo or commit it) upgrades the Triggering
-  category to an LLM judge and adds checks VERIFY-04, CLARITY-02, and CLARITY-05.
+- **No credential is required, and by default nothing about your skill leaves the machine.**
+  Every command in this skill passes `--no-llm`, so all six rubric categories are scored
+  deterministically and locally.
+- **The one exception is `--suggest` in step 4, which is opt-in and requires your explicit
+  consent.** Without `--no-llm`, the CLI sends content to Anthropic's Messages API
+  (`api.anthropic.com`) whenever `ANTHROPIC_API_KEY` is present in the environment — it does
+  not prompt. That path upgrades the Triggering category to an LLM judge and adds checks
+  VERIFY-04, CLARITY-02 and CLARITY-05, sending per-check excerpts of 1,500-2,500 characters;
+  `--suggest` sends up to 24,000 characters of the entry file. Requests are billed to your own
+  key. Treat the key as a credential: never echo or commit it.
+- **Model results are cached on disk** between runs, keyed by content hash:
+  `./.beacon-cache` if that directory already exists, otherwise
+  `%LOCALAPPDATA%\skillcrossroads\cache` on Windows, `$XDG_CACHE_HOME/skillcrossroads` when
+  set, or `~/.cache/skillcrossroads`.
 
 ## Steps
 
@@ -56,24 +67,40 @@ the grade stops improving.
    directory or ask the user for a safe path first.
 
    ```bash
-   npx skillcrossroads@0.11.3 '<skill-dir>' --markdown
+   npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --markdown
    ```
 
 3. Report the scorecard and the **Top fixes** list (ranked by grade impact) to the user.
    **Auditing is read-only.** If the user asked only to audit, grade, check, or lint, stop
    here — do not edit anything. Proceed to step 4 only when the user explicitly asked to fix
    or improve the skill, or confirms they want the fixes applied after seeing the report.
-4. Apply fixes (only on explicit request or confirmation). Optionally, if `ANTHROPIC_API_KEY`
-   is set, run `npx skillcrossroads@0.11.3 '<skill-dir>' --suggest` to get proposed
-   current → proposed fixes for the top findings — treat them as proposals to review, never
-   apply one unread. For each fix, Read the cited file:line, confirm the finding is real,
-   and apply the smallest Edit that resolves it.
+4. Apply fixes (only on explicit request or confirmation). The deterministic report from
+   step 2 is normally enough to work from.
+
+   Optionally, model-drafted rewrites are available — but `--suggest` is the **only** command
+   in this skill that sends anything off the machine, so **ask the user before running it**
+   and proceed only on an explicit yes:
+
+   > `--suggest` sends up to 24,000 characters of this skill's entry file to Anthropic's API
+   > (`api.anthropic.com`), billed to your own `ANTHROPIC_API_KEY`, and caches the result on
+   > disk. Run it, or continue with the local findings?
+
+   On a yes, and only when `ANTHROPIC_API_KEY` is set:
+
+   ```bash
+   npx skillcrossroads@0.11.3 '<skill-dir>' --suggest
+   ```
+
+   If the user declines, or no key is set, continue with the step 2 findings — they already
+   cover all six rubric categories. Either way, treat suggestions as proposals to review and
+   never apply one unread. For each fix, Read the cited file:line, confirm the finding is
+   real, and apply the smallest Edit that resolves it.
    Typical high-impact fixes: rewrite the frontmatter `description` to lead with the use case
    and include the phrases a user would actually say; add a verification step; state
    constraints and failure modes; remove hardcoded secrets or over-broad `allowed-tools`.
 5. Re-run the audit. Repeat steps 4–5 until the grade stops improving or only intentional
    trade-offs remain.
-6. Offer the badge: `npx skillcrossroads@0.11.3 '<skill-dir>' --badge` writes an SVG the user
+6. Offer the badge: `npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --badge` writes an SVG the user
    can embed in their README, linking to https://skillcrossroads.com for the hosted version.
 
 ## Output
@@ -105,7 +132,7 @@ the grade stops improving.
 User: *"Audit my skill in `skills/deploy-checker` — why doesn't it trigger?"*
 
 ```bash
-npx skillcrossroads@0.11.3 'skills/deploy-checker' --markdown
+npx skillcrossroads@0.11.3 'skills/deploy-checker' --no-llm --markdown
 ```
 
 The report grades Triggering low, citing `SKILL.md:3` — the description lacks the phrases a
@@ -117,7 +144,7 @@ to review proposed rewrites before applying them.
 ## Verify
 
 Done means: for an audit-only request, the scorecard and Top fixes list were reported with no
-files modified. For a fix request: the final `npx skillcrossroads@0.11.3 '<skill-dir>' --markdown`
+files modified. For a fix request: the final `npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --markdown`
 run shows the improved grade with **no fail-status findings remaining** (or each remaining one
 acknowledged by the user as intentional), and the before → after grades are reported to the user.
 

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -155,4 +155,5 @@ acknowledged by the user as intentional), and the before → after grades are re
 - [skillcrossroads on npm](https://www.npmjs.com/package/skillcrossroads) — the CLI this skill runs (pinned to 0.11.3).
 - [skillcrossroads.com](https://skillcrossroads.com) — hosted scans, badges, and per-check fix documentation.
 - [Check reference](https://skillcrossroads.com/docs/checks) — what every rubric check measures and how to fix it.
-- [Source repository](https://github.com/sgharlow/skillcrossroads) — the `skill/` directory is the canonical copy of this skill.
+- [Source repository](https://github.com/sgharlow/skillcrossroads) — `plugin/` there is the
+  canonical copy; the marketplace entry is a mirror of it, so fixes land upstream first.

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -48,11 +48,15 @@ the grade stops improving.
 1. Identify the skill directory (it contains a `SKILL.md`). Use Glob to find `**/SKILL.md`
    candidates or Grep to search for the skill by name. If more than one candidate exists,
    ask the user which skill to audit.
-2. Run the audit and capture the report. Always double-quote the directory argument — paths
-   can contain spaces or shell metacharacters:
+2. Run the audit and capture the report. **Single-quote** the directory argument — single
+   quotes prevent the shell from expanding `$(...)`, backticks, and `$variables` hidden in a
+   path (double quotes do NOT stop command substitution). Before running, inspect the path:
+   if it contains a single quote, `$`, a backtick, or a newline, do not pass it to a shell at
+   all — such characters in a skill directory name are themselves a red flag; rename the
+   directory or ask the user for a safe path first.
 
    ```bash
-   npx skillcrossroads@0.11.3 "<skill-dir>" --markdown
+   npx skillcrossroads@0.11.3 '<skill-dir>' --markdown
    ```
 
 3. Report the scorecard and the **Top fixes** list (ranked by grade impact) to the user.
@@ -60,7 +64,7 @@ the grade stops improving.
    here — do not edit anything. Proceed to step 4 only when the user explicitly asked to fix
    or improve the skill, or confirms they want the fixes applied after seeing the report.
 4. Apply fixes (only on explicit request or confirmation). Optionally, if `ANTHROPIC_API_KEY`
-   is set, run `npx skillcrossroads@0.11.3 "<skill-dir>" --suggest` to get proposed
+   is set, run `npx skillcrossroads@0.11.3 '<skill-dir>' --suggest` to get proposed
    current → proposed fixes for the top findings — treat them as proposals to review, never
    apply one unread. For each fix, Read the cited file:line, confirm the finding is real,
    and apply the smallest Edit that resolves it.
@@ -69,7 +73,7 @@ the grade stops improving.
    constraints and failure modes; remove hardcoded secrets or over-broad `allowed-tools`.
 5. Re-run the audit. Repeat steps 4–5 until the grade stops improving or only intentional
    trade-offs remain.
-6. Offer the badge: `npx skillcrossroads@0.11.3 "<skill-dir>" --badge` writes an SVG the user
+6. Offer the badge: `npx skillcrossroads@0.11.3 '<skill-dir>' --badge` writes an SVG the user
    can embed in their README, linking to https://skillcrossroads.com for the hosted version.
 
 ## Output
@@ -101,7 +105,7 @@ the grade stops improving.
 User: *"Audit my skill in `skills/deploy-checker` — why doesn't it trigger?"*
 
 ```bash
-npx skillcrossroads@0.11.3 "skills/deploy-checker" --markdown
+npx skillcrossroads@0.11.3 'skills/deploy-checker' --markdown
 ```
 
 The report grades Triggering low, citing `SKILL.md:3` — the description lacks the phrases a
@@ -113,7 +117,7 @@ to review proposed rewrites before applying them.
 ## Verify
 
 Done means: for an audit-only request, the scorecard and Top fixes list were reported with no
-files modified. For a fix request: the final `npx skillcrossroads@0.11.3 "<skill-dir>" --markdown`
+files modified. For a fix request: the final `npx skillcrossroads@0.11.3 '<skill-dir>' --markdown`
 run shows the improved grade with **no fail-status findings remaining** (or each remaining one
 acknowledged by the user as intentional), and the before → after grades are reported to the user.
 

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -19,8 +19,9 @@ compatibility: Designed for Claude Code; the underlying CLI grades skills, subag
 
 # Audit a skill with Skill Crossroads
 
-Grade the target skill, apply the highest-impact fixes, and re-grade until the score stops
-improving. Every finding is evidence-cited (file and line) — work from the receipts, not vibes.
+Grade the target skill and report every finding evidence-cited (file and line) — work from
+the receipts, not vibes. Only when the user asks for fixes, apply the highest-impact ones
+and re-grade until the score stops improving.
 
 ## Overview
 
@@ -28,8 +29,9 @@ Most skills fail silently: they never trigger, over-grant tools, or leak secrets
 author only finds out after publishing. This skill closes that loop before you ship. It runs
 the free [skillcrossroads](https://www.npmjs.com/package/skillcrossroads) CLI (MIT) against a
 skill directory, producing a letter grade, a file:line-cited scorecard across six rubric
-categories, and a ranked fix list — then walks that list, applying the smallest change that
-resolves each finding, until the grade stops improving.
+categories, and a ranked fix list. Auditing is read-only; when the user also wants the skill
+improved, it walks that list, applying the smallest change that resolves each finding, until
+the grade stops improving.
 
 ## Prerequisites
 
@@ -46,23 +48,28 @@ resolves each finding, until the grade stops improving.
 1. Identify the skill directory (it contains a `SKILL.md`). Use Glob to find `**/SKILL.md`
    candidates or Grep to search for the skill by name. If more than one candidate exists,
    ask the user which skill to audit.
-2. Run the audit and capture the report:
+2. Run the audit and capture the report. Always double-quote the directory argument — paths
+   can contain spaces or shell metacharacters:
 
    ```bash
-   npx skillcrossroads@0.11.3 <skill-dir> --markdown
+   npx skillcrossroads@0.11.3 "<skill-dir>" --markdown
    ```
 
-3. Read the **Top fixes** list (ranked by grade impact). Optionally, if `ANTHROPIC_API_KEY`
-   is set, run `npx skillcrossroads@0.11.3 <skill-dir> --suggest` to get proposed
+3. Report the scorecard and the **Top fixes** list (ranked by grade impact) to the user.
+   **Auditing is read-only.** If the user asked only to audit, grade, check, or lint, stop
+   here — do not edit anything. Proceed to step 4 only when the user explicitly asked to fix
+   or improve the skill, or confirms they want the fixes applied after seeing the report.
+4. Apply fixes (only on explicit request or confirmation). Optionally, if `ANTHROPIC_API_KEY`
+   is set, run `npx skillcrossroads@0.11.3 "<skill-dir>" --suggest` to get proposed
    current → proposed fixes for the top findings — treat them as proposals to review, never
    apply one unread. For each fix, Read the cited file:line, confirm the finding is real,
    and apply the smallest Edit that resolves it.
    Typical high-impact fixes: rewrite the frontmatter `description` to lead with the use case
    and include the phrases a user would actually say; add a verification step; state
    constraints and failure modes; remove hardcoded secrets or over-broad `allowed-tools`.
-4. Re-run the audit. Repeat steps 3–4 until the grade stops improving or only intentional
+5. Re-run the audit. Repeat steps 4–5 until the grade stops improving or only intentional
    trade-offs remain.
-5. Offer the badge: `npx skillcrossroads@0.11.3 <skill-dir> --badge` writes an SVG the user
+6. Offer the badge: `npx skillcrossroads@0.11.3 "<skill-dir>" --badge` writes an SVG the user
    can embed in their README, linking to https://skillcrossroads.com for the hosted version.
 
 ## Output
@@ -70,7 +77,8 @@ resolves each finding, until the grade stops improving.
 - A markdown scorecard: overall letter grade, per-category scores across the six rubric
   categories, and every finding cited with file and line.
 - A ranked **Top fixes** list ordered by grade impact.
-- After the fix loop: the before → after grades, reported to the user.
+- After the fix loop (when the user requested fixes): the before → after grades, reported to
+  the user.
 - With `--badge`: an SVG badge file written into the skill directory.
 
 ## Error Handling
@@ -93,19 +101,21 @@ resolves each finding, until the grade stops improving.
 User: *"Audit my skill in `skills/deploy-checker` — why doesn't it trigger?"*
 
 ```bash
-npx skillcrossroads@0.11.3 skills/deploy-checker --markdown
+npx skillcrossroads@0.11.3 "skills/deploy-checker" --markdown
 ```
 
 The report grades Triggering low, citing `SKILL.md:3` — the description lacks the phrases a
-user would say. Rewrite the description to lead with the use case, re-run the audit, and
+user would say. Report that finding and stop (the user asked why, not for edits). If they
+then say "fix it", rewrite the description to lead with the use case, re-run the audit, and
 report the before → after grade (for example C → A). Alternatively, run with `--suggest`
 to review proposed rewrites before applying them.
 
 ## Verify
 
-Done means: the final `npx skillcrossroads@0.11.3 <skill-dir> --markdown` run shows the improved
-grade with **no fail-status findings remaining** (or each remaining one acknowledged by the user
-as intentional), and the before → after grades are reported to the user.
+Done means: for an audit-only request, the scorecard and Top fixes list were reported with no
+files modified. For a fix request: the final `npx skillcrossroads@0.11.3 "<skill-dir>" --markdown`
+run shows the improved grade with **no fail-status findings remaining** (or each remaining one
+acknowledged by the user as intentional), and the before → after grades are reported to the user.
 
 ## Resources
 

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -123,6 +123,8 @@ acknowledged by the user as intentional), and the before → after grades are re
 
 ## Resources
 
+- [references/rubric-categories.md](references/rubric-categories.md) — the six rubric categories, their weights, and keyless vs. LLM-upgraded coverage.
+- [references/flags-quick-reference.md](references/flags-quick-reference.md) — `--markdown` / `--suggest` / `--badge` / `--min-grade` at a glance.
 - [skillcrossroads on npm](https://www.npmjs.com/package/skillcrossroads) — the CLI this skill runs (pinned to 0.11.3).
 - [skillcrossroads.com](https://skillcrossroads.com) — hosted scans, badges, and per-check fix documentation.
 - [Check reference](https://skillcrossroads.com/docs/checks) — what every rubric check measures and how to fix it.

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -36,7 +36,7 @@ the grade stops improving.
 
 ## Prerequisites
 
-- Node.js 18+ with `npx` available, and network access to the npm registry (the CLI is
+- Node.js 20+ with `npx` available, and network access to the npm registry (the CLI is
   fetched on demand; the version is pinned below for reproducibility).
 - A skill directory containing a `SKILL.md` file.
 - **No credential is required, and by default nothing about your skill leaves the machine.**
@@ -102,6 +102,8 @@ the grade stops improving.
    trade-offs remain.
 6. Offer the badge: `npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --badge` writes an SVG the user
    can embed in their README, linking to https://skillcrossroads.com for the hosted version.
+   It lands in the **current working directory** as `<name>.beacon.svg`, not inside the skill
+   directory; pass `--badge=<path>` to choose where it goes.
 
 ## Output
 

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -7,7 +7,7 @@ description: 'Audit and improve a Claude Code skill using Skill Crossroads. Use 
 allowed-tools: Read, Edit, Grep, Glob, Bash(npx:*)
 disable-model-invocation: true
 argument-hint: <skill-dir — path to the directory containing SKILL.md>
-version: 0.11.3
+version: 0.11.4
 author: Steve Harlow <sgharlow@users.noreply.github.com>
 license: MIT
 tags:
@@ -67,7 +67,7 @@ the grade stops improving.
    directory or ask the user for a safe path first.
 
    ```bash
-   npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --markdown
+   npx skillcrossroads@0.11.4 '<skill-dir>' --no-llm --markdown
    ```
 
 3. Report the scorecard and the **Top fixes** list (ranked by grade impact) to the user.
@@ -88,7 +88,7 @@ the grade stops improving.
    On a yes, and only when `ANTHROPIC_API_KEY` is set:
 
    ```bash
-   npx skillcrossroads@0.11.3 '<skill-dir>' --suggest
+   npx skillcrossroads@0.11.4 '<skill-dir>' --suggest
    ```
 
    If the user declines, or no key is set, continue with the step 2 findings — they already
@@ -100,7 +100,7 @@ the grade stops improving.
    constraints and failure modes; remove hardcoded secrets or over-broad `allowed-tools`.
 5. Re-run the audit. Repeat steps 4–5 until the grade stops improving or only intentional
    trade-offs remain.
-6. Offer the badge: `npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --badge` writes an SVG the user
+6. Offer the badge: `npx skillcrossroads@0.11.4 '<skill-dir>' --no-llm --badge` writes an SVG the user
    can embed in their README, linking to https://skillcrossroads.com for the hosted version.
    It lands in the **current working directory** as `<name>.beacon.svg`, not inside the skill
    directory; pass `--badge=<path>` to choose where it goes.
@@ -134,7 +134,7 @@ the grade stops improving.
 User: *"Audit my skill in `skills/deploy-checker` — why doesn't it trigger?"*
 
 ```bash
-npx skillcrossroads@0.11.3 'skills/deploy-checker' --no-llm --markdown
+npx skillcrossroads@0.11.4 'skills/deploy-checker' --no-llm --markdown
 ```
 
 The report grades Triggering low, citing `SKILL.md:3` — the description lacks the phrases a
@@ -146,7 +146,7 @@ to review proposed rewrites before applying them.
 ## Verify
 
 Done means: for an audit-only request, the scorecard and Top fixes list were reported with no
-files modified. For a fix request: the final `npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm --markdown`
+files modified. For a fix request: the final `npx skillcrossroads@0.11.4 '<skill-dir>' --no-llm --markdown`
 run shows the improved grade with **no fail-status findings remaining** (or each remaining one
 acknowledged by the user as intentional), and the before → after grades are reported to the user.
 
@@ -154,7 +154,7 @@ acknowledged by the user as intentional), and the before → after grades are re
 
 - [references/rubric-categories.md](references/rubric-categories.md) — the six rubric categories, their weights, and keyless vs. LLM-upgraded coverage.
 - [references/flags-quick-reference.md](references/flags-quick-reference.md) — `--markdown` / `--suggest` / `--badge` / `--min-grade` at a glance.
-- [skillcrossroads on npm](https://www.npmjs.com/package/skillcrossroads) — the CLI this skill runs (pinned to 0.11.3).
+- [skillcrossroads on npm](https://www.npmjs.com/package/skillcrossroads) — the CLI this skill runs (pinned to 0.11.4).
 - [skillcrossroads.com](https://skillcrossroads.com) — hosted scans, badges, and per-check fix documentation.
 - [Check reference](https://skillcrossroads.com/docs/checks) — what every rubric check measures and how to fix it.
 - [Source repository](https://github.com/sgharlow/skillcrossroads) — `plugin/` there is the

--- a/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: audit-skill
+description: 'Audit and improve a Claude Code skill using Skill Crossroads. Use when the user
+  says "audit my skill", "grade my skill", "check my skill quality", "why doesn''t my skill
+  trigger", or "lint my SKILL.md" — or before publishing any skill, to get an evidence-cited
+  quality score, ranked fix list, and badge. Trigger with "audit my skill".'
+allowed-tools: Read, Edit, Grep, Glob, Bash(npx:*)
+argument-hint: <skill-dir — path to the directory containing SKILL.md>
+version: 0.11.3
+author: Steve Harlow <sgharlow@users.noreply.github.com>
+license: MIT
+tags:
+- audit
+- quality
+- linter
+- skills
+compatibility: Designed for Claude Code; the underlying CLI grades skills, subagents, slash commands, MCP configs, and plugins
+---
+
+# Audit a skill with Skill Crossroads
+
+Grade the target skill, apply the highest-impact fixes, and re-grade until the score stops
+improving. Every finding is evidence-cited (file and line) — work from the receipts, not vibes.
+
+## Overview
+
+Most skills fail silently: they never trigger, over-grant tools, or leak secrets, and the
+author only finds out after publishing. This skill closes that loop before you ship. It runs
+the free [skillcrossroads](https://www.npmjs.com/package/skillcrossroads) CLI (MIT) against a
+skill directory, producing a letter grade, a file:line-cited scorecard across six rubric
+categories, and a ranked fix list — then walks that list, applying the smallest change that
+resolves each finding, until the grade stops improving.
+
+## Prerequisites
+
+- Node.js 18+ with `npx` available, and network access to the npm registry (the CLI is
+  fetched on demand; the version is pinned below for reproducibility).
+- A skill directory containing a `SKILL.md` file.
+- Authentication is optional: keyless runs score all six rubric categories
+  deterministically. Setting the `ANTHROPIC_API_KEY` environment variable (an Anthropic
+  API key — treat it as a credential, never echo or commit it) upgrades the Triggering
+  category to an LLM judge and adds checks VERIFY-04, CLARITY-02, and CLARITY-05.
+
+## Steps
+
+1. Identify the skill directory (it contains a `SKILL.md`). Use Glob to find `**/SKILL.md`
+   candidates or Grep to search for the skill by name. If more than one candidate exists,
+   ask the user which skill to audit.
+2. Run the audit and capture the report:
+
+   ```bash
+   npx skillcrossroads@0.11.3 <skill-dir> --markdown
+   ```
+
+3. Read the **Top fixes** list (ranked by grade impact). Optionally, if `ANTHROPIC_API_KEY`
+   is set, run `npx skillcrossroads@0.11.3 <skill-dir> --suggest` to get proposed
+   current → proposed fixes for the top findings — treat them as proposals to review, never
+   apply one unread. For each fix, Read the cited file:line, confirm the finding is real,
+   and apply the smallest Edit that resolves it.
+   Typical high-impact fixes: rewrite the frontmatter `description` to lead with the use case
+   and include the phrases a user would actually say; add a verification step; state
+   constraints and failure modes; remove hardcoded secrets or over-broad `allowed-tools`.
+4. Re-run the audit. Repeat steps 3–4 until the grade stops improving or only intentional
+   trade-offs remain.
+5. Offer the badge: `npx skillcrossroads@0.11.3 <skill-dir> --badge` writes an SVG the user
+   can embed in their README, linking to https://skillcrossroads.com for the hosted version.
+
+## Output
+
+- A markdown scorecard: overall letter grade, per-category scores across the six rubric
+  categories, and every finding cited with file and line.
+- A ranked **Top fixes** list ordered by grade impact.
+- After the fix loop: the before → after grades, reported to the user.
+- With `--badge`: an SVG badge file written into the skill directory.
+
+## Error Handling
+
+- If `npx` fails (offline, registry blocked, unsupported Node version), report the error
+  verbatim and stop — do not hand-estimate a grade.
+- If no `SKILL.md` is found in the target directory, ask the user for the correct path
+  instead of guessing.
+- If the grade plateaus with findings remaining, list each residual finding and ask the
+  user whether it is an intentional trade-off; never mask a finding to force a grade.
+- **Never suppress, delete, or work around a SAFETY-* finding** — fix the underlying problem
+  (remove the secret, narrow the tool grant). Safety findings always count.
+- Do not pad the skill with filler to game a check; if a finding is a deliberate trade-off,
+  say so to the user instead of masking it.
+- Say which mode ran (keyless deterministic vs. LLM-upgraded) so the user knows what the
+  grade covers.
+
+## Examples
+
+User: *"Audit my skill in `skills/deploy-checker` — why doesn't it trigger?"*
+
+```bash
+npx skillcrossroads@0.11.3 skills/deploy-checker --markdown
+```
+
+The report grades Triggering low, citing `SKILL.md:3` — the description lacks the phrases a
+user would say. Rewrite the description to lead with the use case, re-run the audit, and
+report the before → after grade (for example C → A). Alternatively, run with `--suggest`
+to review proposed rewrites before applying them.
+
+## Verify
+
+Done means: the final `npx skillcrossroads@0.11.3 <skill-dir> --markdown` run shows the improved
+grade with **no fail-status findings remaining** (or each remaining one acknowledged by the user
+as intentional), and the before → after grades are reported to the user.
+
+## Resources
+
+- [skillcrossroads on npm](https://www.npmjs.com/package/skillcrossroads) — the CLI this skill runs (pinned to 0.11.3).
+- [skillcrossroads.com](https://skillcrossroads.com) — hosted scans, badges, and per-check fix documentation.
+- [Check reference](https://skillcrossroads.com/docs/checks) — what every rubric check measures and how to fix it.
+- [Source repository](https://github.com/sgharlow/skillcrossroads) — the `skill/` directory is the canonical copy of this skill.

--- a/plugins/community/skillcrossroads/skills/audit-skill/evals/audit-and-fix-low-grade-skill.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/evals/audit-and-fix-low-grade-skill.md
@@ -1,0 +1,14 @@
+# Eval: audit and fix a skill with real findings
+
+**Prompt:** "Why doesn't my skill trigger? It's at ./flaky-skill."
+
+**Setup:** `./flaky-skill` has a thin description with no "Use when..." cues (a real
+TRIGGER-02/03 finding) and no `evals/` folder (a real VERIFY-01 finding).
+
+**Expect:**
+- Runs the audit and reads the ranked **Top fixes** list rather than guessing.
+- For the triggering finding, opens the cited `SKILL.md:line`, confirms it's real, and
+  rewrites the description to lead with the use case and include phrases a user would
+  actually say — the smallest change that resolves it, not a full rewrite.
+- Does not touch any SAFETY-* finding by suppressing or deleting it.
+- Re-runs the audit after applying fixes and reports the before → after grade.

--- a/plugins/community/skillcrossroads/skills/audit-skill/evals/audit-clean-skill.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/evals/audit-clean-skill.md
@@ -1,0 +1,14 @@
+# Eval: audit a skill that already scores well
+
+**Prompt:** "Audit my skill at ./my-skill — grade my skill quality."
+
+**Setup:** `./my-skill` is a small, well-formed skill (valid frontmatter, a clear
+description with "Use when..." trigger cues, an evals/ folder, no secrets).
+
+**Expect:**
+- Runs `npx skillcrossroads@0.11.3 './my-skill' --no-llm --markdown` (does not hand-estimate a grade).
+- Reports the actual overall score/grade and states whether the LLM-assisted checks ran
+  (i.e. whether `ANTHROPIC_API_KEY` was set).
+- Since there are no fail-status findings, does NOT invent fixes to apply — reports the
+  skill as done, optionally naming any remaining warn-status findings as intentional
+  trade-offs if the user says so.

--- a/plugins/community/skillcrossroads/skills/audit-skill/evals/audit-clean-skill.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/evals/audit-clean-skill.md
@@ -6,7 +6,7 @@
 description with "Use when..." trigger cues, an evals/ folder, no secrets).
 
 **Expect:**
-- Runs `npx skillcrossroads@0.11.3 './my-skill' --no-llm --markdown` (does not hand-estimate a grade).
+- Runs `npx skillcrossroads@0.11.4 './my-skill' --no-llm --markdown` (does not hand-estimate a grade).
 - Reports the actual overall score/grade and states whether the LLM-assisted checks ran
   (i.e. whether `ANTHROPIC_API_KEY` was set).
 - Since there are no fail-status findings, does NOT invent fixes to apply — reports the

--- a/plugins/community/skillcrossroads/skills/audit-skill/evals/npx-unavailable.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/evals/npx-unavailable.md
@@ -1,0 +1,10 @@
+# Eval: npx fails (offline / registry blocked)
+
+**Prompt:** "Audit my skill" (run in a sandbox with no network access / npm registry
+blocked, so `npx skillcrossroads@0.11.3` fails to fetch the package).
+
+**Expect:**
+- Reports the `npx` error verbatim to the user.
+- Stops — does **not** hand-estimate a grade or fabricate a scorecard from memory of a
+  prior run.
+- Does not silently fall back to a different tool or claim the audit succeeded.

--- a/plugins/community/skillcrossroads/skills/audit-skill/evals/npx-unavailable.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/evals/npx-unavailable.md
@@ -1,7 +1,7 @@
 # Eval: npx fails (offline / registry blocked)
 
 **Prompt:** "Audit my skill" (run in a sandbox with no network access / npm registry
-blocked, so `npx skillcrossroads@0.11.3` fails to fetch the package).
+blocked, so `npx skillcrossroads@0.11.4` fails to fetch the package).
 
 **Expect:**
 - Reports the `npx` error verbatim to the user.

--- a/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
@@ -1,0 +1,20 @@
+# CLI flags quick reference (skillcrossroads 0.11.3)
+
+All invocations in this skill pin the version: `npx skillcrossroads@0.11.3 '<skill-dir>' <flags>`.
+Single-quote the directory argument (see SKILL.md step 2 for the shell-safety rationale).
+
+| Flag | Purpose | Needs API key? |
+| --- | --- | --- |
+| `--markdown` (`--md`) | Emit the Markdown scorecard — the default mode this skill uses for reporting. | No |
+| `--suggest[=N]` | Propose current → proposed fixes for the top N findings (default 3). Proposals only — **never auto-applies**; review each before editing. | Yes (`ANTHROPIC_API_KEY`) |
+| `--badge[=<file>]` | Write an SVG grade badge into the skill directory (default `<name>.beacon.svg`) for embedding in a README. | No |
+| `--min-grade=<G>` | Exit non-zero below grade G — useful as a CI gate (for example `--min-grade=B`). | No |
+
+## `--suggest` vs `--badge` in this skill's flow
+
+- **`--suggest`** belongs to step 4 (the fix loop): it drafts targeted rewrites for the
+  highest-impact findings. Treat every proposal as a review candidate — Read the cited
+  file:line, confirm the finding is real, then apply the smallest edit that resolves it.
+- **`--badge`** belongs to step 6 (after the audit or fix loop): it is output-only and
+  changes no grades. Offer it when the user wants an embeddable proof-of-quality artifact;
+  the badge links to [skillcrossroads.com](https://skillcrossroads.com) for the hosted scan.

--- a/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
@@ -1,18 +1,32 @@
 # CLI flags quick reference (skillcrossroads 0.11.3)
 
-All invocations in this skill pin the version: `npx skillcrossroads@0.11.3 '<skill-dir>' <flags>`.
+All invocations in this skill pin the version and pass `--no-llm`:
+`npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm <flags>`.
 Single-quote the directory argument (see SKILL.md step 2 for the shell-safety rationale).
 
-| Flag | Purpose | Needs API key? |
+⚠️ **`--no-llm` is not the CLI's own default.** Without it, the CLI sends content to
+Anthropic's Messages API whenever `ANTHROPIC_API_KEY` is present in the environment — it does
+not prompt first. This skill therefore passes it explicitly on every command except the
+opt-in `--suggest` in step 4.
+
+The column that matters is what leaves the machine, not whether a key is required:
+
+| Flag | Purpose | Sends your content off-machine? |
 | --- | --- | --- |
-| `--markdown` (`--md`) | Emit the Markdown scorecard — the default mode this skill uses for reporting. | No |
-| `--suggest[=N]` | Propose current → proposed fixes for the top N findings (default 3). Proposals only — **never auto-applies**; review each before editing. | Yes (`ANTHROPIC_API_KEY`) |
-| `--badge[=<file>]` | Write an SVG grade badge into the skill directory (default `<name>.beacon.svg`) for embedding in a README. | No |
-| `--min-grade=<G>` | Exit non-zero below grade G — useful as a CI gate (for example `--min-grade=B`). | No |
+| `--no-llm` | Force the fully local path: all six rubric categories scored deterministically. **This skill passes it on every command below.** | **No — never.** |
+| `--markdown` (`--md`) | Emit the Markdown scorecard — the default mode this skill uses for reporting. | No, as this skill invokes it (`--no-llm`). Without `--no-llm` and with a key set, yes: per-check excerpts of 1,500-2,500 characters. |
+| `--badge[=<file>]` | Write an SVG grade badge into the skill directory (default `<name>.beacon.svg`) for embedding in a README. | No, as this skill invokes it (`--no-llm`). |
+| `--min-grade=<G>` | Exit non-zero below grade G — useful as a CI gate (for example `--min-grade=B`). | No, as this skill invokes it (`--no-llm`). |
+| `--suggest[=N]` | Propose current → proposed fixes for the top N findings (default 3). Proposals only — **never auto-applies**; review each before editing. | **Yes — up to 24,000 characters of the entry file**, to `api.anthropic.com`, billed to your own `ANTHROPIC_API_KEY`. Requires explicit user consent (SKILL.md step 4). |
+
+Model results are cached on disk by content hash: `./.beacon-cache` if present, else
+`%LOCALAPPDATA%\skillcrossroads\cache` (Windows), `$XDG_CACHE_HOME/skillcrossroads` when set,
+otherwise `~/.cache/skillcrossroads`.
 
 ## `--suggest` vs `--badge` in this skill's flow
 
-- **`--suggest`** belongs to step 4 (the fix loop): it drafts targeted rewrites for the
+- **`--suggest`** belongs to step 4 (the fix loop) and is the only off-machine command here,
+  so it runs only after the user agrees: it drafts targeted rewrites for the
   highest-impact findings. Treat every proposal as a review candidate — Read the cited
   file:line, confirm the finding is real, then apply the smallest edit that resolves it.
 - **`--badge`** belongs to step 6 (after the audit or fix loop): it is output-only and

--- a/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
@@ -1,7 +1,7 @@
-# CLI flags quick reference (skillcrossroads 0.11.3)
+# CLI flags quick reference (skillcrossroads 0.11.4)
 
 All invocations in this skill pin the version and pass `--no-llm`:
-`npx skillcrossroads@0.11.3 '<skill-dir>' --no-llm <flags>`.
+`npx skillcrossroads@0.11.4 '<skill-dir>' --no-llm <flags>`.
 Single-quote the directory argument (see SKILL.md step 2 for the shell-safety rationale).
 
 ⚠️ **`--no-llm` is not the CLI's own default.** Without it, the CLI sends content to

--- a/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/references/flags-quick-reference.md
@@ -15,7 +15,7 @@ The column that matters is what leaves the machine, not whether a key is require
 | --- | --- | --- |
 | `--no-llm` | Force the fully local path: all six rubric categories scored deterministically. **This skill passes it on every command below.** | **No — never.** |
 | `--markdown` (`--md`) | Emit the Markdown scorecard — the default mode this skill uses for reporting. | No, as this skill invokes it (`--no-llm`). Without `--no-llm` and with a key set, yes: per-check excerpts of 1,500-2,500 characters. |
-| `--badge[=<file>]` | Write an SVG grade badge into the skill directory (default `<name>.beacon.svg`) for embedding in a README. | No, as this skill invokes it (`--no-llm`). |
+| `--badge[=<file>]` | Write an SVG grade badge for embedding in a README. Writes to the **current working directory** as `<name>.beacon.svg`, not into the skill directory - pass `--badge=<path>` to place it explicitly. | No, as this skill invokes it (`--no-llm`). |
 | `--min-grade=<G>` | Exit non-zero below grade G — useful as a CI gate (for example `--min-grade=B`). | No, as this skill invokes it (`--no-llm`). |
 | `--suggest[=N]` | Propose current → proposed fixes for the top N findings (default 3). Proposals only — **never auto-applies**; review each before editing. | **Yes — up to 24,000 characters of the entry file**, to `api.anthropic.com`, billed to your own `ANTHROPIC_API_KEY`. Requires explicit user consent (SKILL.md step 4). |
 

--- a/plugins/community/skillcrossroads/skills/audit-skill/references/rubric-categories.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/references/rubric-categories.md
@@ -1,0 +1,32 @@
+# The six rubric categories (skillcrossroads 0.11.3)
+
+Every scan scores the artifact across six weighted categories. The overall letter grade is
+the weighted average; each finding in the scorecard belongs to exactly one category and
+cites file and line.
+
+| Category | Weight | What it measures |
+| --- | --- | --- |
+| Triggering & Discoverability | 22% | Will Claude actually invoke this skill? Description quality, trigger cues, invocation-flag consistency (TRIGGER-01/02/03/05). |
+| Correctness & Structure | 20% | Valid frontmatter, required fields, resolvable supporting-file references (STRUCT-01/02/05). |
+| Clarity & Instructions | 18% | Unambiguous, contradiction-free instructions with stated constraints; no filler (CLARITY-02/03/05). |
+| Token & Context Cost | 15% | Body length budget, progressive disclosure, description budget, recurring context cost (TOKEN-01/02/03/04). |
+| Safety & Security | 15% | Hardcoded secrets, over-broad tool grants, auto-invoke risk, prompt-injection surface (SAFETY-01/02/03/04). |
+| Verifiability & Maintainability | 10% | Eval coverage, maintenance hygiene, a checkable "done" definition (VERIFY-01/03/04). |
+
+## Keyless vs. LLM-upgraded runs
+
+- **Keyless (default):** all six categories score deterministically — no network calls
+  beyond fetching the CLI, no API key, fully reproducible.
+- **With `ANTHROPIC_API_KEY` set:** TRIGGER-01 upgrades Triggering to an LLM judge, and
+  three LLM-assisted checks are added: VERIFY-04 (verification steps), CLARITY-02
+  (contradictions), and CLARITY-05 (constraints). A failing LLM check is reported, never
+  silently guessed.
+
+The report always states which mode ran, so the reader knows what the grade covers.
+
+## Reading a finding
+
+Each finding carries a check ID (for example `SAFETY-02`), a status, the file:line evidence,
+and a fix hint. **SAFETY-* findings are never suppressed or worked around** — fix the
+underlying problem. Per-check fix documentation:
+[skillcrossroads.com/docs/checks](https://skillcrossroads.com/docs/checks).

--- a/plugins/community/skillcrossroads/skills/audit-skill/references/rubric-categories.md
+++ b/plugins/community/skillcrossroads/skills/audit-skill/references/rubric-categories.md
@@ -1,4 +1,4 @@
-# The six rubric categories (skillcrossroads 0.11.3)
+# The six rubric categories (skillcrossroads 0.11.4)
 
 Every scan scores the artifact across six weighted categories. The overall letter grade is
 the weighted average; each finding in the scorecard belongs to exactly one category and

--- a/sources.lock.json
+++ b/sources.lock.json
@@ -737,6 +737,23 @@
         "skills/servicegraph/SKILL.md": "sha256:3e358f9451696f5690bc90006eff12737a76b4b5aad3eeb550343233ed9042dc"
       }
     },
+    "skillcrossroads": {
+      "repo": "sgharlow/skillcrossroads",
+      "resolved_ref": "7f1a7b2caca117ea1e64b935c17a7f6f2493292d",
+      "locked_at": "2026-09-03T18:17:18.274Z",
+      "files": {
+        ".claude-plugin/plugin.json": "sha256:2735a18b14021fa118dd8246004590b8c172bd9103043947c3409b319e325359",
+        "LICENSE": "sha256:4dcc217acd1eee58ad0cc6631e02326433a9209cb36cd856e94df90aee379792",
+        "README.md": "sha256:62336ba4c5bc60d254cdca5ccc422537bcfb0541372a8b704bc9fd2a602ad046",
+        "docs/PRD.md": "sha256:8b9b633f646424fb7e2edbcc6a266a08d8fa715c4f4dea66617b8c623ec090c9",
+        "skills/audit-skill/SKILL.md": "sha256:edc0cf8f9e25b4fc5dd2ea8bf84e08bdc5268229ed81b5f7bb51178c637642b2",
+        "skills/audit-skill/evals/audit-and-fix-low-grade-skill.md": "sha256:dc4577518fe99c9b091fa985c8bf6ae7234e34fad7caba2eb291a10fdf2e0ffa",
+        "skills/audit-skill/evals/audit-clean-skill.md": "sha256:1ed278c8245a724eba39a6f4889d8d17b1d2e54341e525fdadd9e686cdf14edd",
+        "skills/audit-skill/evals/npx-unavailable.md": "sha256:db24f74274c9cab2842c9dc06446af77b1442c466ef18a729c8c45a83cc16dba",
+        "skills/audit-skill/references/flags-quick-reference.md": "sha256:f00fa749749a3c3ecc8712955ed83bd81aeae2eb602d8cb6a27ac376d7f6ae55",
+        "skills/audit-skill/references/rubric-categories.md": "sha256:c4f07c149a035e4cfa5c8702aca33937445db7ec4521c6ddc0d26d20f068eb8b"
+      }
+    },
     "skills-janitor": {
       "repo": "khendzel/skills-janitor",
       "resolved_ref": "c63c3478edbfee1fe19da8c9b7f2b8e0d60d134e",

--- a/sources.lock.json
+++ b/sources.lock.json
@@ -739,19 +739,19 @@
     },
     "skillcrossroads": {
       "repo": "sgharlow/skillcrossroads",
-      "resolved_ref": "8a9b6ce588d0cf64eb3f2b433504125c99419745",
-      "locked_at": "2026-09-03T18:28:47.114Z",
+      "resolved_ref": "32a705ca207a58be7a77be59058ed4cd36406172",
+      "locked_at": "2026-09-03T19:55:46.289Z",
       "files": {
-        ".claude-plugin/plugin.json": "sha256:2735a18b14021fa118dd8246004590b8c172bd9103043947c3409b319e325359",
+        ".claude-plugin/plugin.json": "sha256:53d966fa235d2ac67056ff3931aba0d6c04d1148b30224934e08e52986855b61",
         "LICENSE": "sha256:4dcc217acd1eee58ad0cc6631e02326433a9209cb36cd856e94df90aee379792",
-        "README.md": "sha256:62336ba4c5bc60d254cdca5ccc422537bcfb0541372a8b704bc9fd2a602ad046",
-        "docs/PRD.md": "sha256:8b9b633f646424fb7e2edbcc6a266a08d8fa715c4f4dea66617b8c623ec090c9",
-        "skills/audit-skill/SKILL.md": "sha256:382ec9929473c2cfbd7625d33856ff276125380151b94450668e757b74e8e17e",
+        "README.md": "sha256:e3b17a6a2e06d4ccd967ec54b40df7fc5803daafd63dad126f168c089294c097",
+        "docs/PRD.md": "sha256:03bc0e5dd169fffd328d79f15a719b19143a1d75221f8d813b7807cbf14041f6",
+        "skills/audit-skill/SKILL.md": "sha256:14d1c7635bfe4a8114a611753b6a71447515b90762caba1ea2cc4b0727cf9818",
         "skills/audit-skill/evals/audit-and-fix-low-grade-skill.md": "sha256:dc4577518fe99c9b091fa985c8bf6ae7234e34fad7caba2eb291a10fdf2e0ffa",
-        "skills/audit-skill/evals/audit-clean-skill.md": "sha256:1ed278c8245a724eba39a6f4889d8d17b1d2e54341e525fdadd9e686cdf14edd",
-        "skills/audit-skill/evals/npx-unavailable.md": "sha256:db24f74274c9cab2842c9dc06446af77b1442c466ef18a729c8c45a83cc16dba",
-        "skills/audit-skill/references/flags-quick-reference.md": "sha256:ded995264c6adb9a5657586c7f845ad377ffb89436201276cd06152bc39947be",
-        "skills/audit-skill/references/rubric-categories.md": "sha256:c4f07c149a035e4cfa5c8702aca33937445db7ec4521c6ddc0d26d20f068eb8b"
+        "skills/audit-skill/evals/audit-clean-skill.md": "sha256:36de5c1ae9b531111c815b5e88666deb1fc29a7b95f93acdf72ff1bc107e4042",
+        "skills/audit-skill/evals/npx-unavailable.md": "sha256:08dc274b83cf54db638a04673e27a706af2adb78bdf1f7416bd02595c631bd94",
+        "skills/audit-skill/references/flags-quick-reference.md": "sha256:9460bb2e33386b9f5de1d90496c5f5b85c5aac01a4f8324fd0ba82ada715595a",
+        "skills/audit-skill/references/rubric-categories.md": "sha256:01e696caaefae1d9d0d6664f62924983e02b8e4fbbcd242591d51235f3131827"
       }
     },
     "skills-janitor": {

--- a/sources.lock.json
+++ b/sources.lock.json
@@ -739,18 +739,18 @@
     },
     "skillcrossroads": {
       "repo": "sgharlow/skillcrossroads",
-      "resolved_ref": "7f1a7b2caca117ea1e64b935c17a7f6f2493292d",
-      "locked_at": "2026-09-03T18:17:18.274Z",
+      "resolved_ref": "8a9b6ce588d0cf64eb3f2b433504125c99419745",
+      "locked_at": "2026-09-03T18:28:47.114Z",
       "files": {
         ".claude-plugin/plugin.json": "sha256:2735a18b14021fa118dd8246004590b8c172bd9103043947c3409b319e325359",
         "LICENSE": "sha256:4dcc217acd1eee58ad0cc6631e02326433a9209cb36cd856e94df90aee379792",
         "README.md": "sha256:62336ba4c5bc60d254cdca5ccc422537bcfb0541372a8b704bc9fd2a602ad046",
         "docs/PRD.md": "sha256:8b9b633f646424fb7e2edbcc6a266a08d8fa715c4f4dea66617b8c623ec090c9",
-        "skills/audit-skill/SKILL.md": "sha256:edc0cf8f9e25b4fc5dd2ea8bf84e08bdc5268229ed81b5f7bb51178c637642b2",
+        "skills/audit-skill/SKILL.md": "sha256:382ec9929473c2cfbd7625d33856ff276125380151b94450668e757b74e8e17e",
         "skills/audit-skill/evals/audit-and-fix-low-grade-skill.md": "sha256:dc4577518fe99c9b091fa985c8bf6ae7234e34fad7caba2eb291a10fdf2e0ffa",
         "skills/audit-skill/evals/audit-clean-skill.md": "sha256:1ed278c8245a724eba39a6f4889d8d17b1d2e54341e525fdadd9e686cdf14edd",
         "skills/audit-skill/evals/npx-unavailable.md": "sha256:db24f74274c9cab2842c9dc06446af77b1442c466ef18a729c8c45a83cc16dba",
-        "skills/audit-skill/references/flags-quick-reference.md": "sha256:f00fa749749a3c3ecc8712955ed83bd81aeae2eb602d8cb6a27ac376d7f6ae55",
+        "skills/audit-skill/references/flags-quick-reference.md": "sha256:ded995264c6adb9a5657586c7f845ad377ffb89436201276cd06152bc39947be",
         "skills/audit-skill/references/rubric-categories.md": "sha256:c4f07c149a035e4cfa5c8702aca33937445db7ec4521c6ddc0d26d20f068eb8b"
       }
     },

--- a/sources.yaml
+++ b/sources.yaml
@@ -1239,6 +1239,34 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # Skill Crossroads (Steve Harlow)
+  # https://github.com/sgharlow/skillcrossroads
+  # ============================================================
+
+  - name: skillcrossroads
+    description: Audit Claude Code artifacts from inside Claude Code - grade skills, subagents, slash commands, MCP configs and plugins with an evidence-cited file:line scorecard, then walk the ranked fix list until the grade stops improving.
+    repo: sgharlow/skillcrossroads
+    source_path: plugin
+    target_path: plugins/community/skillcrossroads
+    author:
+      name: Steve Harlow
+      github: sgharlow
+      email: sgharlow@users.noreply.github.com
+    license: MIT
+    category: community
+    verified: false
+    include:
+      - '/.claude-plugin/plugin.json'
+      - '/README.md'
+      - '/LICENSE'
+      - '/docs/**'
+      - '/skills/**'
+    exclude:
+      - '/.git/**'
+      - '**/node_modules/**'
+      - '**/*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
@jeremylongshore Resubmission of #1080, rebuilt per your closing notes.

What changed:

- Fresh branch off current main. The diff is 9 files, +300/-5: the plugin dir, one entry in marketplace.extended.json, and the files sync-marketplace regenerates (marketplace.json, plugin package.json, README TOC). No deletions of existing content this time.
- Pre-screen blocker fixed. SKILL.md grades A (100/100) with 0 errors on the marketplace-tier validator (was C, 79, 6 errors; graded A 95 at review time, before `references/` was added in the review-response commit). The original errors were six missing required sections: Overview, Prerequisites, Output, Error Handling, Examples, Resources. All added with real content, plus argument-hint and documented optional ANTHROPIC_API_KEY auth.
- Greptile's pin suggestion applied: every npx invocation is pinned to skillcrossroads@0.11.3, including a fourth one in the Verify section the review didn't flag. plugin.json, SKILL.md, and the marketplace entry all declare 0.11.3.
- Submission docs added per templates/skill-docs: docs/PRD.md (micro tier, 1 skill). check-submission-docs.mjs passes with --changed-only.

Thanks for the clear instructions on #1080, they made the rebuild straightforward.

---

**Review response (2026-08-02):** all three items from the review addressed in `99007b3e`:

- **Package naming:** kept `@intentsolutionsio/skillcrossroads` — the `package.json` here is the marketplace's generated tracking artifact and every catalog plugin uses that scope (per CHANGELOG #541), so renaming it would break repo convention and the publish workflows. Instead the README and PRD now document the split explicitly: un-scoped `skillcrossroads` on npm = the upstream CLI; the scoped package = this repo's tracking artifact.
- **Grade claim:** added `skills/audit-skill/references/` (rubric-categories.md, flags-quick-reference.md — content verified against the pinned 0.11.3 source), linked from SKILL.md Resources. Fresh validator run: A (100/100), 0 errors. The claim above is updated to match.
- **LICENSE nit:** copyright holder aligned to Steve Harlow.

