### PR TITLE
fix(ci-infra): make every auto-generated PR title pass the required commit gate

### DIFF
--- a/.github/workflows/promote-curated.yml
+++ b/.github/workflows/promote-curated.yml
@@ -148,7 +148,7 @@ jobs:
 
           if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr create \
-              --title "🏅 Refresh curated skills mirror ($COUNT A/B skills)" \
+              --title "chore(catalog): refresh curated skills mirror ($COUNT A/B skills)" \
               --head "$BRANCH" \
               --base main \
               --label "automated" \

--- a/.github/workflows/sync-external.yml
+++ b/.github/workflows/sync-external.yml
@@ -262,7 +262,7 @@ jobs:
           # shared branch and silently skipped creation, stranding the sync).
           if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr create \
-              --title "🔄 Sync external plugins" \
+              --title "chore(external-sync): mirror upstream external plugins" \
               --head "$BRANCH" \
               --base main \
               --label "automated,sync,external-plugins" \

--- a/.github/workflows/update-npm-stats.yml
+++ b/.github/workflows/update-npm-stats.yml
@@ -103,7 +103,7 @@ jobs:
           # (estate audit finding F5). Only an OPEN PR counts.
           if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
             gh pr create \
-              --title "📦 Daily npm download stats refresh" \
+              --title "chore(marketplace-site): refresh daily npm download stats" \
               --head "$BRANCH" \
               --base main \
               --label "automated,stats" \

--- a/tests/ci/test_workflow_pr_titles.py
+++ b/tests/ci/test_workflow_pr_titles.py
@@ -1,0 +1,120 @@
+"""Every auto-generated PR title must satisfy the repo's own commit-scope gate.
+
+THE BUG THIS PINS
+
+`commit-scope-check` became a required check on 2026-07-16 (#1076). It lints the
+PULL REQUEST TITLE against .github/.commit-rules.json. Three workflows create
+PRs automatically, and all three generated titles that the gate rejects:
+
+    sync-external.yml     "🔄 Sync external plugins"
+    promote-curated.yml   "🏅 Refresh curated skills mirror ($COUNT A/B skills)"
+    update-npm-stats.yml  "📦 Daily npm download stats refresh"
+
+So every automated PR opened after 2026-07-16 was born unmergeable — it could
+only land via an admin override. PR #1149 (npm stats) sat open from 2026-07-30,
+and the recovered external-plugin sync PR #1167 hit the same wall the moment it
+was finally able to open at all.
+
+WHY A TEST RATHER THAN JUST FIXING THE THREE STRINGS
+
+The failure was invisible from either side. The workflow author never sees the
+gate (it runs on the PR, not the workflow), and the gate author never sees the
+generated titles (they live in unrelated YAML). Fixing the strings without
+pinning them leaves the next automated workflow free to reintroduce it, and the
+symptom — a stuck bot PR nobody is watching — is one people learn to ignore.
+
+Deliberately NOT checked: hand-written PR titles (the live gate covers those)
+and `gh release create --title`, which is a release name and never passes
+through commit-scope-check.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+RULES = json.loads((REPO_ROOT / ".github" / ".commit-rules.json").read_text(encoding="utf-8"))
+
+# Mirrors the validator inlined in validate-plugins.yml's commit-scope-check job.
+RE_CONVENTIONAL = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?(?:!)?: (?P<subject>[^\r\n]+)$"
+)
+RE_TITLE_FLAG = re.compile(r'--title\s+"([^"]+)"')
+
+# How far back to look for the command that owns a --title flag. The flag is
+# usually a continuation line a few lines below `gh pr create`.
+_LOOKBACK = 8
+
+
+def _iter_pr_titles():
+    """Yield (workflow_name, line_number, title) for every `gh pr create --title`."""
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for idx, line in enumerate(lines):
+            match = RE_TITLE_FLAG.search(line)
+            if not match:
+                continue
+            window = "\n".join(lines[max(0, idx - _LOOKBACK) : idx + 1])
+            # `gh release create` also takes --title but is not gated.
+            if "gh pr create" not in window:
+                continue
+            yield path.name, idx + 1, match.group(1)
+
+
+def test_at_least_one_generated_pr_title_is_discovered() -> None:
+    """Guard against the discovery loop silently matching nothing.
+
+    If a refactor changes how these workflows invoke `gh pr create`, every
+    assertion below would vacuously pass — the same "gate that gates nothing"
+    failure this file exists to prevent.
+    """
+    found = list(_iter_pr_titles())
+    assert len(found) >= 3, (
+        "Expected to discover the automated PR titles in sync-external.yml, "
+        f"promote-curated.yml and update-npm-stats.yml; found {len(found)}: {found}. "
+        "If a workflow changed how it opens PRs, update this discovery logic."
+    )
+
+
+def test_generated_pr_titles_are_conventional_commits() -> None:
+    offenders = []
+    for name, lineno, title in _iter_pr_titles():
+        # Shell interpolation is fine INSIDE the subject; only the type(scope):
+        # prefix must be literal, since that is all the gate parses.
+        if not RE_CONVENTIONAL.match(title):
+            offenders.append(f"{name}:{lineno} -> {title!r}")
+
+    assert not offenders, (
+        "These workflows generate PR titles that the required `commit-scope-check` "
+        "job rejects, so the PRs they open can never merge without an admin "
+        "override:\n  " + "\n  ".join(offenders) + "\n\n"
+        "Use `type(scope): subject` with a scope registered in "
+        ".github/.commit-rules.json."
+    )
+
+
+def test_generated_pr_title_types_and_scopes_are_registered() -> None:
+    allowed_types = set(RULES["allowedTypes"])
+    allowed_scopes = set(RULES["allowedScopes"])
+    patterns = [re.compile(p) for p in RULES.get("allowedScopePatterns", [])]
+
+    offenders = []
+    for name, lineno, title in _iter_pr_titles():
+        m = RE_CONVENTIONAL.match(title)
+        if not m:
+            continue  # reported by the test above
+        if m.group("type") not in allowed_types:
+            offenders.append(f"{name}:{lineno} type {m.group('type')!r} not registered")
+        scope = m.group("scope")
+        if scope and scope not in allowed_scopes and not any(p.match(scope) for p in patterns):
+            offenders.append(f"{name}:{lineno} scope {scope!r} not registered")
+
+    assert not offenders, (
+        "Generated PR titles use a type or scope that .github/.commit-rules.json "
+        "does not register, which `commit-scope-check` rejects:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nEither use a registered value or add it to the registry deliberately."
+    )


### PR DESCRIPTION
## What

Fixes the generated PR title in the three workflows that open PRs automatically, and adds `tests/ci/test_workflow_pr_titles.py` to pin the invariant.

| Workflow | Was | Now |
|---|---|---|
| `sync-external.yml` | `🔄 Sync external plugins` | `chore(external-sync): mirror upstream external plugins` |
| `promote-curated.yml` | `🏅 Refresh curated skills mirror ($COUNT A/B skills)` | `chore(catalog): refresh curated skills mirror ($COUNT A/B skills)` |
| `update-npm-stats.yml` | `📦 Daily npm download stats refresh` | `chore(marketplace-site): refresh daily npm download stats` |

## Why

`commit-scope-check` lints the **pull request title** against `.github/.commit-rules.json` and became a required check on **2026-07-16** (#1076). None of the three generated titles parse as `type(scope): subject`.

So **every automated PR opened since 2026-07-16 was born unmergeable** — it could only land through an admin override.

```
PR title is not a Conventional Commit.
Expected: type(scope): subject
Allowed types: feat, fix, docs, chore, refactor, test, ci, build, perf, style, revert, content
```

### Observed cost

- **#1149** (npm download stats) has been open since **2026-07-30**.
- **#1167** — the external-plugin sync PR that only became possible to open at all after the #1164 outage fix — hit this wall the moment it was created.

That is two automated pipelines whose output cannot merge, in a repo where nobody watches bot PRs.

## Why a test rather than three string edits

**The failure is invisible from both sides.** The workflow author never sees the gate (it runs on the PR, not on the workflow). The gate author never sees the generated titles (they live in unrelated YAML). Nothing connects them.

Editing three literals fixes today and leaves the next automated workflow free to reintroduce it, with a symptom — a stuck bot PR — that people learn to ignore.

**Chose pinning the invariant over editing the literals** because this repo produced three separate instances of the same class in a single day: an inert changelog gate (#1162), a cron that could not report its own failure (#1164/#1166), and a write-detector blind to the most common write in the file it guarded (#1165). The pattern is a check that exists and does not check.

## How it works

`test_workflow_pr_titles.py` walks every `.github/workflows/*.yml`, finds each `--title` flag whose owning command is `gh pr create` (deliberately ignoring `gh release create`, which is not gated), and asserts:

1. the title parses as a conventional commit, using the same regex the live gate inlines;
2. its type and scope are registered in `.github/.commit-rules.json`;
3. **at least three titles were discovered** — so a refactor of how workflows open PRs cannot make the file vacuously pass. That third assertion is the lesson from #1165, where a narrow detector silently guarded nothing.

Shell interpolation inside the subject stays allowed (`$COUNT` is preserved); only the `type(scope):` prefix must be literal, which is all the gate parses.

## Layers touched

CI/automation and tests only. No product, catalog, validator, or marketplace code. No change to `.commit-rules.json` itself — scopes were chosen from the existing registry (`external-sync`, `catalog`, `marketplace-site`) rather than adding new ones.

## Verification

```
$ python3 -m pytest tests/ci/ -q
47 passed in 0.58s
```

Confirmed the new test rejects each original title (regex applied to all three):

```
REJECTED: 🔄 Sync external plugins
REJECTED: 🏅 Refresh curated skills mirror ($COUNT A/B skills)
REJECTED: 📦 Daily npm download stats refresh
```

Full audit of every `gh pr create --title` in the repo now reports PASS for all three; the four `gh release create --title` call sites are deliberately out of scope.

## Risk

Very low, and user-visible only as a nicer bot PR title. The titles are cosmetic metadata; the only behavioral change is that automated PRs now satisfy a gate they previously failed.

**Rollback:** revert the commit. The three titles return to their emoji form and automated PRs go back to requiring an admin override.

## Operational impact

None — no secrets, deps, migrations, or deploy ordering. Existing open PRs #1167 and #1149 keep their old titles and are retitled manually alongside this PR; the workflow change only affects PRs opened from now on.

## Follow-up

- #1166 tracks the sibling class: 4 of 7 scheduled workflows still cannot report their own failure.
- The `gh release create` titles are untouched by design; release names are not linted.

## Refs

Refs #1164, #1166