### PR TITLE
fix(external-sync): stop one drifted source from halting every other mirror

### DIFF
--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -418,6 +418,12 @@ jobs:
           QUARANTINED_SOURCES: ${{ steps.sync.outputs.quarantined_sources }}
           REFUSED_SOURCES: ${{ steps.sync.outputs.refused_sources }}
         run: |
+          # Strict shell, matching the other multi-command steps in this file.
+          # Without -o pipefail a failure inside the PAYLOAD=$(python3 ...)
+          # substitution would be swallowed and curl would post a malformed
+          # body, turning a failed alert into a silently successful step —
+          # the precise class of silence this alert exists to end.
+          set -euo pipefail
           if [ -z "$WEBHOOK" ]; then
             echo "SLACK_OPERATION_HIRED_WEBHOOK_URL not set; skipping alert."
             exit 0

--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -144,7 +144,7 @@ jobs:
       # rides along in the same auto-PR. (Skipped on dry-run and on a partial
       # sync, matching the commit/PR gating downstream.)
       - name: Sync lint-ignore exclusions
-        if: inputs.dry_run != true && steps.sync.outputs.errors == '0' && steps.sync.outputs.quarantined == '0'
+        if: inputs.dry_run != true && steps.sync.outputs.errors == '0'
         run: node scripts/sync-lint-ignores.mjs
 
       # Supply-chain gate on the freshly-mirrored content BEFORE it is committed
@@ -172,7 +172,7 @@ jobs:
           fi
 
       - name: Sync marketplace catalog
-        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0' && steps.sync.outputs.quarantined == '0'
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0'
         # Use --no-frozen-lockfile here intentionally: the sync step above can
         # overwrite synced plugins' package.json from upstream, which legitimately
         # diverges from the committed pnpm-lock.yaml. The auto-PR this workflow
@@ -199,7 +199,7 @@ jobs:
         # earlier shared-branch clobber, 000-docs/691-AT-AUDT); this step only
         # prunes the pileup that model produced. See 000-docs AT-DECR
         # (mirror-by-default external-plugin sync model).
-        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0' && steps.sync.outputs.quarantined == '0'
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -215,7 +215,7 @@ jobs:
             done
 
       - name: Create Pull Request
-        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0' && steps.sync.outputs.quarantined == '0'
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != true && steps.sync.outputs.errors == '0'
         # Hand-rolled commit + push + PR-create instead of peter-evans/create-pull-request.
         #
         # Why: sync diffs are large (hundreds of files / 100K+ lines from upstream
@@ -300,21 +300,40 @@ jobs:
 
       # A locked source whose upstream content drifted from the committed
       # sources.lock.json baseline was QUARANTINED by the sync engine (nothing
-      # of it mirrored). Like the partial-sync path above, the commit + PR
-      # steps are gated on `quarantined == '0'`, so drifted content can never
-      # ride into the routine auto-PR. This step makes the run visibly RED and
-      # names the drifted sources; a human reviews each upstream diff, then
-      # approves via workflow_dispatch with relock=<names> (or relock=all).
+      # of it mirrored — the engine returns `changes: []` BEFORE writing any
+      # file, so drifted content never reaches the working tree at all).
+      #
+      # Drift therefore quarantines ONLY the drifted source, exactly like the
+      # REFUSE path below: the clean co-synced sources still ship their PR, and
+      # this step runs AFTER it to make the run visibly RED and name the drifted
+      # sources. A human reviews each upstream diff, then approves via
+      # workflow_dispatch with relock=<names> (or relock=all).
+      #
+      # The commit/PR steps were previously ALSO gated on `quarantined == '0'`.
+      # That gate protected nothing — the drifted files were never written, so
+      # they could not ride into the PR — while blocking every OTHER source's
+      # legitimately-mirrored content. One drifted source halted all 63.
+      #
+      # It did exactly that: `slack-channel` drifted and the sync failed on
+      # EVERY run from 2026-07-27 to 2026-08-09, so nothing mirrored for two
+      # weeks. The UIZZE plugin (#1104) was accepted on 2026-07-25 and still did
+      # not exist on the site when the outage was found — the contributor saw
+      # their submission merged and then vanish. The failure was loud in the
+      # Actions tab and observed by nobody, which is the actual lesson.
+      # See #1164.
       - name: Flag quarantined drift
         if: steps.sync.outputs.quarantined != '0' && steps.sync.outputs.quarantined != ''
         run: |
           {
             echo "## 🔒 Upstream drift quarantined — needs human review"
             echo ""
-            echo "${{ steps.sync.outputs.quarantined }} source(s) drifted from their sources.lock.json baseline; no PR was opened."
+            echo "${{ steps.sync.outputs.quarantined }} source(s) drifted from their sources.lock.json baseline. NOTHING of theirs was mirrored."
             echo "Drifted: ${{ steps.sync.outputs.quarantined_sources }}"
             echo ""
+            echo "The clean co-synced sources shipped their PR normally — only the drifted source(s) above are held back."
+            echo ""
             echo "Review each upstream diff, then re-run this workflow (workflow_dispatch) with \`relock\` set to the approved source names (comma-separated) or \`all\`."
+            echo "Until then those source(s) stay frozen at their locked baseline and every run will red-fail here."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::error::Drift quarantined (${{ steps.sync.outputs.quarantined_sources }}) — review upstream diffs, then approve via the relock input."
           exit 1
@@ -350,3 +369,44 @@ jobs:
           else
             echo "✓ All sources are up to date" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      # ── Failure alerting (Slack-only, per the /slack skill convention) ────────
+      # This workflow had NO failure alerting, which is why a drift quarantine
+      # could red-fail every scheduled run from 2026-07-27 to 2026-08-09 while
+      # 63 sources silently stopped mirroring. The run was loud in the Actions
+      # tab the whole time; nobody reads the Actions tab of a weekly cron.
+      #
+      # A scheduled job with no alert on failure is indistinguishable from one
+      # that is not running at all. Modeled on promote-curated.yml. See #1164.
+      - name: Alert Slack on failure
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "SLACK_OPERATION_HIRED_WEBHOOK_URL not set; skipping alert."
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PAYLOAD=$(python3 - "$RUN_URL" "${{ steps.sync.outputs.quarantined_sources }}" "${{ steps.sync.outputs.refused_sources }}" <<'PY'
+          import json, sys
+          run_url, quarantined, refused = sys.argv[1], sys.argv[2], sys.argv[3]
+          detail = ""
+          if quarantined:
+              detail += f"\n• Drift quarantined: `{quarantined}` — review the upstream diff, then re-run with `relock` set."
+          if refused:
+              detail += f"\n• *REFUSED (supply-chain)*: `{refused}` — malicious content excluded; investigate the upstream."
+          if not detail:
+              detail = "\n• No source was quarantined or refused — the job failed for another reason."
+          text = (
+              "⚠️ *sync-external.yml failed* — external plugin mirroring did not "
+              f"complete.{detail} <@U099CBRE7CL> <{run_url}|View run>"
+          )
+          print(json.dumps({"text": text}))
+          PY
+          )
+          curl --silent --show-error --fail \
+            --header "Content-Type: application/json" \
+            --data "$PAYLOAD" \
+            -- "$WEBHOOK" > /dev/null
+          echo "✓ Slack failure alert posted."

--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -288,20 +288,38 @@ jobs:
       # partial run visibly RED and names the failed sources so a human can act.
       - name: Flag partial sync
         if: steps.sync.outputs.errors != '0' && steps.sync.outputs.errors != ''
+        # Source-name outputs go through env:, never ${{ }} inside run:. They
+        # are built from the `name:` fields in sources.yaml, which external
+        # contributors submit PRs against, so a name containing a quote or
+        # backtick would be executed rather than echoed. Same class as
+        # f-ccp-workflows-1; pinned by tests/ci/test_workflow_injection_hygiene.py.
+        env:
+          ERRORS: ${{ steps.sync.outputs.errors }}
+          FAILED_SOURCES: ${{ steps.sync.outputs.failed_sources }}
         run: |
           {
             echo "## ⚠️ Partial external sync — needs human"
             echo ""
-            echo "${{ steps.sync.outputs.errors }} source(s) errored; no PR was opened."
-            echo "Failed: ${{ steps.sync.outputs.failed_sources }}"
+            echo "$ERRORS source(s) errored; no PR was opened."
+            echo "Failed: $FAILED_SOURCES"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::error::Partial external sync (${{ steps.sync.outputs.failed_sources }}) — investigate before re-running."
+          echo "::error::Partial external sync ($FAILED_SOURCES) — investigate before re-running."
           exit 1
 
       # A locked source whose upstream content drifted from the committed
       # sources.lock.json baseline was QUARANTINED by the sync engine (nothing
-      # of it mirrored — the engine returns `changes: []` BEFORE writing any
-      # file, so drifted content never reaches the working tree at all).
+      # of it mirrored). The load-bearing invariant for the gating below is that
+      # a drifted source writes NOTHING — in scripts/sync-external.mjs, the
+      # guard
+      #
+      #     if (lockDiff.status === 'drifted' && !relockRequested) { ... return
+      #     { source, changes: [], lockStatus: 'quarantined', ... } }
+      #
+      # short-circuits unconditionally at the TOP of the per-source body, before
+      # any copy/write call, so drifted bytes never reach the working tree.
+      # tests/ci/test_sync_external_gating.py pins this — if someone ever moves
+      # a write above that early return, the test fails rather than this
+      # workflow silently shipping drifted content.
       #
       # Drift therefore quarantines ONLY the drifted source, exactly like the
       # REFUSE path below: the clean co-synced sources still ship their PR, and
@@ -323,19 +341,23 @@ jobs:
       # See #1164.
       - name: Flag quarantined drift
         if: steps.sync.outputs.quarantined != '0' && steps.sync.outputs.quarantined != ''
+        # Source names via env: — see the note on "Flag partial sync" above.
+        env:
+          QUARANTINED: ${{ steps.sync.outputs.quarantined }}
+          QUARANTINED_SOURCES: ${{ steps.sync.outputs.quarantined_sources }}
         run: |
           {
             echo "## 🔒 Upstream drift quarantined — needs human review"
             echo ""
-            echo "${{ steps.sync.outputs.quarantined }} source(s) drifted from their sources.lock.json baseline. NOTHING of theirs was mirrored."
-            echo "Drifted: ${{ steps.sync.outputs.quarantined_sources }}"
+            echo "$QUARANTINED source(s) drifted from their sources.lock.json baseline. NOTHING of theirs was mirrored."
+            echo "Drifted: $QUARANTINED_SOURCES"
             echo ""
             echo "The clean co-synced sources shipped their PR normally — only the drifted source(s) above are held back."
             echo ""
             echo "Review each upstream diff, then re-run this workflow (workflow_dispatch) with \`relock\` set to the approved source names (comma-separated) or \`all\`."
             echo "Until then those source(s) stay frozen at their locked baseline and every run will red-fail here."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::error::Drift quarantined (${{ steps.sync.outputs.quarantined_sources }}) — review upstream diffs, then approve via the relock input."
+          echo "::error::Drift quarantined ($QUARANTINED_SOURCES) — review upstream diffs, then approve via the relock input."
           exit 1
 
       # A source was REFUSED by the sync-time supply-chain scanner (blocker
@@ -348,16 +370,20 @@ jobs:
       # security review (the excluded source, not the clean PR, is the concern).
       - name: Flag REFUSED sources (supply-chain security event)
         if: steps.sync.outputs.refused != '0' && steps.sync.outputs.refused != ''
+        # Source names via env: — see the note on "Flag partial sync" above.
+        env:
+          REFUSED: ${{ steps.sync.outputs.refused }}
+          REFUSED_SOURCES: ${{ steps.sync.outputs.refused_sources }}
         run: |
           {
             echo "## ⛔ Source REFUSED — malicious content quarantined (security review)"
             echo ""
-            echo "${{ steps.sync.outputs.refused }} source(s) tripped a REFUSE grade in the sync-time payload scanner; NONE of their content was mirrored."
-            echo "Refused: ${{ steps.sync.outputs.refused_sources }}"
+            echo "$REFUSED source(s) tripped a REFUSE grade in the sync-time payload scanner; NONE of their content was mirrored."
+            echo "Refused: $REFUSED_SOURCES"
             echo ""
             echo "Clean co-synced sources shipped their PR normally. Investigate each refused upstream (a pipe-to-shell / reverse-shell / exfil pattern in an auto-executing file) before re-enabling it."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::error::Source REFUSED (${{ steps.sync.outputs.refused_sources }}) — malicious content excluded from the mirror; review the upstream."
+          echo "::error::Source REFUSED ($REFUSED_SOURCES) — malicious content excluded from the mirror; review the upstream."
           exit 1
 
       - name: Summary
@@ -382,13 +408,21 @@ jobs:
         if: failure()
         env:
           WEBHOOK: ${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}
+          # Passed through the environment, NOT interpolated into the run:
+          # script. `${{ }}` expands before bash parses the line, so a source
+          # name containing a quote or backtick would be executed rather than
+          # quoted — the standard GitHub Actions script-injection vector. These
+          # values originate in sources.yaml, which external contributors submit
+          # PRs against, so they are attacker-influenced by design.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          QUARANTINED_SOURCES: ${{ steps.sync.outputs.quarantined_sources }}
+          REFUSED_SOURCES: ${{ steps.sync.outputs.refused_sources }}
         run: |
           if [ -z "$WEBHOOK" ]; then
             echo "SLACK_OPERATION_HIRED_WEBHOOK_URL not set; skipping alert."
             exit 0
           fi
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          PAYLOAD=$(python3 - "$RUN_URL" "${{ steps.sync.outputs.quarantined_sources }}" "${{ steps.sync.outputs.refused_sources }}" <<'PY'
+          PAYLOAD=$(python3 - "$RUN_URL" "$QUARANTINED_SOURCES" "$REFUSED_SOURCES" <<'PY'
           import json, sys
           run_url, quarantined, refused = sys.argv[1], sys.argv[2], sys.argv[3]
           detail = ""

--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -333,8 +333,9 @@ jobs:
       # legitimately-mirrored content. One drifted source halted all 63.
       #
       # It did exactly that: `slack-channel` drifted and the sync failed on
-      # EVERY run from 2026-07-27 to 2026-08-09, so nothing mirrored for two
-      # weeks. The UIZZE plugin (#1104) was accepted on 2026-07-25 and still did
+      # EVERY run from 2026-07-20 to 2026-08-09 — seven consecutive runs, all
+      # failing at "Flag quarantined drift", with the last success on
+      # 2026-07-17. Nothing mirrored for 23 days. The UIZZE plugin (#1104) was accepted on 2026-07-25 and still did
       # not exist on the site when the outage was found — the contributor saw
       # their submission merged and then vanish. The failure was loud in the
       # Actions tab and observed by nobody, which is the actual lesson.
@@ -398,7 +399,7 @@ jobs:
 
       # ── Failure alerting (Slack-only, per the /slack skill convention) ────────
       # This workflow had NO failure alerting, which is why a drift quarantine
-      # could red-fail every scheduled run from 2026-07-27 to 2026-08-09 while
+      # could red-fail every run from 2026-07-20 to 2026-08-09 (23 days) while
       # 63 sources silently stopped mirroring. The run was loud in the Actions
       # tab the whole time; nobody reads the Actions tab of a weekly cron.
       #

--- a/marketplace/src/content/blog-posts/the-filesystem-was-the-only-thing-they-shared.md
+++ b/marketplace/src/content/blog-posts/the-filesystem-was-the-only-thing-they-shared.md
@@ -191,7 +191,7 @@ I did not classify all 71 of the day's failure-to-fix moments, so I cannot say w
 Two human course-corrections that day carried the right instinct:
 
 > hold on check bobs big brain imbrella and make sure we are all aligned etc etc
-
+>
 > i dont see that api key anywhere this machine has ssh access see intent os for instructions
 
 Both are the same move. Before trusting your read of shared state, go check whether it already changed, or already exists.

--- a/tests/ci/test_sync_external_gating.py
+++ b/tests/ci/test_sync_external_gating.py
@@ -1,0 +1,164 @@
+"""Pins the invariant that makes sync-external.yml's PR gating safe (#1164).
+
+BACKGROUND
+
+The weekly external-plugin sync failed on every run from 2026-07-27 to
+2026-08-09. One source (`slack-channel`) drifted from its sources.lock.json
+baseline, and the commit/PR steps were gated on `quarantined == '0'`, so a
+single drifted source halted mirroring for all 63. UIZZE (#1104) was accepted
+2026-07-25 and still did not exist on the site two weeks later.
+
+That gate was removed. It is safe to remove ONLY because of one property of
+the sync engine: a drifted source writes nothing at all. The engine
+short-circuits at the top of the per-source body and returns `changes: []`
+before reaching any copy/write call, so drifted bytes never enter the working
+tree and therefore cannot ride into the auto-PR.
+
+WHY THIS FILE EXISTS
+
+That property is an implicit contract between two files that are edited
+independently. Nothing enforced it. If someone moves a write above the early
+return — or deletes the early return — the workflow would silently begin
+shipping drifted upstream content into an auto-PR, which is a supply-chain
+regression that no existing gate would catch.
+
+The reviewer of #1165 asked for exactly this: "the only durable fix for that
+class of bug is an automated assertion, not a Slack ping." These are static
+assertions rather than a live sync, so they need no network, no clone, and no
+credentials, and they fail in CI the moment the contract is broken.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sync-external.yml"
+ENGINE = REPO_ROOT / "scripts" / "sync-external.mjs"
+
+# Calls that put bytes on disk. `fs.rmSync` is included because the pruning of
+# orphaned files is equally a mutation of the working tree.
+RE_WRITE_CALL = re.compile(
+    r"\b(?:fs\.(?:writeFileSync|copyFileSync|cpSync|mkdirSync|rmSync|renameSync)|writeFileSync\()"
+)
+
+
+def _engine_source() -> str:
+    return ENGINE.read_text(encoding="utf-8")
+
+
+def test_drift_short_circuit_returns_before_any_write() -> None:
+    """The drift guard must return before the first write call in its function.
+
+    Located by finding the drift guard, then the `return` that closes it, and
+    asserting no write call appears between the two. A write inside the guard
+    body would mean drifted content reaches disk despite the quarantine.
+    """
+    src = _engine_source()
+
+    guard = src.find("lockDiff.status === 'drifted' && !relockRequested")
+    assert guard != -1, (
+        "Could not find the drift quarantine guard in scripts/sync-external.mjs. "
+        "If it was renamed, update this test deliberately — do not delete it. "
+        "sync-external.yml's PR gating depends on this short-circuit."
+    )
+
+    ret = src.find("lockStatus: 'quarantined'", guard)
+    assert ret != -1, "Drift guard no longer returns a 'quarantined' result."
+
+    body = src[guard:ret]
+    offenders = RE_WRITE_CALL.findall(body)
+    assert not offenders, (
+        "A filesystem write appears inside the drift-quarantine branch of "
+        "scripts/sync-external.mjs. A quarantined source must write NOTHING — "
+        "sync-external.yml no longer gates its commit/PR steps on the "
+        "quarantine count, so any byte written here would be committed into "
+        f"the automated sync PR unreviewed. Offending calls: {offenders}"
+    )
+
+
+def test_quarantined_result_reports_no_changes() -> None:
+    """The quarantine branch must report an empty change set.
+
+    The workflow's `Check for changes` step keys off the working tree, but the
+    summary and downstream reporting key off `changes`. A non-empty value here
+    would mean the quarantine is claiming to have mirrored something.
+    """
+    src = _engine_source()
+    guard = src.find("lockDiff.status === 'drifted' && !relockRequested")
+    ret = src.find("lockStatus: 'quarantined'", guard)
+    body = src[guard:ret]
+    assert "changes: []" in body, (
+        "The drift-quarantine branch must return `changes: []`. A quarantined "
+        "source mirrors nothing by definition."
+    )
+
+
+def test_commit_and_pr_steps_are_not_gated_on_quarantine_count() -> None:
+    """Drift must quarantine one source, not halt the whole run.
+
+    This is the regression that caused the 2026-07-27..08-09 outage. Restoring
+    a `quarantined == '0'` gate would make one drifted source block all 63
+    mirrors again. Drift is deliberately aligned with the REFUSE path, which
+    already quarantines only the offending source.
+    """
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["sync"]["steps"]
+
+    offenders = [
+        s.get("name", "<unnamed>")
+        for s in steps
+        if "quarantined ==" in str(s.get("if", ""))
+    ]
+    assert not offenders, (
+        "Steps are gated on the quarantine COUNT again: "
+        f"{offenders}. One drifted source would halt mirroring for every other "
+        "source (see #1164 — this caused a two-week outage). Drifted content "
+        "cannot reach the working tree anyway, which the tests above pin, so "
+        "the gate blocks only clean sources. Use the `Flag quarantined drift` "
+        "step to fail the run instead."
+    )
+
+
+def test_drift_is_still_flagged_loudly() -> None:
+    """Removing the gate must not make drift silent.
+
+    The quarantine still has to red-fail the run and name the drifted sources;
+    only the collateral damage to other sources was removed.
+    """
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["sync"]["steps"]
+
+    flag = next((s for s in steps if s.get("name") == "Flag quarantined drift"), None)
+    assert flag is not None, "The drift-flagging step was removed."
+    assert "quarantined !=" in str(flag.get("if", "")), (
+        "The drift-flagging step must still trigger on a non-zero quarantine count."
+    )
+    assert "exit 1" in flag.get("run", ""), (
+        "The drift-flagging step must still fail the run — a quarantine that "
+        "reports success is indistinguishable from a clean run."
+    )
+
+
+def test_scheduled_workflow_alerts_on_failure() -> None:
+    """A cron job that cannot report its own failure is the root cause here.
+
+    sync-external.yml red-failed weekly for two weeks with no alerting, and was
+    found only while triaging an unrelated issue. See #1166 for the other
+    scheduled workflows still missing this.
+    """
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    on = doc.get("on") or doc.get(True) or {}
+    assert "schedule" in on, "Expected sync-external.yml to still be scheduled."
+
+    steps = doc["jobs"]["sync"]["steps"]
+    alerts = [s for s in steps if str(s.get("if", "")).strip() == "failure()"]
+    assert alerts, (
+        "sync-external.yml runs on a schedule but has no `if: failure()` step. "
+        "A scheduled job with no failure alerting is indistinguishable from one "
+        "that is not running at all — that is precisely how #1164 went unnoticed "
+        "for two weeks."
+    )

--- a/tests/ci/test_sync_external_gating.py
+++ b/tests/ci/test_sync_external_gating.py
@@ -39,11 +39,81 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sync-external.yml"
 ENGINE = REPO_ROOT / "scripts" / "sync-external.mjs"
 
-# Calls that put bytes on disk. `fs.rmSync` is included because the pruning of
-# orphaned files is equally a mutation of the working tree.
-RE_WRITE_CALL = re.compile(
-    r"\b(?:fs\.(?:writeFileSync|copyFileSync|cpSync|mkdirSync|rmSync|renameSync)|writeFileSync\()"
+# Calls that mutate the filesystem. Deletions and permission changes count:
+# pruning an orphaned file is as much a working-tree mutation as writing one.
+#
+# The first version of this pattern listed six sync APIs and missed
+# `fs.appendFileSync` — which the engine uses TEN times, more than any other
+# write call — along with every `fs.promises.*` async form. A detector that
+# cannot see the most common write in the file it guards is not a guard, which
+# is the same "gate that gates nothing" defect this whole PR exists to fix.
+# Caught in review of #1165.
+#
+# Enumerated deliberately rather than inferred: an allowlist of read-only APIs
+# would silently pass any newly-introduced mutator, whereas a missing entry here
+# is caught by test_write_detector_recognizes_known_write_forms below.
+_MUTATORS = (
+    "writeFile|appendFile|copyFile|cp|mkdir|mkdtemp|rm|rmdir|unlink|rename|"
+    "chmod|chown|truncate|symlink|link|utimes|writev|open"
 )
+RE_WRITE_CALL = re.compile(
+    # fs.writeFileSync(...) / fs.appendFileSync(...) / fs.rmSync(...)
+    rf"\bfs\.(?:{_MUTATORS})Sync\s*\("
+    # fs.promises.writeFile(...) / fsp.copyFile(...) / fs.promises.rm(...)
+    rf"|\bfs(?:\.promises|p)?\.(?:{_MUTATORS})\s*\("
+    # createWriteStream in either form
+    r"|\bfs(?:\.promises|p)?\.createWriteStream\s*\("
+    # bare destructured imports: writeFileSync(...), appendFileSync(...)
+    rf"|(?<![.\w])(?:{_MUTATORS})Sync\s*\("
+)
+
+# Write forms that MUST be detectable. If someone narrows RE_WRITE_CALL, this
+# fails immediately rather than the narrowing going unnoticed until a real
+# regression slips past the drift guard.
+KNOWN_WRITE_FORMS = [
+    "fs.writeFileSync(target, body)",
+    "fs.appendFileSync(logPath, line)",
+    "fs.copyFileSync(src, dest)",
+    "fs.cpSync(src, dest, { recursive: true })",
+    "fs.mkdirSync(dir, { recursive: true })",
+    "fs.mkdtempSync(prefix)",
+    "fs.rmSync(dir, { recursive: true, force: true })",
+    "fs.renameSync(a, b)",
+    "fs.chmodSync(p, 0o755)",
+    "await fs.promises.writeFile(target, body)",
+    "await fs.promises.copyFile(src, dest)",
+    "await fs.promises.rm(dir, { recursive: true })",
+    "await fsp.appendFile(logPath, line)",
+    "const out = fs.createWriteStream(target)",
+    "writeFileSync(target, body)",
+]
+
+# Read-only calls that must NOT trip the detector, or the test becomes noise
+# and gets deleted.
+KNOWN_SAFE_FORMS = [
+    "fs.existsSync(p)",
+    "fs.readFileSync(p, 'utf8')",
+    "fs.statSync(p)",
+    "fs.readdirSync(dir)",
+    "const changes = [];",
+    "log('nothing mirrored this run')",
+]
+
+
+def test_write_detector_recognizes_known_write_forms() -> None:
+    """The detector must actually detect. A guard is only as good as its pattern."""
+    missed = [f for f in KNOWN_WRITE_FORMS if not RE_WRITE_CALL.search(f)]
+    assert not missed, (
+        "RE_WRITE_CALL no longer matches these filesystem writes, so "
+        "test_drift_short_circuit_returns_before_any_write would not catch them "
+        f"inside the quarantine branch: {missed}"
+    )
+
+    false_positives = [f for f in KNOWN_SAFE_FORMS if RE_WRITE_CALL.search(f)]
+    assert not false_positives, (
+        f"RE_WRITE_CALL matches read-only calls, which makes the guard noisy "
+        f"and likely to be disabled: {false_positives}"
+    )
 
 
 def _engine_source() -> str:

--- a/tests/ci/test_workflow_injection_hygiene.py
+++ b/tests/ci/test_workflow_injection_hygiene.py
@@ -59,3 +59,30 @@ def test_sync_external_routes_source_through_env():
     assert '"$SYNC_SOURCE"' in sync_step["run"], (
         "run block must pass the source as a quoted env-var argv entry"
     )
+
+
+# Step OUTPUTS carrying source names are attacker-influenced too, and the
+# original guard above did not cover them.
+#
+# `quarantined_sources` / `refused_sources` are built by the sync engine from
+# the `name:` fields in sources.yaml — a file external contributors open PRs
+# against. A name containing a quote or backtick, interpolated with ${{ }}
+# straight into a run: block, is executed rather than quoted: the same
+# command-injection class as f-ccp-workflows-1, reached by a different route.
+#
+# This gap was live: the failure-alert step added in #1165 interpolated both
+# outputs directly, and the guard above passed it because the regex only knew
+# about client_payload / inputs.source. Widened rather than duplicated, so
+# there is one place that answers "which values must go through env:".
+RE_INJECTABLE_OUTPUTS = re.compile(r"\$\{\{[^}]*steps\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_-]*sources[^}]*\}\}")
+
+
+def test_sync_external_run_blocks_do_not_interpolate_source_name_outputs():
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    offenders = [run for run in _iter_run_blocks(doc) if RE_INJECTABLE_OUTPUTS.search(run)]
+    assert not offenders, (
+        "Step outputs carrying source names (quarantined_sources / "
+        "refused_sources) derive from contributor-supplied sources.yaml and "
+        "must reach run: blocks via env:, not direct ${{ }} interpolation. "
+        f"Offending run blocks:\n{offenders}"
+    )


### PR DESCRIPTION
> **Description corrected 2026-08-09** after review. The original claimed "Layer touched: CI/automation only" and "diff is exactly 4 gate removals + 1 failure-alert step". Both became false when later commits added tests and a content fix, and two figures ("63 mirrors", "since 2026-07-27") were wrong. Corrected below with evidence attached. The adversarial review was right to flag them.

## What

1. Removes `quarantined == '0'` from four commit/PR gating conditions in `sync-external.yml`, so one drifted source no longer halts every other mirror.
2. Adds Slack-on-failure alerting to that workflow (it had none).
3. Routes source-name step outputs through `env:` in **four** steps — three of which predate this PR — closing a command-injection vector.
4. Adds `tests/ci/test_sync_external_gating.py` and widens `tests/ci/test_workflow_injection_hygiene.py` to pin both invariants.
5. Fixes an MD028 markdownlint break in a blog post that was failing `ci-required` on `main`.

## Why

### The sync has been dead for 23 days

```
$ gh run list --workflow sync-external.yml --limit 8
  2026-08-04T20:45  repository_dispatch  failure
  2026-08-04T20:40  repository_dispatch  failure
  2026-08-03T07:07  schedule             failure
  2026-07-27T07:07  schedule             failure
  2026-07-24T00:35  repository_dispatch  failure
  2026-07-22T00:49  workflow_dispatch    failure
  2026-07-20T07:03  schedule             failure
  2026-07-17T22:44  workflow_dispatch    success   <-- last success
```

All seven failures are the same step:

```
$ for each run: gh api .../jobs --jq '[.jobs[].steps[]?|select(.conclusion=="failure")|.name]'
  2026-08-04  failed at: Flag quarantined drift
  2026-08-03  failed at: Flag quarantined drift
  2026-07-27  failed at: Flag quarantined drift
  2026-07-24  failed at: Flag quarantined drift
  2026-07-22  failed at: Flag quarantined drift
  2026-07-20  failed at: Flag quarantined drift
```

One source drifted. `sources.yaml` holds **64** entries, so the other **63** stopped mirroring.

### The gate protected nothing

`scripts/sync-external.mjs` short-circuits at the top of the per-source body:

```js
if (lockDiff.status === 'drifted' && !relockRequested) {
  log('🔒 QUARANTINED — upstream drifted from sources.lock.json baseline; nothing mirrored this run');
  ...
  return { source: source.name, changes: [], error: null, lockStatus: 'quarantined', ... };
}
```

The `return` precedes every copy/write call, so drifted bytes never reach the working tree and could not have ridden into the auto-PR under any gating. The gate blocked only the clean sources' content.

The workflow already documents the correct pattern one step below, on the **REFUSE** path — malicious content, strictly worse than drift:

> a REFUSE quarantines ONLY the offending source — nothing of it was mirrored, and the commit/PR steps are NOT gated on `refused`, so the clean co-synced sources still shipped their PR.

Drift was treated more harshly than a supply-chain attack. **Chose aligning drift with the existing REFUSE semantics over a skip-list or force flag** — it removes a special case rather than adding one.

### Nobody could have known

`sync-external.yml` had **no failure alerting**. It red-failed for 23 days, in public, and was found only while triaging an unrelated issue. A scheduled job that cannot report its own failure is indistinguishable from one that is not running.

Secret name verified against the precedent:

```
$ grep SLACK_OPERATION_HIRED_WEBHOOK_URL .github/workflows/promote-curated.yml
16: # on ANY failure, post to #operation-hired via SLACK_OPERATION_HIRED_WEBHOOK_URL
187:          WEBHOOK: ${{ secrets.SLACK_OPERATION_HIRED_WEBHOOK_URL }}
```

### Command injection — found by widening the guard

The new alert step interpolated `${{ steps.sync.outputs.quarantined_sources }}` directly into a `run:` block. `${{ }}` expands before bash parses the line, so a source name containing a quote or backtick executes rather than quotes. Those names come from `sources.yaml`, which external contributors submit PRs against.

`tests/ci/test_workflow_injection_hygiene.py` already existed but matched only `client_payload` / `inputs.source`. Widening it to step outputs showed the problem was **not confined to my step** — `Flag partial sync`, `Flag quarantined drift` and `Flag REFUSED sources` all did the same and predate this PR. All four now route through `env:`.

## Blast radius this caused

UIZZE (#1104) was registered by PR #1127, merged 2026-07-25:

```
$ ls plugins/design/ | grep -i uizze
  (absent)
```

The contributor's submission was accepted and then silently never delivered. #1102, #1143 and #1160 are queued behind the same breakage.

## Layers touched

- **CI/automation** — `.github/workflows/sync-external.yml` (gating, alerting, injection hygiene)
- **Tests** — one new file, one widened
- **Content** — one blog post line (MD028), unrelated to the sync fix; see below

No change to the sync engine, the lockfile model, or the supply-chain scanner. The quarantine *mechanism* is untouched — only its blast radius.

## Verification

```
$ python3 -m pytest tests/ci/ -q
43 passed in 0.63s

$ python3 -c "import yaml; ..."
YAML OK, 16 steps

$ node scripts/sync-external.mjs --source=slack-channel --dry-run
🔒 QUARANTINED — upstream drifted from sources.lock.json baseline
   +0 added  ~8 changed  -0 removed (upstream @ 282c49ad1745)
```

Zero remaining `*_sources` `${{ }}` interpolations inside any `run:` block (asserted by the widened test, not by eye).

The drift being held back is **our own repo** — `jeremylongshore/claude-code-slack-channel`, 19 merged PRs `f1ddf6de..282c49ad`, several security hardening (fail-closed policy, pinned journal genesis, stderr routing). Benign.

## Risk

Low. The change can only cause *more* content to ship into an auto-PR that a human already reviews before merge, and the invariant that makes it safe is now asserted in CI rather than assumed.

One intended behavioral change: a persistent drift now red-fails **every** run while the PR still ships. That matches REFUSE, and it is no longer silent because of the alert.

**Rollback:** revert the commits; the workflow returns to its prior gating with no data migration or state to unwind.

## Operational impact

Requires repo secret `SLACK_OPERATION_HIRED_WEBHOOK_URL` (already used by `promote-curated.yml`). If unset the step logs and exits 0.

## Scope extension, declared

The blog-post hunk (`the-filesystem-was-the-only-thing-they-shared.md`) is unrelated to this fix. `markdownlint` is inside `ci-required`, so that MD028 was blocking **every** PR in the repo. Fixed in place rather than deferred; per repo convention a docs-only change bundles into a code PR rather than opening its own.

## Deliberately not changed

The `<@U099CBRE7CL>` Slack mention. It is the existing convention in `promote-curated.yml`, this is a solo-maintainer repo, and the alert should reach the maintainer rather than `@channel`. Worth revisiting repo-wide — tracked in #1166 — but diverging in one workflow would just create inconsistency.

## Follow-up

**Relocking `slack-channel` is deliberately not in this PR.** It is an approval action and belongs in the reviewable auto-PR the workflow generates. After merge: dispatch `sync-external.yml` with `relock=slack-channel`, review the resulting 64-source auto-PR, merge → #1104 / #1102 / #1143 / #1160 unblock.

#1166 tracks the wider class: 4 of 7 scheduled workflows still cannot report their own failure.

## Refs

Refs #1164, #1104, #1166
