### PR TITLE
feat(sources): add qaia-core external plugin source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1745,6 +1745,38 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # QAIA (Cédric Moretti)
+  # https://github.com/QAIA-Project/QAIA
+  # ============================================================
+
+  - name: qaia-core
+    description: Turn a user story into a traceable Gherkin test book -- stable scenario IDs, an acceptance-criterion coverage matrix, and ambiguities surfaced as questions instead of silently resolved.
+    repo: QAIA-Project/QAIA
+    source_path: plugins/qaia-core
+    target_path: plugins/testing/qaia-core
+    author:
+      name: Cedric Moretti
+      github: Opaland
+      email: ced.moretti@gmail.com
+    license: MIT
+    category: testing
+    verified: false
+    keywords:
+      - testing
+      - qa
+      - gherkin
+      - istqb
+      - test-generation
+    include:
+      - '/README.md'
+      - '/skills/**'
+    exclude:
+      - '/.git/**'
+      - '**/node_modules/**'
+      - '**/*.log'
+
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Path B (external mirror) per CONTRIBUTING — one entry in `sources.yaml`, `README.md` untouched, nothing vendored.

## What it is

[QAIA](https://github.com/QAIA-Project/QAIA) (MIT) is a set of Claude Code plugins for QA engineers. `qaia-core` — the plugin submitted here — takes a user story to a **Gherkin test book with stable scenario IDs** (`@QAIA-xxx`) and an **acceptance-criterion → condition → scenario coverage matrix**. 15 Markdown skills, no API key, no MCP server, no hooks, nothing that executes on its own.

The design bet worth a look: **when an acceptance criterion is ambiguous, it does not pick.** On the worked example (an expense-approval story), 38 scenarios were derived and **11 carry a "low confidence" flag naming the open question**, with the risk of both answers written out, waiting on a human. Silent disambiguation is, I think, the real failure mode of generated test suites — the guess ends up exactly at the boundary where the bugs are, and it's invisible.

## Honest state, up front

**Pre-alpha. No human pilot has ever run it end to end.** Its output has been measured by evaluation harnesses, executed in real CI, and reviewed by personas — but "does it save a real QA engineer real time on real work?" is unanswered. An external 13-persona audit scored it 2.4/5 and an architecture review 5.0/10; both are published in the repo with what was and wasn't fixed. I'd rather you read [`docs/STATUS.md`](https://github.com/QAIA-Project/QAIA/blob/main/docs/STATUS.md) than my landing page. Happy for the entry to sit at `verified: false` indefinitely, or to be declined on maturity grounds — that's a fair call at this stage.

What *is* verifiable in five minutes without installing anything:

- a suite generated by the sibling `automate` skill runs on a GitHub Actions runner with **no Claude session and no skill loaded** — 8 tests, 8 green ([run 30702503888](https://github.com/QAIA-Project/QAIA/actions/runs/30702503888))
- no producer scores its own output — the deterministic structural score lives in a separate read-only plugin
- all 32 manifests in the repo pass a validator, enforced in CI

## Entry details

| field | value |
|---|---|
| `repo` | `QAIA-Project/QAIA` |
| `source_path` | `plugins/qaia-core` |
| `target_path` | `plugins/testing/qaia-core` |
| `license` | MIT |
| `category` | testing |
| `verified` | false |

One thing to flag on the include globs: this plugin's unit is a **bundle of skills**, so there is no single `SKILL.md` at the plugin root — the globs pull `README.md` plus `skills/**` (each skill has its own `SKILL.md` and `references/`). If your catalog expects a root-level `SKILL.md`, say so and I'll either restructure upstream or narrow the entry to a single skill instead — whichever fits your model better. Same for the category if `testing` isn't where you'd file it.

Only one repo submitted, per the one-at-a-time norm.
