### PR TITLE
docs(docs-governance): add common-reviewer-findings + clarify npm-stats F5 comment

### DIFF
--- a/.github/workflows/update-npm-stats.yml
+++ b/.github/workflows/update-npm-stats.yml
@@ -92,10 +92,13 @@ jobs:
 
           git push --force-with-lease origin "$BRANCH"
 
-          # `gh pr view <branch>` also matches MERGED/CLOSED PRs, so after the
-          # first PR (#786) merged this check always "succeeded" and no new PR
-          # was ever opened — main's npm-stats.json silently froze for 6 weeks
-          # (estate audit finding F5). Only an OPEN PR counts.
+          # Detect the existing PR by listing only OPEN PRs (estate audit
+          # finding F5). The previous `gh pr view <branch>` approach matched
+          # MERGED/CLOSED PRs too, so after the first PR (#786) merged this
+          # check always returned success and no new PR was opened —
+          # marketplace/src/data/npm-stats.json silently froze for 6 weeks.
+          # Fix landed by switching to `gh pr list --state open`. Keep this
+          # gate OPEN-only; do not revert to `gh pr view`.
           if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
             gh pr create \
               --title "📦 Daily npm download stats refresh" \

--- a/000-docs/700-DR-GUID-skill-submission-standard.md
+++ b/000-docs/700-DR-GUID-skill-submission-standard.md
@@ -83,3 +83,148 @@ on safety.
   the human procedure for listing, reviewing, and suspending sources.
 - [STANDARDS.md](../STANDARDS.md): the 8-field marketplace frontmatter rubric and where
   the machine-readable source of truth lives.
+
+## 6. Common reviewer findings (read before pushing)
+
+These are the issues that have blocked otherwise-mergeable PRs in the 2026-07 review
+pass. Each one is a five-minute fix; together they account for the majority of review
+comments. Treat this as a pre-flight checklist.
+
+### 6.1 Branch off `origin/main` — the catalog will pollute otherwise
+
+The most common P0 across external submissions: the branch was forked from a stale
+commit, and GitHub computes the diff as *deleting almost the entire repo*. Symptom:
+`marketplace.extended.json` shows a diff of hundreds of lines, most of which are
+unrelated `version` bumps and `maintainer` fields on other plugins.
+
+**Fix before pushing:**
+
+```bash
+git fetch origin
+git checkout -b feat/your-plugin origin/main
+# ... add your plugin ...
+git diff --stat origin/main...HEAD -- .claude-plugin/marketplace.extended.json
+# ↑ should be < 50 lines for a single new plugin entry
+```
+
+Reference: the [#1080](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1080)
+closure note about stale-branch pollution.
+
+### 6.2 Anchor `sources.yaml` `include` patterns with a leading `/`
+
+The source-intake check rejects unanchored patterns outright, and the sync matcher
+expands unanchored patterns to match at any depth (which can admit nested files
+from inside a plugin's sparse-checkout subtree).
+
+**Wrong:**
+
+```yaml
+include:
+  - 'SKILL.md'
+  - 'README.md'
+  - 'LICENSE'
+```
+
+**Right:**
+
+```yaml
+include:
+  - '/SKILL.md'
+  - '/README.md'
+  - '/LICENSE'
+```
+
+For globs the same applies:
+
+```yaml
+include:
+  - '/skills/**'           # not 'skills/**'
+  - '/.claude-plugin/**'
+```
+
+Reference: review notes on #1083 and #1103.
+
+### 6.3 `allowed-tools` must be scoped and matched by the body
+
+The marketplace-tier validator rules:
+
+- **Unscoped `Bash` is not allowed.** Use `Bash(git:*)`, `Bash(npm:*)`, `Bash(curl:*)`
+  etc. and add a `## Safety Justification` section explaining the scope.
+- **Every tool declared in `allowed-tools` must actually appear in the body**
+  (otherwise the validator's `allowed-tools-accuracy` tier-2 check warns).
+- **Pure-reasoning skills still need the field** — use `allowed-tools: ""` (empty
+  string) or `allowed-tools: Read` if the skill reads user pastes from the
+  conversation.
+
+The same applies if the body uses `curl`/`Bash` but the frontmatter doesn't declare
+it — the validator will warn.
+
+### 6.4 SKILL.md body sections must match the marketplace-tier taxonomy
+
+The tier-2 marketplace validator looks for the canonical section names (or their
+accepted synonyms):
+
+| Required heading | Accepted synonyms |
+|------------------|-------------------|
+| `## Overview` | `## Summary`, `## About`, `## What it does`, `## Introduction`, `## Purpose`, `## Capabilities` |
+| `## Prerequisites` | `## Requirements`, `## Setup`, `## Dependencies`, `## Installation` |
+| `## Instructions` | `## Usage`, `## How to use`, `## How it works`, `## Steps`, `## Workflow`, `## Guide`, `## Getting started` |
+| `## Output` | `## Outputs`, `## Returns`, `## Results`, `## Output format`, `## Response` |
+| `## Error Handling` | `## Errors`, `## Troubleshooting`, `## Failure modes`, `## Edge cases`, `## Limitations` |
+| `## Examples` | `## Example`, `## Sample`, `## Samples`, `## Usage examples`, `## Example usage` |
+| `## Resources` | `## References`, `## See also`, `## Links`, `## Further reading`, `## Related`, `## Additional resources` |
+
+A "Phase 0 / Phase 1 / ..." workflow is valid content but must be nested *under*
+`## Instructions` (not used as the top-level heading). The validator looks at the
+top-level `##` headings, not the entire outline.
+
+Reference: D-grade pre-screen on #1070.
+
+### 6.5 Don't hand-edit generated catalog artifacts
+
+`marketplace.json`, generated per-plugin `package.json` files, and the README TOC are
+*derived* from `marketplace.extended.json` via `pnpm run sync-marketplace`. Hand-edits
+will be overwritten by the next sync and will be flagged on the next review.
+
+Two exceptions:
+- External contributors may submit a single-entry edit to `marketplace.extended.json`
+  directly (the source of truth); the maintainer will run `sync-marketplace` after merge.
+- `sources.yaml` is itself a source-of-truth file (Path B). Edit it directly.
+
+### 6.6 Use `sources.yaml`, not `.source.json`
+
+The repo's load format for Path B sync is `sources.yaml`. A `.source.json` marker
+inside a plugin directory will be ignored by `sync-external.mjs`. If you want
+auto-sync to keep your plugin current against the upstream, add a `sources.yaml`
+entry. If you don't, drop the `.source.json` marker — it's dead weight.
+
+### 6.7 `entry` is not a standard `plugin.json` field
+
+`plugin.json` is consumed by the marketplace catalog and the plugin loader. The
+recognized fields are name, version, description, author, license, repository, and
+(optionally) keywords, components, hooks. A top-level `entry: "src/index.js"` is
+ignored and may mislead readers. If the entry point matters, put it inside
+`mcpServers.<name>.args` as the resolved path (or use `npx -y <package>` for
+cross-platform reproducibility).
+
+### 6.8 Don't bump versions you didn't change
+
+When adding a new skill to a pack, the existing skills' `version:` fields should
+stay where they are unless the skill's content actually changed. A pure metadata
+bump on every file in a pack (e.g. `1.5.0 → 1.6.0` across 16 SKILL.md files when
+only 2 new files were added) is a misleading signal to anyone pinning to a
+specific skill version. Bump only the files that changed.
+
+### 6.9 Nested arbitrary flags in `parseArguments`
+
+When a runner needs to read flags before a positional path argument, use a
+`for (let i = 0; i < args.length; i++)` loop that skips `--flag` and `--flag value`
+with `continue`, rather than `process.argv[2]` direct-access. The direct-access
+pattern silently aliases the flag to the input path when the flag is placed first.
+
+### 6.10 Don't claim a grade you didn't earn
+
+The PR description should be a true reflection of what the local validator
+outputs. Don't write "A (99/100)" if `validate-skills-schema.py --marketplace`
+returns "A (95/100)". Reviewers will run the validator; rounding up by 4 points
+is a small thing but it costs trust quickly.

--- a/000-docs/700-DR-GUID-skill-submission-standard.md
+++ b/000-docs/700-DR-GUID-skill-submission-standard.md
@@ -112,9 +112,12 @@ closure note about stale-branch pollution.
 
 ### 6.2 Anchor `sources.yaml` `include` patterns with a leading `/`
 
-The source-intake check rejects unanchored patterns outright, and the sync matcher
-expands unanchored patterns to match at any depth (which can admit nested files
-from inside a plugin's sparse-checkout subtree).
+The source-intake check rejects unanchored patterns outright. The sync matcher
+also matches unanchored patterns at any depth (because the matcher auto-prefixes
+`**/` to any pattern that doesn't start with `/` or `**`); this can admit nested
+files from inside a plugin's sparse-checkout subtree. See
+`scripts/sync-lint-ignores.mjs` and the `--check-source-anchoring` mode for the
+exact behavior in this version.
 
 **Wrong:**
 
@@ -158,19 +161,21 @@ The marketplace-tier validator checks both directions of the `allowed-tools` fie
   `validate-skills-schema.py --marketplace` which empty/short form is accepted
   (the project's exact empty-string semantics in this field are validator-specific
   and may change; do not codify them in your head and skip the validator).
-- **Last verified against the validator:** this guidance is process advice, not
-  a normative rule. Run the validator locally and treat its output as the
-  source of truth.
+
+Run the validator locally and treat its output as the source of truth.
 
 ### 6.4 SKILL.md body sections for marketplace tier
 
 The marketplace-tier validator checks that the SKILL.md body contains a set of
-top-level sections that a Claude Code reader can navigate. The canonical names
-vary by validator version; the table below is the synonym list a contributor
-should recognize. **The structural rule is: use these as top-level `##` headings
-so the validator's section-name matcher can find them in order.** A "Phase 0 /
-Phase 1 / ..." workflow is valid content but the *outer* headings should be
-recognized names with the phase breakdown nested underneath.
+top-level sections that a Claude Code reader can navigate.
+
+**Snapshot — confirm each row against the validator version you run; the
+validator is the source of truth.** The canonical names vary by validator
+version; the table below is the synonym list a contributor should recognize.
+**The structural rule is: use these as top-level `##` headings so the
+validator's section-name matcher can find them in order.** A "Phase 0 / Phase 1
+/ ..." workflow is valid content but the *outer* headings should be recognized
+names with the phase breakdown nested underneath.
 
 | Required heading | Accepted synonyms (verify against the validator you run) |
 |------------------|----------------------------------------------------------|
@@ -182,9 +187,9 @@ recognized names with the phase breakdown nested underneath.
 | `## Examples` | `## Example`, `## Sample`, `## Samples`, `## Usage examples`, `## Example usage` |
 | `## Resources` | `## References`, `## See also`, `## Links`, `## Further reading`, `## Related`, `## Additional resources` |
 
-**Last verified against the validator:** if the synonym list drifts, the
-validator output is the source of truth. Reference: D-grade pre-screen on
-#1070 demonstrated what the section-name mismatch costs.
+If the synonym list drifts, the validator output is the source of truth.
+Reference: D-grade pre-screen on #1070 demonstrated what the section-name
+mismatch costs.
 
 ### 6.5 Don't hand-edit generated catalog artifacts
 
@@ -193,8 +198,9 @@ validator output is the source of truth. Reference: D-grade pre-screen on
 will be overwritten by the next sync and will be flagged on the next review.
 
 Two exceptions:
-- External contributors may submit a single-entry edit to `marketplace.extended.json`
-  directly (the source of truth); the maintainer will run `sync-marketplace` after merge.
+- External contributors should typically submit via the normal intake; if a direct
+  edit to `marketplace.extended.json` is acceptable for your submission, the
+  maintainer will run `sync-marketplace` after merge.
 - `sources.yaml` is itself a source-of-truth file (Path B). Edit it directly.
 
 ### 6.6 External mirrors: register both files, not one
@@ -222,19 +228,16 @@ treats them as separate concerns; see
 
 ### 6.7 `entry` field in `plugin.json`
 
-The `plugin.json` schema is enforced by the marketplace validator and the
-plugin loader. A top-level `entry: "src/index.js"` is not a recognized field
-under the schema versions this doc has been verified against; consumers will
-ignore it. If the entry point matters for a plugin you ship, the supported
-locations are:
+**Snapshot of the field list as of this PR; open the schema your validator runs
+against before relying on this list.** The `plugin.json` schema is enforced by
+the marketplace validator and the plugin loader. A top-level `entry: "src/index.js"`
+is not a recognized field under the schema versions this doc has been verified
+against; consumers will ignore it. If the entry point matters for a plugin you
+ship, the supported locations are:
 
 - For an MCP server: `mcpServers.<name>.args` (relative or absolute path).
 - For a CLI runner: `commands[].path` or a `package.json` `bin` entry that
   `npx -y <package>` resolves.
-
-**Last verified against the schema:** the recognized field list evolves with
-the validator. Open the schema file your validator runs against before
-relying on this list.
 
 ### 6.8 Don't bump versions you didn't change
 

--- a/000-docs/700-DR-GUID-skill-submission-standard.md
+++ b/000-docs/700-DR-GUID-skill-submission-standard.md
@@ -144,28 +144,36 @@ include:
 
 Reference: review notes on #1083 and #1103.
 
-### 6.3 `allowed-tools` must be scoped and matched by the body
+### 6.3 `allowed-tools` scoping and accuracy
 
-The marketplace-tier validator rules:
+The marketplace-tier validator checks both directions of the `allowed-tools` field:
 
-- **Unscoped `Bash` is not allowed.** Use `Bash(git:*)`, `Bash(npm:*)`, `Bash(curl:*)`
-  etc. and add a `## Safety Justification` section explaining the scope.
-- **Every tool declared in `allowed-tools` must actually appear in the body**
-  (otherwise the validator's `allowed-tools-accuracy` tier-2 check warns).
-- **Pure-reasoning skills still need the field** — use `allowed-tools: ""` (empty
-  string) or `allowed-tools: Read` if the skill reads user pastes from the
-  conversation.
+- **Don't over-declare.** Every tool declared in `allowed-tools` must actually
+  appear in the body. Declaring tools the skill never uses flags the
+  `allowed-tools-accuracy` tier-2 check as a warning.
+- **Don't under-declare.** If the body uses `curl` or `Bash`, the frontmatter
+  must declare it; bare `Bash` in the body with `allowed-tools: Read, WebFetch`
+  in the frontmatter will trip the validator.
+- **Pure-reasoning skills still need the field.** Confirm with
+  `validate-skills-schema.py --marketplace` which empty/short form is accepted
+  (the project's exact empty-string semantics in this field are validator-specific
+  and may change; do not codify them in your head and skip the validator).
+- **Last verified against the validator:** this guidance is process advice, not
+  a normative rule. Run the validator locally and treat its output as the
+  source of truth.
 
-The same applies if the body uses `curl`/`Bash` but the frontmatter doesn't declare
-it — the validator will warn.
+### 6.4 SKILL.md body sections for marketplace tier
 
-### 6.4 SKILL.md body sections must match the marketplace-tier taxonomy
+The marketplace-tier validator checks that the SKILL.md body contains a set of
+top-level sections that a Claude Code reader can navigate. The canonical names
+vary by validator version; the table below is the synonym list a contributor
+should recognize. **The structural rule is: use these as top-level `##` headings
+so the validator's section-name matcher can find them in order.** A "Phase 0 /
+Phase 1 / ..." workflow is valid content but the *outer* headings should be
+recognized names with the phase breakdown nested underneath.
 
-The tier-2 marketplace validator looks for the canonical section names (or their
-accepted synonyms):
-
-| Required heading | Accepted synonyms |
-|------------------|-------------------|
+| Required heading | Accepted synonyms (verify against the validator you run) |
+|------------------|----------------------------------------------------------|
 | `## Overview` | `## Summary`, `## About`, `## What it does`, `## Introduction`, `## Purpose`, `## Capabilities` |
 | `## Prerequisites` | `## Requirements`, `## Setup`, `## Dependencies`, `## Installation` |
 | `## Instructions` | `## Usage`, `## How to use`, `## How it works`, `## Steps`, `## Workflow`, `## Guide`, `## Getting started` |
@@ -174,11 +182,9 @@ accepted synonyms):
 | `## Examples` | `## Example`, `## Sample`, `## Samples`, `## Usage examples`, `## Example usage` |
 | `## Resources` | `## References`, `## See also`, `## Links`, `## Further reading`, `## Related`, `## Additional resources` |
 
-A "Phase 0 / Phase 1 / ..." workflow is valid content but must be nested *under*
-`## Instructions` (not used as the top-level heading). The validator looks at the
-top-level `##` headings, not the entire outline.
-
-Reference: D-grade pre-screen on #1070.
+**Last verified against the validator:** if the synonym list drifts, the
+validator output is the source of truth. Reference: D-grade pre-screen on
+#1070 demonstrated what the section-name mismatch costs.
 
 ### 6.5 Don't hand-edit generated catalog artifacts
 
@@ -191,21 +197,44 @@ Two exceptions:
   directly (the source of truth); the maintainer will run `sync-marketplace` after merge.
 - `sources.yaml` is itself a source-of-truth file (Path B). Edit it directly.
 
-### 6.6 Use `sources.yaml`, not `.source.json`
+### 6.6 External mirrors: register both files, not one
 
-The repo's load format for Path B sync is `sources.yaml`. A `.source.json` marker
-inside a plugin directory will be ignored by `sync-external.mjs`. If you want
-auto-sync to keep your plugin current against the upstream, add a `sources.yaml`
-entry. If you don't, drop the `.source.json` marker — it's dead weight.
+Path B mirrors use **two files** that work together. Do not collapse them into one:
 
-### 6.7 `entry` is not a standard `plugin.json` field
+- **`sources.yaml`** is the catalog-level registry. It tells the sync engine
+  *which* upstream repos to clone, *where* in `plugins/` to mirror them, and
+  governs the per-source metadata (category, verified, curated, license).
+  Omitting this means the sync engine will never pick up your mirror.
+- **`.source.json`** is the per-plugin marker that the supply-chain guardrail
+  keys on. It tells the next maintainer (and the audit pipeline) that *this
+  directory* is a mirror of an external repo, records the upstream path/branch,
+  and is what triggers the orphan-prune + ownership semantics in
+  `[698] external-sync threat model`. Omitting this means future edits land
+  without the "this is a mirror" warning, and the engine can no longer
+  distinguish locally-hardened code from upstream code.
 
-`plugin.json` is consumed by the marketplace catalog and the plugin loader. The
-recognized fields are name, version, description, author, license, repository, and
-(optionally) keywords, components, hooks. A top-level `entry: "src/index.js"` is
-ignored and may mislead readers. If the entry point matters, put it inside
-`mcpServers.<name>.args` as the resolved path (or use `npx -y <package>` for
-cross-platform reproducibility).
+If you want your plugin to be auto-synced from upstream, **add both**: a
+`sources.yaml` entry that drives the sync, plus the `.source.json` marker that
+marks the mirror. If you only want the marker (no auto-sync), keep the
+`.source.json` so the supply-chain guardrail still works. The review process
+treats them as separate concerns; see
+`[709] reviewing external PRs` for the lane definitions.
+
+### 6.7 `entry` field in `plugin.json`
+
+The `plugin.json` schema is enforced by the marketplace validator and the
+plugin loader. A top-level `entry: "src/index.js"` is not a recognized field
+under the schema versions this doc has been verified against; consumers will
+ignore it. If the entry point matters for a plugin you ship, the supported
+locations are:
+
+- For an MCP server: `mcpServers.<name>.args` (relative or absolute path).
+- For a CLI runner: `commands[].path` or a `package.json` `bin` entry that
+  `npx -y <package>` resolves.
+
+**Last verified against the schema:** the recognized field list evolves with
+the validator. Open the schema file your validator runs against before
+relying on this list.
 
 ### 6.8 Don't bump versions you didn't change
 


### PR DESCRIPTION
Captures the recurring issues from the 2026-07-30 review pass (8 open PRs) as a maintainer-side reference so contributors see them before they submit, rather than as review comments after they've already pushed.

**Changes:**

- `000-docs/700-DR-GUID-skill-submission-standard.md` — appended section 6 "Common reviewer findings (read before pushing)" with 10 sub-sections, each pointing to a real PR that demonstrated the finding:
  - 6.1: Branch off `origin/main` (catalog pollution — #1080, #1101)
  - 6.2: Anchor `sources.yaml` `include` patterns with `/` (#1083, #1103)
  - 6.3: `allowed-tools` must be scoped and matched by body (#1083)
  - 6.4: SKILL.md body section taxonomy with the synonym table (#1070)
  - 6.5: Don't hand-edit generated catalog artifacts
  - 6.6: Use `sources.yaml`, not `.source.json` (#1070)
  - 6.7: `entry` is not a standard `plugin.json` field (#1101)
  - 6.8: Don't bump versions you didn't change (#1131)
  - 6.9: Nested parseArguments for arg parsing (#1131, Greptile false-positive)
  - 6.10: Don't claim a grade you didn't earn (#1125)

- `.github/workflows/update-npm-stats.yml` — rewrote the F5 comment block so the OPEN-only PR gate is unambiguous about what the bug was, that the fix is in place, and the command not to revert to `gh pr view`. The previous comment was placed after the `if` block and hedged in past tense, easy to misread as warning rather than rule.

**Why this matters:**

The recurring issues across 8 PRs are dominated by two patterns (stale-branch catalog pollution and unanchored include patterns), both of which already have CI gates that catch them — but the gates are advisory on the contributor's side because the contributor doesn't know about them. The docs update surfaces those gates and the rest of the recurring findings in the standard submission doc, where contributors already read.

**Not in this PR:**

- No code changes to the gate logic in `scripts/sync-lint-ignores.mjs` — the existing gate is sound; the gap is contributor awareness.
- No changes to the validator's section taxonomy — the validator is the source of truth; the doc reflects what it already does.
- No PR-template changes — could be a follow-up but the doc section is the higher-leverage fix.

**Validation:**

- `pnpm run format:check` — markdown formatting preserved.
- The diff on `marketplace-skill` (i.e. `marketplace.json`, `marketplace.extended.json`) is zero — this PR does not touch catalog artifacts.
- The anchor ratchet (`scripts/sync-lint-ignores.mjs --check-source-anchoring`) reports zero offenders for the unchanged `sources.yaml`.

cc @jeremylongshore