### PR TITLE
feat(plugins-mcp): add the A2A protocol MCP server as a standalone plugin

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -16,6 +16,202 @@
   },
   "plugins": [
     {
+      "name": "000-jeremy-content-consistency-validator",
+      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
+      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
+      "version": "3.29.0",
+      "category": "productivity",
+      "maintainer": "@jeremylongshore",
+      "keywords": [
+        "documentation",
+        "consistency",
+        "validation",
+        "drift-detection",
+        "source-of-truth",
+        "authority-registry",
+        "content-audit",
+        "quality-assurance",
+        "release-gate",
+        "standards"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "002-jeremy-yaml-master-agent",
+      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
+      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
+      "version": "2.21.0",
+      "category": "productivity",
+      "keywords": [
+        "yaml",
+        "validation",
+        "linting",
+        "schema",
+        "json",
+        "conversion",
+        "parsing",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 1
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "003-jeremy-vertex-ai-media-master",
+      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
+      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
+      "version": "2.25.0",
+      "category": "productivity",
+      "keywords": [
+        "vertex-ai",
+        "gemini",
+        "multimodal",
+        "video-processing",
+        "audio-generation",
+        "image-generation",
+        "marketing",
+        "campaigns",
+        "content-generation",
+        "imagen",
+        "media-production",
+        "google-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "004-jeremy-google-cloud-agent-sdk",
+      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
+      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
+      "version": "2.24.0",
+      "category": "productivity",
+      "keywords": [
+        "agent-development-kit",
+        "adk",
+        "agent-starter-pack",
+        "multi-agent",
+        "containerized-agents",
+        "cloud-run",
+        "gke",
+        "agent-engine",
+        "rag-agents",
+        "react-agents",
+        "google-cloud",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "access-control-auditor",
+      "source": "./plugins/security/access-control-auditor",
+      "description": "Audit access control implementations",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "accessibility-test-scanner",
+      "source": "./plugins/testing/accessibility-test-scanner",
+      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
+      "version": "1.23.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "accessibility",
+        "a11y",
+        "wcag",
+        "aria",
+        "screen-reader",
+        "compliance"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "agent-context-manager",
+      "source": "./plugins/productivity/agent-context-manager",
+      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
+      "version": "1.23.0",
+      "category": "productivity",
+      "keywords": ["agents", "context", "automation"],
+      "author": {
+        "name": "Jeremy Longshore"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "agency-os",
       "source": "./plugins/ai-agency/agency-os",
       "description": "Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel with dependency ordering and model routing.",
@@ -36,209 +232,28 @@
       }
     },
     {
-      "name": "discovery-questionnaire",
-      "source": "./plugins/ai-agency/discovery-questionnaire",
-      "description": "Generate custom discovery questionnaires for AI agency prospects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "discovery",
-        "questionnaire",
-        "client",
-        "sales",
-        "agency",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "hyperflow",
-      "source": "./plugins/ai-agency/hyperflow",
-      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
-      "version": "4.26.1",
-      "category": "ai-agency",
-      "keywords": [
-        "claude-code-plugin",
-        "multi-agent",
-        "dynamic-workflows",
-        "workflow-chain",
-        "triageflow",
-        "personas",
-        "flow-profiles",
-        "code-review",
-        "project-memory",
-        "multi-tool"
-      ],
-      "author": {
-        "name": "Mohammed Abdelhady",
-        "url": "https://github.com/Mohammed-Abdelhady"
-      },
-      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "license": "MIT"
-    },
-    {
-      "name": "make-scenario-builder",
-      "source": "./plugins/ai-agency/make-scenario-builder",
-      "description": "Create Make.com (Integromat) scenarios with AI assistance",
-      "version": "1.15.0",
-      "category": "ai-agency",
-      "keywords": [
-        "make",
-        "integromat",
-        "automation",
-        "scenarios",
-        "workflow",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "n8n-workflow-designer",
-      "source": "./plugins/ai-agency/n8n-workflow-designer",
-      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
-      "version": "1.13.0",
-      "category": "ai-agency",
-      "keywords": [
-        "n8n",
-        "workflow",
-        "automation",
-        "self-hosted",
-        "open-source",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "url": "https://github.com/jeremylongshore/claude-code-plugins"
-      },
-      "featured": true
-    },
-    {
-      "name": "roi-calculator",
-      "source": "./plugins/ai-agency/roi-calculator",
-      "description": "Calculate and present ROI for AI automation projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "roi",
-        "return on investment",
-        "calculator",
-        "sales",
-        "value",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "shipwright",
-      "source": "./plugins/ai-agency/shipwright",
-      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
-      "version": "1.3.0",
-      "category": "ai-agency",
-      "author": {
-        "name": "Nate Nelson",
-        "url": "https://github.com/Wynelson94"
-      },
-      "keywords": [
-        "app-builder",
-        "code-generator",
-        "autonomous-agent",
-        "pipeline",
-        "nextjs",
-        "supabase",
-        "sveltekit",
-        "astro",
-        "ai-agency"
-      ],
-      "repository": "https://github.com/Wynelson94/shipwright",
-      "homepage": "https://github.com/Wynelson94/shipwright",
-      "license": "MIT",
-      "featured": false,
-      "pricing": "free",
-      "components": {
-        "skills": 1,
-        "commands": 4
-      }
-    },
-    {
-      "name": "sow-generator",
-      "source": "./plugins/ai-agency/sow-generator",
-      "description": "Generate professional Statements of Work for AI projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "sow",
-        "statement of work",
-        "contract",
-        "proposal",
-        "agency",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "tonone",
-      "source": "./plugins/ai-agency/tonone",
-      "description": "23-agent engineering + product team with 125 skills for Claude Code",
-      "version": "1.8.0",
-      "category": "ai-agency",
-      "keywords": [
-        "agents",
-        "engineering-team",
-        "infrastructure",
-        "devops",
-        "backend",
-        "security",
-        "observability",
-        "frontend",
-        "ml",
-        "mobile",
-        "embedded",
-        "analytics",
-        "testing",
-        "platform",
-        "sales",
-        "revenue",
-        "customer-success",
-        "content-marketing",
-        "pr",
-        "community",
-        "finance",
-        "people",
-        "operations",
-        "support"
-      ],
-      "author": {
-        "name": "tonone-ai",
-        "url": "https://tonone.ai"
-      },
-      "repository": "https://github.com/tonone-ai/tonone",
-      "license": "MIT"
-    },
-    {
-      "name": "zapier-zap-builder",
-      "source": "./plugins/ai-agency/zapier-zap-builder",
-      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
+      "name": "ai-commit-gen",
+      "source": "./plugins/productivity/ai-commit-gen",
+      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
       "version": "1.10.0",
-      "category": "ai-agency",
+      "category": "productivity",
       "keywords": [
-        "zapier",
-        "zap",
+        "git",
+        "commit",
+        "conventional-commits",
+        "ai",
         "automation",
-        "integration",
-        "workflow",
-        "ai-agency"
+        "productivity",
+        "devops"
       ],
       "author": {
-        "name": "Claude Code Plugin Hub"
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "commands": 1,
+        "total": 1
       }
     },
     {
@@ -247,13 +262,7 @@
       "description": "AI ethics and fairness validation",
       "version": "1.24.0",
       "category": "ai-ml",
-      "keywords": [
-        "ethics",
-        "fairness",
-        "bias",
-        "responsible-ai",
-        "ml"
-      ],
+      "keywords": ["ethics", "fairness", "bias", "responsible-ai", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -262,6 +271,68 @@
         "score": 85,
         "grade": "B",
         "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "a2a-client",
+      "source": "./plugins/mcp/a2a-client",
+      "description": "Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": ["mcp", "a2a", "agent2agent", "agent-card", "multi-agent", "interoperability"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "featured": true,
+      "mcpTools": 7
+    },
+    {
+      "name": "ai-experiment-logger",
+      "source": "./plugins/mcp/ai-experiment-logger",
+      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
+      "version": "1.12.0",
+      "category": "mcp",
+      "keywords": ["ai", "experiments", "logging", "mcp"],
+      "author": {
+        "name": "Claude Code Plugins"
+      },
+      "zcf_metadata": {
+        "preset_id": "ai-experiment-logger",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "ai-ml"
+      }
+    },
+    {
+      "name": "ai-ml-engineering-pack",
+      "source": "./plugins/packages/ai-ml-engineering-pack",
+      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "ai",
+        "ml",
+        "llm",
+        "prompt-engineering",
+        "rag",
+        "vector-database",
+        "ai-safety",
+        "openai",
+        "anthropic",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pluginCount": 12,
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
@@ -304,18 +375,30 @@
       }
     },
     {
+      "name": "alerting-rule-creator",
+      "source": "./plugins/performance/alerting-rule-creator",
+      "description": "Create intelligent alerting rules for performance monitoring",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["alerting", "monitoring", "sre", "observability"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "anomaly-detection-system",
       "source": "./plugins/ai-ml/anomaly-detection-system",
       "description": "Detect anomalies and outliers in data",
       "version": "1.26.0",
       "category": "ai-ml",
-      "keywords": [
-        "anomaly",
-        "outliers",
-        "detection",
-        "isolation",
-        "ml"
-      ],
+      "keywords": ["anomaly", "outliers", "detection", "isolation", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -328,66 +411,12 @@
       }
     },
     {
-      "name": "automl-pipeline-builder",
-      "source": "./plugins/ai-ml/automl-pipeline-builder",
-      "description": "Build AutoML pipelines",
-      "version": "1.25.0",
-      "category": "ai-ml",
-      "keywords": [
-        "automl",
-        "automated",
-        "pipeline",
-        "h2o",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "classification-model-builder",
-      "source": "./plugins/ai-ml/classification-model-builder",
-      "description": "Build classification models",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "classification",
-        "supervised",
-        "predictor",
-        "labels",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "clustering-algorithm-runner",
-      "source": "./plugins/ai-ml/clustering-algorithm-runner",
-      "description": "Run clustering algorithms on datasets",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "clustering",
-        "kmeans",
-        "dbscan",
-        "hierarchical",
-        "ml"
-      ],
+      "name": "ansible-playbook-creator",
+      "source": "./plugins/devops/ansible-playbook-creator",
+      "description": "Create Ansible playbooks for configuration management",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": ["ansible", "automation", "configuration", "playbooks", "devops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -400,42 +429,12 @@
       }
     },
     {
-      "name": "computer-vision-processor",
-      "source": "./plugins/ai-ml/computer-vision-processor",
-      "description": "Computer vision image processing and analysis",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "cv",
-        "vision",
-        "images",
-        "detection",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-preprocessing-pipeline",
-      "source": "./plugins/ai-ml/data-preprocessing-pipeline",
-      "description": "Automated data preprocessing and cleaning pipelines",
+      "name": "api-authentication-builder",
+      "source": "./plugins/api-development/api-authentication-builder",
+      "description": "Build authentication systems with JWT, OAuth2, and API keys",
       "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "preprocessing",
-        "cleaning",
-        "etl",
-        "pipeline",
-        "data"
-      ],
+      "category": "api-development",
+      "keywords": ["authentication", "jwt", "oauth", "security"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -448,18 +447,390 @@
       }
     },
     {
-      "name": "data-visualization-creator",
-      "source": "./plugins/ai-ml/data-visualization-creator",
-      "description": "Create data visualizations and plots",
+      "name": "api-batch-processor",
+      "source": "./plugins/api-development/api-batch-processor",
+      "description": "Implement batch API operations with bulk processing and job queues",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["batch", "bulk", "queue", "job-processing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-cache-manager",
+      "source": "./plugins/api-development/api-cache-manager",
+      "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["caching", "redis", "cdn", "performance"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-contract-generator",
+      "source": "./plugins/api-development/api-contract-generator",
+      "description": "Generate API contracts for consumer-driven contract testing",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["contract", "pact", "testing", "microservices"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-documentation-generator",
+      "source": "./plugins/api-development/api-documentation-generator",
+      "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
+      "version": "1.27.0",
+      "category": "api-development",
+      "keywords": ["api", "documentation", "openapi", "swagger", "docs"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-error-handler",
+      "source": "./plugins/api-development/api-error-handler",
+      "description": "Implement standardized error handling with proper HTTP status codes",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["error-handling", "api", "http-status", "exceptions"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-event-emitter",
+      "source": "./plugins/api-development/api-event-emitter",
+      "description": "Implement event-driven APIs with message queues and event streaming",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["events", "messaging", "kafka", "rabbitmq", "event-driven"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-fuzzer",
+      "source": "./plugins/testing/api-fuzzer",
+      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": ["testing", "fuzzing", "api", "security", "edge-cases", "input-validation"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-gateway-builder",
+      "source": "./plugins/api-development/api-gateway-builder",
+      "description": "Build API gateway with routing, authentication, and rate limiting",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["api-gateway", "routing", "proxy", "microservices"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-load-tester",
+      "source": "./plugins/api-development/api-load-tester",
+      "description": "Load test APIs with k6, Gatling, or Artillery",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["load-testing", "performance", "k6", "stress-testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-migration-tool",
+      "source": "./plugins/api-development/api-migration-tool",
+      "description": "Migrate APIs between versions with backward compatibility",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["migration", "versioning", "api", "backward-compatibility"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-mock-server",
+      "source": "./plugins/api-development/api-mock-server",
+      "description": "Create mock API servers from OpenAPI specs for testing",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["mock", "testing", "openapi", "stub"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-monitoring-dashboard",
+      "source": "./plugins/api-development/api-monitoring-dashboard",
+      "description": "Create monitoring dashboards for API health, metrics, and alerts",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["monitoring", "metrics", "observability", "dashboard"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-rate-limiter",
+      "source": "./plugins/api-development/api-rate-limiter",
+      "description": "Implement rate limiting with token bucket, sliding window, and Redis",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["rate-limiting", "throttling", "api", "redis"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-request-logger",
+      "source": "./plugins/api-development/api-request-logger",
+      "description": "Log API requests with structured logging and correlation IDs",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["logging", "observability", "audit", "correlation"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-response-validator",
+      "source": "./plugins/api-development/api-response-validator",
+      "description": "Validate API responses against schemas and contracts",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["validation", "schema", "testing", "api"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-schema-validator",
+      "source": "./plugins/api-development/api-schema-validator",
+      "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["schema", "validation", "json-schema", "joi", "zod"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-sdk-generator",
+      "source": "./plugins/api-development/api-sdk-generator",
+      "description": "Generate client SDKs from OpenAPI specs for multiple languages",
+      "version": "1.22.0",
+      "category": "api-development",
+      "keywords": ["sdk", "client", "openapi", "codegen"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-security-scanner",
+      "source": "./plugins/api-development/api-security-scanner",
+      "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["security", "api", "owasp", "vulnerability"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-test-automation",
+      "source": "./plugins/testing/api-test-automation",
+      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": ["testing", "api", "rest", "graphql", "automation", "endpoints"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-throttling-manager",
+      "source": "./plugins/api-development/api-throttling-manager",
+      "description": "Manage API throttling with dynamic rate limits and quota management",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["throttling", "rate-limiting", "quota", "traffic-management"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-versioning-manager",
+      "source": "./plugins/api-development/api-versioning-manager",
+      "description": "Manage API versions with migration strategies and backward compatibility",
+      "version": "1.26.0",
+      "category": "api-development",
+      "keywords": ["api", "versioning", "migration", "backward-compatibility"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "apm-dashboard-creator",
+      "source": "./plugins/performance/apm-dashboard-creator",
+      "description": "Create Application Performance Monitoring dashboards",
       "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "visualization",
-        "plots",
-        "charts",
-        "graphs",
-        "analytics"
-      ],
+      "category": "performance",
+      "keywords": ["apm", "monitoring", "dashboard", "grafana", "datadog"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -472,18 +843,1138 @@
       }
     },
     {
+      "name": "application-profiler",
+      "source": "./plugins/performance/application-profiler",
+      "description": "Profile application performance with CPU, memory, and execution time analysis",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["performance", "profiling", "monitoring", "optimization"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "arbitrage-opportunity-finder",
+      "source": "./plugins/crypto/arbitrage-opportunity-finder",
+      "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": ["arbitrage", "trading", "defi", "mev", "profit"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "authentication-validator",
+      "source": "./plugins/security/authentication-validator",
+      "description": "Validate authentication implementations",
+      "version": "1.26.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "auto-scaling-configurator",
+      "source": "./plugins/devops/auto-scaling-configurator",
+      "description": "Configure auto-scaling policies for applications and infrastructure",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": ["autoscaling", "scaling", "hpa", "kubernetes", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "automl-pipeline-builder",
+      "source": "./plugins/ai-ml/automl-pipeline-builder",
+      "description": "Build AutoML pipelines",
+      "version": "1.25.0",
+      "category": "ai-ml",
+      "keywords": ["automl", "automated", "pipeline", "h2o", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "backup-strategy-implementor",
+      "source": "./plugins/devops/backup-strategy-implementor",
+      "description": "Implement backup strategies for databases and applications",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": ["backup", "disaster-recovery", "restoration", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "blockchain-explorer-cli",
+      "source": "./plugins/crypto/blockchain-explorer-cli",
+      "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": ["blockchain", "explorer", "etherscan", "transactions", "addresses", "contracts"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "bottleneck-detector",
+      "source": "./plugins/performance/bottleneck-detector",
+      "description": "Detect and resolve performance bottlenecks",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["bottleneck", "performance", "optimization", "profiling"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "browser-compatibility-tester",
+      "source": "./plugins/testing/browser-compatibility-tester",
+      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
+      "version": "2.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "cross-browser",
+        "browserstack",
+        "selenium",
+        "playwright",
+        "compatibility"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cache-performance-optimizer",
+      "source": "./plugins/performance/cache-performance-optimizer",
+      "description": "Optimize caching strategies for improved performance",
+      "version": "1.19.0",
+      "category": "performance",
+      "keywords": ["cache", "performance", "optimization", "redis"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "calendar-to-workflow",
+      "source": "./plugins/skill-enhancers/calendar-to-workflow",
+      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": ["calendar", "automation", "meetings", "productivity"],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "capacity-planning-analyzer",
+      "source": "./plugins/performance/capacity-planning-analyzer",
+      "description": "Analyze and plan for capacity requirements",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["capacity-planning", "scaling", "forecasting", "infrastructure"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "chaos-engineering-toolkit",
+      "source": "./plugins/testing/chaos-engineering-toolkit",
+      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "chaos-engineering",
+        "resilience",
+        "failure-injection",
+        "fault-tolerance",
+        "reliability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ci-cd-pipeline-builder",
+      "source": "./plugins/devops/ci-cd-pipeline-builder",
+      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": ["ci-cd", "github-actions", "gitlab-ci", "jenkins", "devops", "automation"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "classification-model-builder",
+      "source": "./plugins/ai-ml/classification-model-builder",
+      "description": "Build classification models",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": ["classification", "supervised", "predictor", "labels", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cloud-cost-optimizer",
+      "source": "./plugins/devops/cloud-cost-optimizer",
+      "description": "Optimize cloud costs and generate cost reports",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": ["cost", "optimization", "finops", "cloud", "aws", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "clustering-algorithm-runner",
+      "source": "./plugins/ai-ml/clustering-algorithm-runner",
+      "description": "Run clustering algorithms on datasets",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": ["clustering", "kmeans", "dbscan", "hierarchical", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "compliance-checker",
+      "source": "./plugins/devops/compliance-checker",
+      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": ["compliance", "security", "audit", "soc2", "hipaa", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "compliance-report-generator",
+      "source": "./plugins/security/compliance-report-generator",
+      "description": "Generate compliance reports",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "computer-vision-processor",
+      "source": "./plugins/ai-ml/computer-vision-processor",
+      "description": "Computer vision image processing and analysis",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": ["cv", "vision", "images", "detection", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "container-registry-manager",
+      "source": "./plugins/devops/container-registry-manager",
+      "description": "Manage container registries (ECR, GCR, Harbor)",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": ["registry", "containers", "docker", "ecr", "gcr", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "container-security-scanner",
+      "source": "./plugins/devops/container-security-scanner",
+      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": ["security", "containers", "scanning", "vulnerabilities", "trivy", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "contract-test-validator",
+      "source": "./plugins/testing/contract-test-validator",
+      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "contract-testing",
+        "pact",
+        "openapi",
+        "api",
+        "microservices",
+        "consumer-driven"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "conversational-api-debugger",
+      "source": "./plugins/mcp/conversational-api-debugger",
+      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": ["mcp", "api", "debugging", "openapi", "har", "rest", "curl", "http"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 4,
+      "zcf_metadata": {
+        "preset_id": "conversational-api-debugger",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "api"
+      }
+    },
+    {
+      "name": "cors-policy-validator",
+      "source": "./plugins/security/cors-policy-validator",
+      "description": "Validate CORS policies",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cpu-usage-monitor",
+      "source": "./plugins/performance/cpu-usage-monitor",
+      "description": "Monitor and analyze CPU usage patterns in applications",
+      "version": "1.23.0",
+      "category": "performance",
+      "keywords": ["cpu", "monitoring", "performance", "optimization"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "creator-studio-pack",
+      "source": "./plugins/packages/creator-studio-pack",
+      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
+      "version": "1.16.0",
+      "category": "packages",
+      "keywords": [
+        "video",
+        "content-creation",
+        "youtube",
+        "filmmaking",
+        "creator",
+        "documentation",
+        "screencast",
+        "tutorial",
+        "video-editing",
+        "content-strategy",
+        "distribution",
+        "thumbnails",
+        "subtitles",
+        "repurposing",
+        "batch-recording",
+        "analytics",
+        "package",
+        "premium"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pricing": {
+        "model": "one-time",
+        "price": 149,
+        "currency": "USD"
+      },
+      "components": {
+        "agents": 10,
+        "commands": 10,
+        "total": 20
+      }
+    },
+    {
+      "name": "cross-chain-bridge-monitor",
+      "source": "./plugins/crypto/cross-chain-bridge-monitor",
+      "description": "Monitor cross-chain bridge activity, track transfers, analyze security, and detect bridge exploits",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "cross-chain",
+        "bridge",
+        "security",
+        "monitoring",
+        "layer2",
+        "multichain",
+        "defi"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-derivatives-tracker",
+      "source": "./plugins/crypto/crypto-derivatives-tracker",
+      "description": "Track crypto futures, options, perpetual swaps with funding rates, open interest, and derivatives market analysis",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "derivatives",
+        "futures",
+        "options",
+        "perpetuals",
+        "funding-rate",
+        "open-interest",
+        "trading"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-news-aggregator",
+      "source": "./plugins/crypto/crypto-news-aggregator",
+      "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": ["news", "aggregator", "sentiment", "crypto", "media"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-portfolio-tracker",
+      "source": "./plugins/crypto/crypto-portfolio-tracker",
+      "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": ["crypto", "portfolio", "trading", "investment", "bitcoin", "ethereum", "defi"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-signal-generator",
+      "source": "./plugins/crypto/crypto-signal-generator",
+      "description": "Generate trading signals from technical indicators and market analysis",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": ["trading", "signals", "technical-analysis", "indicators", "crypto"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-tax-calculator",
+      "source": "./plugins/crypto/crypto-tax-calculator",
+      "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": ["crypto", "tax", "calculator", "fifo", "lifo", "capital gains"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "csrf-protection-validator",
+      "source": "./plugins/security/csrf-protection-validator",
+      "description": "Validate CSRF protection",
+      "version": "1.26.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-preprocessing-pipeline",
+      "source": "./plugins/ai-ml/data-preprocessing-pipeline",
+      "description": "Automated data preprocessing and cleaning pipelines",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": ["preprocessing", "cleaning", "etl", "pipeline", "data"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-privacy-scanner",
+      "source": "./plugins/security/data-privacy-scanner",
+      "description": "Scan for data privacy issues",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-seeder-generator",
+      "source": "./plugins/database/data-seeder-generator",
+      "description": "Generate realistic test data and database seed scripts for development and testing environments",
+      "version": "1.22.0",
+      "category": "database",
+      "keywords": ["seeding", "test-data", "fixtures", "database", "testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-validation-engine",
+      "source": "./plugins/database/data-validation-engine",
+      "description": "Database plugin for data-validation-engine",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": ["database", "backend", "validation"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-visualization-creator",
+      "source": "./plugins/ai-ml/data-visualization-creator",
+      "description": "Create data visualizations and plots",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": ["visualization", "plots", "charts", "graphs", "analytics"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-archival-system",
+      "source": "./plugins/database/database-archival-system",
+      "description": "Database plugin for database-archival-system",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "backend", "archival"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-audit-logger",
+      "source": "./plugins/database/database-audit-logger",
+      "description": "Database plugin for database-audit-logger",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": ["database", "backend", "audit"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-backup-automator",
+      "source": "./plugins/database/database-backup-automator",
+      "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
+      "version": "1.26.0",
+      "category": "database",
+      "keywords": ["database", "backup", "automation", "disaster-recovery", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 74,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-cache-layer",
+      "source": "./plugins/database/database-cache-layer",
+      "description": "Database plugin for database-cache-layer",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": ["database", "backend", "cache"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-connection-pooler",
+      "source": "./plugins/database/database-connection-pooler",
+      "description": "Implement and optimize database connection pooling for improved performance and resource management",
+      "version": "1.23.0",
+      "category": "database",
+      "keywords": ["connection-pool", "database", "performance", "backend", "optimization"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-deadlock-detector",
+      "source": "./plugins/database/database-deadlock-detector",
+      "description": "Database plugin for database-deadlock-detector",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "backend", "deadlock"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-diff-tool",
+      "source": "./plugins/database/database-diff-tool",
+      "description": "Database plugin for database-diff-tool",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "backend", "diff"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-documentation-gen",
+      "source": "./plugins/database/database-documentation-gen",
+      "description": "Database plugin for database-documentation-gen",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": ["database", "backend", "documentation"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-health-monitor",
+      "source": "./plugins/database/database-health-monitor",
+      "description": "Database plugin for database-health-monitor",
+      "version": "1.25.0",
+      "category": "database",
+      "keywords": ["database", "backend", "health"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-index-advisor",
+      "source": "./plugins/database/database-index-advisor",
+      "description": "Analyze query patterns and recommend optimal database indexes with impact analysis",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "indexes", "optimization", "performance"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-migration-manager",
+      "source": "./plugins/database/database-migration-manager",
+      "description": "Manage database migrations with version control, rollback capabilities, and automated schema evolution tracking",
+      "version": "1.23.0",
+      "category": "database",
+      "keywords": ["database", "migration", "schema", "version-control", "backend"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-partition-manager",
+      "source": "./plugins/database/database-partition-manager",
+      "description": "Database plugin for database-partition-manager",
+      "version": "1.25.0",
+      "category": "database",
+      "keywords": ["database", "backend", "partition"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-query-profiler",
+      "source": "./plugins/performance/database-query-profiler",
+      "description": "Profile and optimize database queries for performance",
+      "version": "1.9.0",
+      "category": "performance",
+      "keywords": ["database", "query", "profiling", "optimization", "sql"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "database-recovery-manager",
+      "source": "./plugins/database/database-recovery-manager",
+      "description": "Database plugin for database-recovery-manager",
+      "version": "1.26.0",
+      "category": "database",
+      "keywords": ["database", "backend", "recovery"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-replication-manager",
+      "source": "./plugins/database/database-replication-manager",
+      "description": "Manage database replication, failover, and high availability configurations",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": ["replication", "high-availability", "failover", "database", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-schema-designer",
+      "source": "./plugins/database/database-schema-designer",
+      "description": "Design and visualize database schemas with normalization guidance, relationship mapping, and ERD generation",
+      "version": "1.24.0",
+      "category": "database",
+      "keywords": ["database", "schema", "design", "erd", "normalization"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-security-scanner",
+      "source": "./plugins/database/database-security-scanner",
+      "description": "Database plugin for database-security-scanner",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "backend", "security"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-sharding-manager",
+      "source": "./plugins/database/database-sharding-manager",
+      "description": "Database plugin for database-sharding-manager",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "backend", "sharding"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-test-manager",
+      "source": "./plugins/testing/database-test-manager",
+      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "database",
+        "sql",
+        "test-data",
+        "fixtures",
+        "migrations",
+        "transactions"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-transaction-monitor",
+      "source": "./plugins/database/database-transaction-monitor",
+      "description": "Database plugin for database-transaction-monitor",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["database", "backend", "transaction"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "dataset-splitter",
       "source": "./plugins/ai-ml/dataset-splitter",
       "description": "Split datasets for training, validation, and testing",
       "version": "1.22.0",
       "category": "ai-ml",
-      "keywords": [
-        "split",
-        "train-test",
-        "validation",
-        "stratify",
-        "ml"
-      ],
+      "keywords": ["split", "train-test", "validation", "stratify", "ml"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -501,13 +1992,7 @@
       "description": "Deep learning optimization techniques",
       "version": "1.23.0",
       "category": "ai-ml",
-      "keywords": [
-        "optimization",
-        "adam",
-        "sgd",
-        "learning-rate",
-        "deep-learning"
-      ],
+      "keywords": ["optimization", "adam", "sgd", "learning-rate", "deep-learning"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -520,42 +2005,30 @@
       }
     },
     {
-      "name": "experiment-tracking-setup",
-      "source": "./plugins/ai-ml/experiment-tracking-setup",
-      "description": "Set up ML experiment tracking",
-      "version": "1.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "experiments",
-        "mlflow",
-        "wandb",
-        "tracking",
-        "mlops"
-      ],
+      "name": "defi-yield-optimizer",
+      "source": "./plugins/crypto/defi-yield-optimizer",
+      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": ["defi", "yield", "farming", "liquidity", "apy", "optimization", "crypto"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
+        "score": 80,
+        "grade": "B",
+        "badge": "silver",
         "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
-      "name": "feature-engineering-toolkit",
-      "source": "./plugins/ai-ml/feature-engineering-toolkit",
-      "description": "Feature creation, selection, and transformation tools",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "features",
-        "engineering",
-        "selection",
-        "transformation",
-        "ml"
-      ],
+      "name": "dependency-checker",
+      "source": "./plugins/security/dependency-checker",
+      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": ["security", "dependencies", "npm", "pip", "composer", "vulnerabilities"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -568,24 +2041,3033 @@
       }
     },
     {
-      "name": "hyperparameter-tuner",
-      "source": "./plugins/ai-ml/hyperparameter-tuner",
-      "description": "Optimize hyperparameters using grid/random/bayesian search",
-      "version": "1.21.0",
-      "category": "ai-ml",
+      "name": "deployment-pipeline-orchestrator",
+      "source": "./plugins/devops/deployment-pipeline-orchestrator",
+      "description": "Orchestrate complex multi-stage deployment pipelines",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": ["pipeline", "orchestration", "deployment", "cicd", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "deployment-rollback-manager",
+      "source": "./plugins/devops/deployment-rollback-manager",
+      "description": "Manage and execute deployment rollbacks with safety checks",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": ["rollback", "deployment", "kubernetes", "recovery", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "design-to-code",
+      "source": "./plugins/mcp/design-to-code",
+      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
+      "version": "1.14.0",
+      "category": "mcp",
       "keywords": [
-        "hyperparameters",
-        "optimization",
-        "tuning",
-        "search",
-        "ml"
+        "mcp",
+        "design",
+        "figma",
+        "react",
+        "svelte",
+        "vue",
+        "accessibility",
+        "component-generation"
       ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 3,
+      "zcf_metadata": {
+        "preset_id": "design-to-code",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "design"
+      }
+    },
+    {
+      "name": "devops-automation-pack",
+      "source": "./plugins/packages/devops-automation-pack",
+      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "devops",
+        "ci-cd",
+        "docker",
+        "kubernetes",
+        "terraform",
+        "deployment",
+        "infrastructure",
+        "automation",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "dex-aggregator-router",
+      "source": "./plugins/crypto/dex-aggregator-router",
+      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": ["dex", "swap", "trading", "defi", "aggregator", "routing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "disaster-recovery-planner",
+      "source": "./plugins/devops/disaster-recovery-planner",
+      "description": "Plan and implement disaster recovery procedures",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": ["disaster-recovery", "dr", "business-continuity", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "discovery-questionnaire",
+      "source": "./plugins/ai-agency/discovery-questionnaire",
+      "description": "Generate custom discovery questionnaires for AI agency prospects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": ["discovery", "questionnaire", "client", "sales", "agency", "ai-agency"],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "distributed-tracing-setup",
+      "source": "./plugins/performance/distributed-tracing-setup",
+      "description": "Set up distributed tracing for microservices",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["tracing", "observability", "microservices", "opentelemetry"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "docker-compose-generator",
+      "source": "./plugins/devops/docker-compose-generator",
+      "description": "Generate Docker Compose configurations for multi-container applications with best practices",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": ["docker", "docker-compose", "containers", "orchestration", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "domain-memory-agent",
+      "source": "./plugins/mcp/domain-memory-agent",
+      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
+      "version": "1.17.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "knowledge-base",
+        "semantic-search",
+        "tfidf",
+        "summarization",
+        "rag",
+        "documentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 6,
+      "zcf_metadata": {
+        "preset_id": "domain-memory-agent",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "knowledge"
+      }
+    },
+    {
+      "name": "lumera-agent-memory",
+      "source": "./plugins/mcp/lumera-agent-memory",
+      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
+      "version": "1.7.0",
+      "category": "mcp",
+      "keywords": ["mcp", "memory", "cascade", "storage", "encryption", "search", "fts", "agent"],
+      "author": {
+        "name": "Intent Solutions IO",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "mcpTools": ["store_memory", "recall_memory", "search_memory", "delete_memory"]
+    },
+    {
+      "name": "e2e-test-framework",
+      "source": "./plugins/testing/e2e-test-framework",
+      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": ["testing", "e2e", "playwright", "cypress", "selenium", "browser-testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "encryption-tool",
+      "source": "./plugins/security/encryption-tool",
+      "description": "Encrypt and decrypt data with various algorithms",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "engineer-design-diagram",
+      "source": "./plugins/devops/engineer-design-diagram",
+      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI \u2014 package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
+      "version": "0.5.0",
+      "category": "devops",
+      "keywords": [
+        "architecture",
+        "diagram",
+        "visualization",
+        "svg",
+        "html",
+        "pr-review",
+        "drift-detection",
+        "sequence-diagram",
+        "engineering-design",
+        "documentation",
+        "onboarding"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "components": {
+        "skills": 1
+      }
+    },
+    {
+      "name": "environment-config-manager",
+      "source": "./plugins/devops/environment-config-manager",
+      "description": "Manage environment configurations and secrets across deployments",
+      "version": "1.23.0",
+      "category": "devops",
+      "keywords": ["config", "environment", "secrets", "configuration", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "error-rate-monitor",
+      "source": "./plugins/performance/error-rate-monitor",
+      "description": "Monitor and analyze application error rates",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["errors", "monitoring", "reliability", "sre"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "excel-analyst-pro",
+      "source": "./plugins/business-tools/excel-analyst-pro",
+      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
+      "version": "1.21.0",
+      "category": "business-tools",
+      "keywords": [
+        "excel",
+        "financial-modeling",
+        "dcf",
+        "lbo",
+        "valuation",
+        "variance-analysis",
+        "pivot-tables",
+        "investment-banking",
+        "private-equity",
+        "financial-analysis",
+        "skills",
+        "mcp"
+      ],
+      "author": {
+        "name": "ClaudeCodePlugins",
+        "email": "plugins@tonsofskills.com"
+      },
+      "featured": true,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "components": {
+        "skills": 4,
+        "commands": 3
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "brand-strategy-framework",
+      "source": "./plugins/business-tools/brand-strategy-framework",
+      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
+      "version": "1.7.0",
+      "category": "business-tools",
+      "keywords": [
+        "brand-strategy",
+        "marketing",
+        "branding",
+        "positioning",
+        "messaging",
+        "brand-guidelines",
+        "audience-architecture",
+        "brand-identity"
+      ],
+      "author": {
+        "name": "Rowan Brooks",
+        "email": "rowanbrooks100@github.com"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "experiment-tracking-setup",
+      "source": "./plugins/ai-ml/experiment-tracking-setup",
+      "description": "Set up ML experiment tracking",
+      "version": "1.19.0",
+      "category": "ai-ml",
+      "keywords": ["experiments", "mlflow", "wandb", "tracking", "mlops"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "fairdb-operations-kit",
+      "source": "./plugins/devops/fairdb-operations-kit",
+      "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "fairdb",
+        "postgresql",
+        "database",
+        "saas",
+        "operations",
+        "devops",
+        "backup",
+        "monitoring",
+        "vps",
+        "contabo",
+        "wasabi",
+        "pgbackrest",
+        "automation",
+        "incident-response"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "featured": false,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "fairdb-ops-manager",
+      "source": "./plugins/community/fairdb-ops-manager",
+      "description": "Database operations management for FairDB PostgreSQL clusters",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": ["database", "postgresql", "operations"],
+      "author": {
+        "name": "Community"
+      }
+    },
+    {
+      "name": "feature-engineering-toolkit",
+      "source": "./plugins/ai-ml/feature-engineering-toolkit",
+      "description": "Feature creation, selection, and transformation tools",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": ["features", "engineering", "selection", "transformation", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "file-to-code",
+      "source": "./plugins/skill-enhancers/file-to-code",
+      "description": "Converts file references into executable code implementations",
+      "version": "0.16.0",
+      "category": "skill-enhancers",
+      "keywords": ["files", "automation", "code-generation"],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "flash-loan-simulator",
+      "source": "./plugins/crypto/flash-loan-simulator",
+      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "flash-loans",
+        "defi",
+        "aave",
+        "arbitrage",
+        "liquidation",
+        "ethereum",
+        "simulation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 86,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "formatter",
+      "source": "./plugins/examples/formatter",
+      "description": "Code formatting plugin using hooks to auto-format on save",
+      "version": "2.26.0",
+      "category": "examples",
+      "keywords": ["formatting", "hooks", "automation"],
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "freshie-inventory-manager",
+      "source": "./plugins/database/freshie-inventory-manager",
+      "description": "Interactive command center for the freshie ecosystem inventory database \u2014 conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+      "version": "1.5.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "inventory",
+        "freshie",
+        "compliance",
+        "sqlite",
+        "ecosystem",
+        "audit",
+        "subagents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 3
+      }
+    },
+    {
+      "name": "fullstack-starter-pack",
+      "source": "./plugins/packages/fullstack-starter-pack",
+      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
+      "version": "1.21.0",
+      "category": "packages",
+      "keywords": [
+        "fullstack",
+        "react",
+        "express",
+        "fastapi",
+        "postgresql",
+        "prisma",
+        "typescript",
+        "mvp",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pluginCount": 15
+    },
+    {
+      "name": "gas-fee-optimizer",
+      "source": "./plugins/crypto/gas-fee-optimizer",
+      "description": "Optimize transaction gas fees with timing and routing recommendations",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": ["gas", "fees", "ethereum", "optimization", "transaction", "l2"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 88,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gdpr-compliance-scanner",
+      "source": "./plugins/security/gdpr-compliance-scanner",
+      "description": "Scan for GDPR compliance issues",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "git-commit-smart",
+      "source": "./plugins/devops/git-commit-smart",
+      "description": "AI-powered conventional commit message generator with smart analysis",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "git",
+        "commits",
+        "conventional-commits",
+        "automation",
+        "devops",
+        "productivity"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gitops-workflow-builder",
+      "source": "./plugins/devops/gitops-workflow-builder",
+      "description": "Build GitOps workflows with ArgoCD and Flux",
+      "version": "1.22.0",
+      "category": "devops",
+      "keywords": ["gitops", "argocd", "flux", "cd", "kubernetes", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "graphql-server-builder",
+      "source": "./plugins/api-development/graphql-server-builder",
+      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
+      "version": "1.22.0",
+      "category": "api-development",
+      "keywords": ["graphql", "api", "server", "apollo", "schema", "resolvers"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "grpc-service-generator",
+      "source": "./plugins/api-development/grpc-service-generator",
+      "description": "Generate gRPC services with Protocol Buffers and streaming support",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": ["grpc", "protobuf", "microservices", "streaming"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "hello-world",
+      "source": "./plugins/examples/hello-world",
+      "description": "Simple example plugin demonstrating basic slash commands",
+      "version": "1.12.0",
+      "category": "examples",
+      "keywords": ["example", "tutorial", "beginner"],
+      "author": {
+        "name": "Jeremy Longshore"
+      }
+    },
+    {
+      "name": "helm-chart-generator",
+      "source": "./plugins/devops/helm-chart-generator",
+      "description": "Generate Helm charts for Kubernetes applications",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": ["helm", "kubernetes", "packaging", "charts", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "hipaa-compliance-checker",
+      "source": "./plugins/security/hipaa-compliance-checker",
+      "description": "Check HIPAA compliance",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "hyperparameter-tuner",
+      "source": "./plugins/ai-ml/hyperparameter-tuner",
+      "description": "Optimize hyperparameters using grid/random/bayesian search",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": ["hyperparameters", "optimization", "tuning", "search", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "infrastructure-as-code-generator",
+      "source": "./plugins/devops/infrastructure-as-code-generator",
+      "description": "Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": ["iac", "terraform", "cloudformation", "pulumi", "infrastructure", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "infrastructure-drift-detector",
+      "source": "./plugins/devops/infrastructure-drift-detector",
+      "description": "Detect infrastructure drift from desired state",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": ["drift", "terraform", "infrastructure", "monitoring", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "infrastructure-metrics-collector",
+      "source": "./plugins/performance/infrastructure-metrics-collector",
+      "description": "Collect comprehensive infrastructure performance metrics",
+      "version": "1.20.0",
+      "category": "performance",
+      "keywords": ["infrastructure", "metrics", "monitoring", "observability"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "input-validation-scanner",
+      "source": "./plugins/security/input-validation-scanner",
+      "description": "Scan input validation practices",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "integration-test-runner",
+      "source": "./plugins/testing/integration-test-runner",
+      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": ["testing", "integration-tests", "test-runner", "e2e", "api-testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "kobiton-automate",
+      "source": "./plugins/testing/kobiton-automate",
+      "description": "Real mobile devices on demand via Kobiton's remote MCP \u2014 no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
+      "version": "1.0.2",
+      "category": "testing",
+      "keywords": [
+        "mobile",
+        "testing",
+        "appium",
+        "automation",
+        "devices",
+        "ios",
+        "android",
+        "real-device",
+        "mcp",
+        "kobiton"
+      ],
+      "author": {
+        "name": "Kobiton Inc.",
+        "url": "https://github.com/kobiton"
+      },
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "kobiton/automate",
+        "source_path": "."
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "kubernetes-deployment-creator",
+      "source": "./plugins/devops/kubernetes-deployment-creator",
+      "description": "Create Kubernetes deployments, services, and configurations with best practices",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": ["kubernetes", "k8s", "deployment", "orchestration", "containers"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 63,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "liquidity-pool-analyzer",
+      "source": "./plugins/crypto/liquidity-pool-analyzer",
+      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
+      "version": "1.23.0",
+      "category": "crypto",
+      "keywords": ["liquidity", "pool", "defi", "impermanent", "loss", "apy"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "load-balancer-configurator",
+      "source": "./plugins/devops/load-balancer-configurator",
+      "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": ["load-balancer", "alb", "nginx", "haproxy", "networking", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "load-balancer-tester",
+      "source": "./plugins/testing/load-balancer-tester",
+      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "load-balancer",
+        "traffic-distribution",
+        "failover",
+        "high-availability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "load-test-runner",
+      "source": "./plugins/performance/load-test-runner",
+      "description": "Create and execute load tests for performance validation",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["load-testing", "performance", "stress-test", "k6"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "log-aggregation-setup",
+      "source": "./plugins/devops/log-aggregation-setup",
+      "description": "Set up log aggregation (ELK, Loki, Splunk)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": ["logging", "elk", "loki", "splunk", "observability", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "log-analysis-tool",
+      "source": "./plugins/performance/log-analysis-tool",
+      "description": "Analyze logs for performance insights and issues",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": ["logs", "analysis", "performance", "debugging"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "make-scenario-builder",
+      "source": "./plugins/ai-agency/make-scenario-builder",
+      "description": "Create Make.com (Integromat) scenarios with AI assistance",
+      "version": "1.15.0",
+      "category": "ai-agency",
+      "keywords": ["make", "integromat", "automation", "scenarios", "workflow", "ai-agency"],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "market-movers-scanner",
+      "source": "./plugins/crypto/market-movers-scanner",
+      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": ["market", "scanner", "movers", "gainers", "losers", "volume", "trading"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 82,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "market-price-tracker",
+      "source": "./plugins/crypto/market-price-tracker",
+      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": ["market", "price", "tracking", "trading", "crypto", "stocks", "forex"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "market-sentiment-analyzer",
+      "source": "./plugins/crypto/market-sentiment-analyzer",
+      "description": "Analyze market sentiment from social media, news, and on-chain data",
+      "version": "1.24.0",
+      "category": "crypto",
+      "keywords": ["sentiment", "analysis", "social", "news", "market", "crypto"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "memory-leak-detector",
+      "source": "./plugins/performance/memory-leak-detector",
+      "description": "Detect memory leaks and analyze memory usage patterns",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": ["memory", "leak", "detection", "performance"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mempool-analyzer",
+      "source": "./plugins/crypto/mempool-analyzer",
+      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
+      "version": "1.32.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "mempool",
+        "mev",
+        "ethereum",
+        "blockchain",
+        "gas",
+        "pending-transactions",
+        "arbitrage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 85,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "metrics-aggregator",
+      "source": "./plugins/performance/metrics-aggregator",
+      "description": "Aggregate and centralize performance metrics",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["metrics", "aggregation", "prometheus", "monitoring"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ml-model-trainer",
+      "source": "./plugins/ai-ml/ml-model-trainer",
+      "description": "Train and optimize machine learning models with automated workflows",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": ["ml", "machine-learning", "training", "models", "ai"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mobile-app-tester",
+      "source": "./plugins/testing/mobile-app-tester",
+      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mobile",
+        "appium",
+        "detox",
+        "xcuitest",
+        "espresso",
+        "ios",
+        "android"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "model-deployment-helper",
+      "source": "./plugins/ai-ml/model-deployment-helper",
+      "description": "Deploy ML models to production",
+      "version": "1.19.0",
+      "category": "ai-ml",
+      "keywords": ["deployment", "serving", "production", "api", "mlops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "model-evaluation-suite",
+      "source": "./plugins/ai-ml/model-evaluation-suite",
+      "description": "Comprehensive model evaluation with multiple metrics",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": ["evaluation", "metrics", "testing", "validation", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "model-explainability-tool",
+      "source": "./plugins/ai-ml/model-explainability-tool",
+      "description": "Model interpretability and explainability",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": ["explainability", "shap", "lime", "interpretability", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "model-versioning-tracker",
+      "source": "./plugins/ai-ml/model-versioning-tracker",
+      "description": "Track and manage model versions",
+      "version": "1.24.0",
+      "category": "ai-ml",
+      "keywords": ["versioning", "mlflow", "tracking", "registry", "mlops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "monitoring-stack-deployer",
+      "source": "./plugins/devops/monitoring-stack-deployer",
+      "description": "Deploy monitoring stacks (Prometheus, Grafana, Datadog)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": ["monitoring", "prometheus", "grafana", "observability", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mutation-test-runner",
+      "source": "./plugins/testing/mutation-test-runner",
+      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": ["testing", "mutation-testing", "test-quality", "stryker", "pitest"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "n8n-workflow-designer",
+      "source": "./plugins/ai-agency/n8n-workflow-designer",
+      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
+      "version": "1.13.0",
+      "category": "ai-agency",
+      "keywords": ["n8n", "workflow", "automation", "self-hosted", "open-source", "ai-agency"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "url": "https://github.com/jeremylongshore/claude-code-plugins"
+      },
+      "featured": true
+    },
+    {
+      "name": "network-latency-analyzer",
+      "source": "./plugins/performance/network-latency-analyzer",
+      "description": "Analyze network latency and optimize request patterns",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["network", "latency", "performance", "api"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "network-policy-manager",
+      "source": "./plugins/devops/network-policy-manager",
+      "description": "Manage Kubernetes network policies and firewall rules",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": ["network-policy", "security", "kubernetes", "firewall", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "neural-network-builder",
+      "source": "./plugins/ai-ml/neural-network-builder",
+      "description": "Build and configure neural network architectures",
+      "version": "1.20.0",
+      "category": "ai-ml",
+      "keywords": ["neural-networks", "deep-learning", "architecture", "pytorch", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "nft-rarity-analyzer",
+      "source": "./plugins/crypto/nft-rarity-analyzer",
+      "description": "Analyze NFT rarity scores and valuations across collections",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": ["nft", "rarity", "valuation", "traits", "opensea", "crypto"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 88,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "nlp-text-analyzer",
+      "source": "./plugins/ai-ml/nlp-text-analyzer",
+      "description": "Natural language processing and text analysis",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": ["nlp", "text", "analysis", "tokenization", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ollama-local-ai",
+      "source": "./plugins/ai-ml/ollama-local-ai",
+      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
+      "version": "1.18.0",
+      "category": "ai-ml",
+      "keywords": [
+        "ollama",
+        "local-llm",
+        "free-ai",
+        "self-hosted",
+        "llama",
+        "mistral",
+        "privacy",
+        "zero-cost",
+        "openai-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1,
+        "total": 2
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "nosql-data-modeler",
+      "source": "./plugins/database/nosql-data-modeler",
+      "description": "Database plugin for nosql-data-modeler",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": ["database", "backend", "data"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "on-chain-analytics",
+      "source": "./plugins/crypto/on-chain-analytics",
+      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": ["on-chain", "analytics", "whale", "metrics", "blockchain"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "openbb-terminal",
+      "source": "./plugins/business-tools/openbb-terminal",
+      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
+      "version": "1.6.0",
+      "category": "business-tools",
+      "keywords": [
+        "finance",
+        "investment",
+        "openbb",
+        "stocks",
+        "crypto",
+        "portfolio",
+        "trading",
+        "financial-analysis",
+        "market-data",
+        "equity-research",
+        "options",
+        "forex",
+        "macroeconomics",
+        "quant",
+        "ai-finance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "commands": 6,
+        "agents": 4,
+        "total": 10
+      }
+    },
+    {
+      "name": "options-flow-analyzer",
+      "source": "./plugins/crypto/options-flow-analyzer",
+      "description": "Track institutional options flow, unusual activity, and smart money movements",
+      "version": "1.29.0",
+      "category": "crypto",
+      "keywords": ["options", "flow", "institutional", "trading", "derivatives", "smart money"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "orm-code-generator",
+      "source": "./plugins/database/orm-code-generator",
+      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": ["orm", "models", "code-generation", "database", "backend"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "overnight-dev",
+      "source": "./plugins/productivity/overnight-dev",
+      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
+      "version": "1.29.0",
+      "category": "productivity",
+      "keywords": [
+        "overnight",
+        "autonomous",
+        "tdd",
+        "testing",
+        "git-hooks",
+        "automation",
+        "continuous-integration",
+        "test-driven-development",
+        "productivity"
+      ],
+      "author": {
+        "name": "Intent Solutions IO",
+        "url": "https://intentsolutions.io",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "owasp-compliance-checker",
+      "source": "./plugins/security/owasp-compliance-checker",
+      "description": "Check OWASP Top 10 compliance",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "pci-dss-validator",
+      "source": "./plugins/security/pci-dss-validator",
+      "description": "Validate PCI DSS compliance",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "penetration-tester",
+      "source": "./plugins/security/penetration-tester",
+      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
+      "version": "3.30.0",
+      "category": "security",
+      "keywords": ["security", "penetration-testing", "pentesting", "owasp", "owasp-top-10", "vulnerability-scanning", "dependency-audit", "license-compliance", "engagement-governance", "chain-of-custody"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 84,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-budget-validator",
+      "source": "./plugins/performance/performance-budget-validator",
+      "description": "Validate application against performance budgets",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["performance-budget", "validation", "ci-cd", "testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-optimization-advisor",
+      "source": "./plugins/performance/performance-optimization-advisor",
+      "description": "Get comprehensive performance optimization recommendations",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": ["optimization", "performance", "best-practices", "advisor"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-regression-detector",
+      "source": "./plugins/performance/performance-regression-detector",
+      "description": "Detect performance regressions in CI/CD pipeline",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["regression", "performance", "ci-cd", "testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-test-suite",
+      "source": "./plugins/testing/performance-test-suite",
+      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
+      "version": "1.30.0",
+      "category": "testing",
+      "keywords": ["testing", "performance", "load-testing", "benchmarking", "stress-testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "pi-pathfinder",
+      "source": "./plugins/examples/pi-pathfinder",
+      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
+      "version": "1.24.0",
+      "category": "examples",
+      "keywords": [
+        "agent-skills",
+        "pi",
+        "pathfinder",
+        "plugin-intelligence",
+        "task-router",
+        "auto-selector",
+        "skill-extraction",
+        "easy-mode",
+        "automatic",
+        "no-thinking-required"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "skills": 1
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "code-cleanup",
+      "source": "./plugins/testing/code-cleanup",
+      "description": "Comprehensive codebase cleanup across 11 quality dimensions \u2014 dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+      "version": "1.7.0",
+      "category": "testing",
+      "keywords": [
+        "code-quality",
+        "cleanup",
+        "refactoring",
+        "dead-code",
+        "deduplication",
+        "type-safety",
+        "security",
+        "performance",
+        "async",
+        "tech-debt",
+        "code-review"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 11
+      }
+    },
+    {
+      "name": "project-health-auditor",
+      "source": "./plugins/mcp/project-health-auditor",
+      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
+      "version": "1.18.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "code-quality",
+        "technical-debt",
+        "complexity",
+        "git-churn",
+        "test-coverage",
+        "analytics"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 4,
+      "zcf_metadata": {
+        "preset_id": "project-health-auditor",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "code-quality"
+      }
+    },
+    {
+      "name": "promptbook",
+      "source": "./plugins/business-tools/promptbook",
+      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating \u2014 no data transmitted without explicit opt-in. Background submission after session end.",
+      "version": "1.4.0",
+      "category": "business-tools",
+      "keywords": [
+        "analytics",
+        "telemetry",
+        "builds",
+        "portfolio",
+        "tracking",
+        "metrics",
+        "sessions"
+      ],
+      "author": {
+        "name": "Promptbook",
+        "email": "contact@promptbook.gg"
+      },
+      "homepage": "https://promptbook.gg",
+      "repository": "https://github.com/promptbookgg/claude-code-plugin",
+      "license": "MIT",
+      "components": {
+        "skills": 2,
+        "hooks": 4
+      }
+    },
+    {
+      "name": "query-performance-analyzer",
+      "source": "./plugins/database/query-performance-analyzer",
+      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["performance", "query", "optimization", "explain", "database"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "real-user-monitoring",
+      "source": "./plugins/performance/real-user-monitoring",
+      "description": "Implement Real User Monitoring for actual performance data",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["rum", "monitoring", "performance", "user-experience"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "recommendation-engine",
+      "source": "./plugins/ai-ml/recommendation-engine",
+      "description": "Build recommendation systems and engines",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": ["recommendations", "collaborative", "content-based", "ranking", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "regression-analysis-tool",
+      "source": "./plugins/ai-ml/regression-analysis-tool",
+      "description": "Regression analysis and modeling",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": ["regression", "prediction", "linear", "polynomial", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "regression-test-tracker",
+      "source": "./plugins/testing/regression-test-tracker",
+      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": ["testing", "regression-testing", "test-tracking", "ci-cd", "quality-assurance"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "research-to-deploy",
+      "source": "./plugins/skill-enhancers/research-to-deploy",
+      "description": "Transforms research findings into deployed solutions automatically",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": ["research", "automation", "deployment"],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "resource-usage-tracker",
+      "source": "./plugins/performance/resource-usage-tracker",
+      "description": "Track and optimize resource usage across the stack",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["resources", "monitoring", "optimization", "metrics"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "response-time-tracker",
+      "source": "./plugins/performance/response-time-tracker",
+      "description": "Track and optimize application response times",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["response-time", "latency", "performance", "monitoring"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "rest-api-generator",
+      "source": "./plugins/api-development/rest-api-generator",
+      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": ["api", "rest", "generator", "openapi", "swagger", "backend"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "roi-calculator",
+      "source": "./plugins/ai-agency/roi-calculator",
+      "description": "Calculate and present ROI for AI automation projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": ["roi", "return on investment", "calculator", "sales", "value", "ai-agency"],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "search-to-slack",
+      "source": "./plugins/skill-enhancers/search-to-slack",
+      "description": "Automatically posts search results to Slack channels",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": ["search", "slack", "automation", "integration"],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "secret-scanner",
+      "source": "./plugins/security/secret-scanner",
+      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "secrets", "api-keys", "credentials", "passwords"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "severity1-marketplace",
+      "source": "./plugins/security/severity1-marketplace",
+      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
+      "version": "1.6.0",
+      "category": "security",
+      "keywords": [
+        "severity",
+        "classification",
+        "prompt-improvement",
+        "marketplace",
+        "security",
+        "quality",
+        "triage",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "severity1",
+        "email": "severity1@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 2,
+        "agents": 1
+      }
+    },
+    {
+      "name": "secrets-manager-integrator",
+      "source": "./plugins/devops/secrets-manager-integrator",
+      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": ["secrets", "vault", "aws", "security", "credentials", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-agent",
+      "source": "./plugins/examples/security-agent",
+      "description": "Security review subagent for code analysis",
+      "version": "1.28.0",
+      "category": "examples",
+      "keywords": ["security", "agent", "code-review"],
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-audit-reporter",
+      "source": "./plugins/security/security-audit-reporter",
+      "description": "Generate comprehensive security audit reports",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-headers-analyzer",
+      "source": "./plugins/security/security-headers-analyzer",
+      "description": "Analyze HTTP security headers",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-incident-responder",
+      "source": "./plugins/security/security-incident-responder",
+      "description": "Assist with security incident response",
+      "version": "1.32.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-misconfiguration-finder",
+      "source": "./plugins/security/security-misconfiguration-finder",
+      "description": "Find security misconfigurations",
+      "version": "1.29.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-pro-pack",
+      "source": "./plugins/packages/security-pro-pack",
+      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
+      "version": "1.31.0",
+      "category": "packages",
+      "keywords": [
+        "security",
+        "vulnerability-scanning",
+        "compliance",
+        "HIPAA",
+        "PCI-DSS",
+        "GDPR",
+        "SOC2",
+        "cryptography",
+        "devsecops",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pluginCount": 10,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-test-scanner",
+      "source": "./plugins/testing/security-test-scanner",
+      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
+      "version": "1.29.0",
+      "category": "testing",
+      "keywords": ["testing", "security", "vulnerabilities", "owasp", "penetration-testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sentiment-analysis-tool",
+      "source": "./plugins/ai-ml/sentiment-analysis-tool",
+      "description": "Sentiment analysis on text data",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": ["sentiment", "opinion", "emotion", "polarity", "nlp"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "service-mesh-configurator",
+      "source": "./plugins/devops/service-mesh-configurator",
+      "description": "Configure service mesh (Istio, Linkerd) for microservices",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": ["service-mesh", "istio", "linkerd", "microservices", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "session-security-checker",
+      "source": "./plugins/security/session-security-checker",
+      "description": "Check session security implementation",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-plugin-tool",
+      "source": "./plugins/examples/jeremy-plugin-tool",
+      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
+      "version": "2.19.0",
+      "category": "examples",
+      "keywords": [
+        "skills",
+        "agent-skills",
+        "plugin-management",
+        "marketplace",
+        "validation",
+        "audit",
+        "versioning",
+        "meta-plugin",
+        "repository-tools"
+      ],
+      "author": {
+        "name": "Claude Code Plugins",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sla-sli-tracker",
+      "source": "./plugins/performance/sla-sli-tracker",
+      "description": "Track SLAs, SLIs, and SLOs for service reliability",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["sla", "sli", "slo", "sre", "reliability"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "smoke-test-runner",
+      "source": "./plugins/testing/smoke-test-runner",
+      "description": "Quick smoke test suites to verify critical functionality after deployments",
+      "version": "1.20.0",
+      "category": "testing",
+      "keywords": ["testing", "smoke-tests", "deployment", "sanity-check", "critical-path"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "snapshot-test-manager",
+      "source": "./plugins/testing/snapshot-test-manager",
+      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": ["testing", "snapshot", "jest", "vitest", "diff-analysis", "test-management"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "soc2-audit-helper",
+      "source": "./plugins/security/soc2-audit-helper",
+      "description": "Assist with SOC2 audit preparation",
+      "version": "1.30.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sow-generator",
+      "source": "./plugins/ai-agency/sow-generator",
+      "description": "Generate professional Statements of Work for AI projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": ["sow", "statement of work", "contract", "proposal", "agency", "ai-agency"],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "sql-injection-detector",
+      "source": "./plugins/security/sql-injection-detector",
+      "description": "Detect SQL injection vulnerabilities",
+      "version": "1.31.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sql-query-optimizer",
+      "source": "./plugins/database/sql-query-optimizer",
+      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": ["sql", "optimization", "performance", "database", "query"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ssl-certificate-manager",
+      "source": "./plugins/security/ssl-certificate-manager",
+      "description": "Manage and monitor SSL/TLS certificates",
+      "version": "1.21.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "staking-rewards-optimizer",
+      "source": "./plugins/crypto/staking-rewards-optimizer",
+      "description": "Optimize staking rewards across multiple protocols and chains",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": ["crypto", "staking", "defi", "yield", "optimization", "rewards"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 82,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "stored-procedure-generator",
+      "source": "./plugins/database/stored-procedure-generator",
+      "description": "Database plugin for stored-procedure-generator",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": ["database", "backend", "procedure"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 76,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-firestore",
+      "source": "./plugins/community/jeremy-firestore",
+      "description": "Firestore database specialist for schema design, queries, and real-time sync",
+      "version": "2.20.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "firestore",
+        "database",
+        "crud",
+        "security-rules",
+        "cloud-functions",
+        "batch-operations",
+        "data-migration",
+        "performance",
+        "cost-optimization",
+        "nosql",
+        "google-cloud",
+        "a2a",
+        "agent-to-agent",
+        "mcp",
+        "cloud-run",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]",
+        "url": "https://intentsolutions.io"
+      },
+      "featured": true,
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sugar",
+      "source": "./plugins/devops/sugar",
+      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
+      "version": "2.0.0",
+      "category": "devops",
+      "keywords": [
+        "autonomous",
+        "development",
+        "ai",
+        "task-management",
+        "automation",
+        "agents",
+        "enterprise",
+        "workflow",
+        "productivity",
+        "mcp"
+      ],
+      "author": {
+        "name": "Steven Leggett",
+        "email": "contact@roboticforce.io"
+      },
+      "featured": true,
+      "mcpTools": 7,
+      "repository": "https://github.com/cdnsteve/sugar",
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "synthetic-monitoring-setup",
+      "source": "./plugins/performance/synthetic-monitoring-setup",
+      "description": "Set up synthetic monitoring for proactive performance tracking",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": ["synthetic-monitoring", "uptime", "performance", "testing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "terraform-module-builder",
+      "source": "./plugins/devops/terraform-module-builder",
+      "description": "Build reusable Terraform modules",
+      "version": "1.23.0",
+      "category": "devops",
+      "keywords": ["terraform", "iac", "modules", "infrastructure", "devops"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-coverage-analyzer",
+      "source": "./plugins/testing/test-coverage-analyzer",
+      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": ["testing", "coverage", "code-coverage", "metrics", "analysis"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-data-generator",
+      "source": "./plugins/testing/test-data-generator",
+      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": ["testing", "test-data", "fake-data", "fixtures", "factory"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-doubles-generator",
+      "source": "./plugins/testing/test-doubles-generator",
+      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": ["testing", "mocks", "stubs", "spies", "fakes", "test-doubles", "jest", "sinon"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-environment-manager",
+      "source": "./plugins/testing/test-environment-manager",
+      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "environment",
+        "docker",
+        "testcontainers",
+        "isolation",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-orchestrator",
+      "source": "./plugins/testing/test-orchestrator",
+      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": ["testing", "orchestration", "workflow", "parallel", "test-selection", "ci-cd"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-report-generator",
+      "source": "./plugins/testing/test-report-generator",
+      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
+      "version": "1.23.0",
+      "category": "testing",
+      "keywords": ["testing", "reporting", "coverage", "metrics", "dashboard", "ci-cd"],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "throughput-analyzer",
+      "source": "./plugins/performance/throughput-analyzer",
+      "description": "Analyze and optimize system throughput",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": ["throughput", "performance", "capacity", "optimization"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "time-series-forecaster",
+      "source": "./plugins/ai-ml/time-series-forecaster",
+      "description": "Time series forecasting and analysis",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": ["time-series", "forecasting", "arima", "prophet", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "token-launch-tracker",
+      "source": "./plugins/crypto/token-launch-tracker",
+      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "token-launch",
+        "rugpull",
+        "security",
+        "scam-detection",
+        "contract-analysis",
+        "defi",
+        "new-tokens"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "trading-strategy-backtester",
+      "source": "./plugins/crypto/trading-strategy-backtester",
+      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": ["trading", "backtesting", "strategy", "historical", "performance", "risk"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 82,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "transfer-learning-adapter",
+      "source": "./plugins/ai-ml/transfer-learning-adapter",
+      "description": "Transfer learning adaptation",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": ["transfer-learning", "fine-tuning", "pretrained", "adapters", "ml"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "travel-assistant",
+      "source": "./plugins/productivity/travel-assistant",
+      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
+      "version": "1.15.0",
+      "category": "productivity",
+      "keywords": [
+        "travel",
+        "weather",
+        "currency",
+        "timezone",
+        "itinerary",
+        "vacation",
+        "trip-planning",
+        "ai-travel",
+        "real-time",
+        "api-integration",
+        "budget",
+        "packing-list"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "commands": 6,
+        "agents": 4,
+        "hooks": 2,
+        "scripts": 3,
+        "total": 15
+      }
+    },
+    {
+      "name": "unit-test-generator",
+      "source": "./plugins/testing/unit-test-generator",
+      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": ["testing", "unit-tests", "test-generation", "jest", "pytest", "mocha", "junit"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "visual-regression-tester",
+      "source": "./plugins/testing/visual-regression-tester",
+      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "visual-regression",
+        "ui-testing",
+        "percy",
+        "chromatic",
+        "backstop",
+        "screenshot-testing"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "vulnerability-scanner",
+      "source": "./plugins/security/vulnerability-scanner",
+      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "vulnerability", "scanning", "cve", "sast"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wallet-portfolio-tracker",
+      "source": "./plugins/crypto/wallet-portfolio-tracker",
+      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
+      "version": "1.12.0",
+      "category": "crypto",
+      "keywords": ["wallet", "portfolio", "tracking", "blockchain", "defi", "crypto"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "web-to-github-issue",
+      "source": "./plugins/skill-enhancers/web-to-github-issue",
+      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
+      "version": "1.27.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "web-search",
+        "github",
+        "automation",
+        "research",
+        "issue-tracking",
+        "skill-enhancer",
+        "productivity",
+        "workflow"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "webhook-handler-creator",
+      "source": "./plugins/api-development/webhook-handler-creator",
+      "description": "Create secure webhook endpoints with signature verification and retry logic",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": ["webhook", "events", "signature", "security"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "websocket-server-builder",
+      "source": "./plugins/api-development/websocket-server-builder",
+      "description": "Build WebSocket servers for real-time bidirectional communication",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": ["websocket", "real-time", "socket.io", "ws"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "whale-alert-monitor",
+      "source": "./plugins/crypto/whale-alert-monitor",
+      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": ["whale", "alert", "monitor", "large", "transactions"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "workflow-orchestrator",
+      "source": "./plugins/mcp/workflow-orchestrator",
+      "description": "DAG-based workflow automation with parallel task execution and dependency management",
+      "version": "1.15.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "workflow",
+        "dag",
+        "automation",
+        "orchestration",
+        "cicd",
+        "parallel-execution"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 4,
+      "zcf_metadata": {
+        "preset_id": "workflow-orchestrator",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "automation"
+      }
+    },
+    {
+      "name": "xss-vulnerability-scanner",
+      "source": "./plugins/security/xss-vulnerability-scanner",
+      "description": "Scan for XSS vulnerabilities",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": ["security", "compliance", "auditing"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "zapier-zap-builder",
+      "source": "./plugins/ai-agency/zapier-zap-builder",
+      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
+      "version": "1.10.0",
+      "category": "ai-agency",
+      "keywords": ["zapier", "zap", "automation", "integration", "workflow", "ai-agency"],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "jeremy-genkit-pro",
+      "source": "./plugins/ai-ml/jeremy-genkit-pro",
+      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
+      "version": "2.26.0",
+      "category": "ai-ml",
+      "keywords": ["firebase", "genkit", "ai-flows", "rag", "monitoring", "gemini", "vertex-ai"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 1,
+        "commands": 1,
+        "skills": 1
+      },
+      "verification": {
+        "score": 92,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -621,84 +5103,17 @@
       }
     },
     {
-      "name": "jeremy-adk-software-engineer",
-      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
-      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
-      "version": "2.19.0",
+      "name": "jeremy-vertex-validator",
+      "source": "./plugins/ai-ml/jeremy-vertex-validator",
+      "description": "Production readiness validator for Vertex AI deployments and configurations",
+      "version": "2.22.0",
       "category": "ai-ml",
-      "keywords": [
-        "adk",
-        "software-engineer",
-        "agent-development",
-        "vertex-ai"
-      ],
+      "keywords": ["vertex-ai", "validation", "production-readiness", "security", "compliance"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-gcp-starter-examples",
-      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
-      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
-      "version": "2.25.0",
-      "category": "ai-ml",
-      "keywords": [
-        "google-cloud",
-        "adk-samples",
-        "genkit-examples",
-        "vertex-ai",
-        "agent-starter-pack",
-        "code-examples",
-        "starter-kits",
-        "templates"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 1,
-        "skills": 1
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-genkit-pro",
-      "source": "./plugins/ai-ml/jeremy-genkit-pro",
-      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
-      "version": "2.26.0",
-      "category": "ai-ml",
-      "keywords": [
-        "firebase",
-        "genkit",
-        "ai-flows",
-        "rag",
-        "monitoring",
-        "gemini",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 1,
-        "commands": 1,
         "skills": 1
       },
       "verification": {
@@ -711,7 +5126,7 @@
     {
       "name": "jeremy-google-adk",
       "source": "./plugins/ai-ml/jeremy-google-adk",
-      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+      "description": "Google Agent Development Kit (ADK) starter for building production AI agents \u2014 ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
       "version": "2.2.0",
       "category": "ai-ml",
       "keywords": [
@@ -758,6 +5173,69 @@
       }
     },
     {
+      "name": "jeremy-genkit-terraform",
+      "source": "./plugins/devops/jeremy-genkit-terraform",
+      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
+      "version": "2.21.0",
+      "category": "devops",
+      "keywords": ["terraform", "genkit", "firebase", "cloud-run", "infrastructure"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-adk-terraform",
+      "source": "./plugins/devops/jeremy-adk-terraform",
+      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
+      "version": "2.22.0",
+      "category": "devops",
+      "keywords": ["terraform", "adk", "agent-engine", "vertex-ai", "infrastructure", "vpc-sc"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-vertex-terraform",
+      "source": "./plugins/devops/jeremy-vertex-terraform",
+      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
+      "version": "2.22.0",
+      "category": "devops",
+      "keywords": ["terraform", "vertex-ai", "gemini", "model-garden", "infrastructure"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "jeremy-vertex-engine",
       "source": "./plugins/ai-ml/jeremy-vertex-engine",
       "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
@@ -787,73 +5265,28 @@
       }
     },
     {
-      "name": "jeremy-vertex-validator",
-      "source": "./plugins/ai-ml/jeremy-vertex-validator",
-      "description": "Production readiness validator for Vertex AI deployments and configurations",
-      "version": "2.22.0",
+      "name": "jeremy-gcp-starter-examples",
+      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
+      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
+      "version": "2.25.0",
       "category": "ai-ml",
       "keywords": [
+        "google-cloud",
+        "adk-samples",
+        "genkit-examples",
         "vertex-ai",
-        "validation",
-        "production-readiness",
-        "security",
-        "compliance"
+        "agent-starter-pack",
+        "code-examples",
+        "starter-kits",
+        "templates"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "components": {
+        "agents": 1,
         "skills": 1
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "local-tts",
-      "source": "./plugins/ai-ml/local-tts",
-      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
-      "version": "1.3.0",
-      "category": "ai-ml",
-      "keywords": [
-        "tts",
-        "text-to-speech",
-        "voice",
-        "voice-cloning",
-        "voice-design",
-        "offline",
-        "voxcpm",
-        "apple-silicon",
-        "audio",
-        "narration"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "Apache-2.0",
-      "repository": "https://github.com/vdk888/local-tts"
-    },
-    {
-      "name": "ml-model-trainer",
-      "source": "./plugins/ai-ml/ml-model-trainer",
-      "description": "Train and optimize machine learning models with automated workflows",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "ml",
-        "machine-learning",
-        "training",
-        "models",
-        "ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
       },
       "verification": {
         "score": 93,
@@ -863,21 +5296,33 @@
       }
     },
     {
-      "name": "model-deployment-helper",
-      "source": "./plugins/ai-ml/model-deployment-helper",
-      "description": "Deploy ML models to production",
-      "version": "1.19.0",
-      "category": "ai-ml",
+      "name": "jeremy-github-actions-gcp",
+      "source": "./plugins/devops/jeremy-github-actions-gcp",
+      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
+      "version": "2.27.0",
+      "category": "devops",
       "keywords": [
+        "github-actions",
+        "google-cloud",
+        "workload-identity-federation",
+        "wif",
+        "vertex-ai",
+        "agent-engine",
         "deployment",
-        "serving",
-        "production",
-        "api",
-        "mlops"
+        "ci-cd",
+        "security",
+        "best-practices",
+        "oidc",
+        "iam"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 1,
+        "skills": 1,
+        "hooks": 1
       },
       "verification": {
         "score": 93,
@@ -887,150 +5332,97 @@
       }
     },
     {
-      "name": "model-evaluation-suite",
-      "source": "./plugins/ai-ml/model-evaluation-suite",
-      "description": "Comprehensive model evaluation with multiple metrics",
-      "version": "1.22.0",
-      "category": "ai-ml",
+      "name": "prettier-markdown-hook",
+      "source": "./plugins/productivity/prettier-markdown-hook",
+      "description": "Automatically format markdown files with prettier when Claude stops responding, with configurable organization and path exclusions",
+      "version": "1.8.0",
+      "category": "productivity",
       "keywords": [
-        "evaluation",
-        "metrics",
+        "prettier",
+        "markdown",
+        "formatting",
+        "automation",
+        "hook",
+        "stop",
+        "git",
+        "conventional-commits"
+      ],
+      "author": {
+        "name": "Terry Li",
+        "email": "[email protected]",
+        "url": "https://github.com/terrylica"
+      },
+      "components": {
+        "hooks": 1,
+        "total": 1
+      }
+    },
+    {
+      "name": "axiom",
+      "source": "./plugins/skill-enhancers/axiom",
+      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
+      "version": "0.3.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "ios",
+        "debugging",
+        "swift",
+        "persistence",
         "testing",
-        "validation",
-        "ml"
+        "performance",
+        "xcode",
+        "concurrency",
+        "database",
+        "swiftdata",
+        "grdb",
+        "liquid-glass",
+        "swiftui"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "Charles Wiltgen",
+        "url": "https://github.com/CharlesWiltgen"
       },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
+      "components": {
+        "skills": 13,
+        "total": 13
       }
     },
     {
-      "name": "model-explainability-tool",
-      "source": "./plugins/ai-ml/model-explainability-tool",
-      "description": "Model interpretability and explainability",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "explainability",
-        "shap",
-        "lime",
-        "interpretability",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "model-versioning-tracker",
-      "source": "./plugins/ai-ml/model-versioning-tracker",
-      "description": "Track and manage model versions",
-      "version": "1.24.0",
-      "category": "ai-ml",
-      "keywords": [
-        "versioning",
-        "mlflow",
-        "tracking",
-        "registry",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "neural-network-builder",
-      "source": "./plugins/ai-ml/neural-network-builder",
-      "description": "Build and configure neural network architectures",
-      "version": "1.20.0",
-      "category": "ai-ml",
-      "keywords": [
-        "neural-networks",
-        "deep-learning",
-        "architecture",
-        "pytorch",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "nlp-text-analyzer",
-      "source": "./plugins/ai-ml/nlp-text-analyzer",
-      "description": "Natural language processing and text analysis",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "nlp",
-        "text",
-        "analysis",
-        "tokenization",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ollama-local-ai",
-      "source": "./plugins/ai-ml/ollama-local-ai",
-      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
-      "version": "1.18.0",
-      "category": "ai-ml",
-      "keywords": [
-        "ollama",
-        "local-llm",
-        "free-ai",
-        "self-hosted",
-        "llama",
-        "mistral",
-        "privacy",
-        "zero-cost",
-        "openai-alternative"
-      ],
+      "name": "skill-creator",
+      "source": "./plugins/skill-enhancers/skill-creator",
+      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
+      "version": "5.20.0",
+      "category": "skill-enhancers",
+      "keywords": ["skill-creation", "validation", "meta-tooling", "grading", "anthropic-spec"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
+      "featured": true,
+      "pluginCount": 1,
       "components": {
         "skills": 1,
-        "commands": 1,
-        "total": 2
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "claude-never-forgets",
+      "source": "./plugins/community/claude-never-forgets",
+      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "version": "1.21.0",
+      "category": "community",
+      "keywords": ["memory", "context", "persistent", "preferences", "sessions", "recall"],
+      "author": {
+        "name": "yldrmahmet",
+        "url": "https://github.com/yldrmahmet"
+      },
+      "components": {
+        "hooks": 4,
+        "commands": 3,
+        "skills": 1,
+        "total": 8
       },
       "verification": {
         "score": 92,
@@ -1040,813 +5432,220 @@
       }
     },
     {
-      "name": "recommendation-engine",
-      "source": "./plugins/ai-ml/recommendation-engine",
-      "description": "Build recommendation systems and engines",
-      "version": "1.21.0",
-      "category": "ai-ml",
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
+      "version": "1.13.0",
+      "category": "community",
       "keywords": [
-        "recommendations",
-        "collaborative",
-        "content-based",
-        "ranking",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "regression-analysis-tool",
-      "source": "./plugins/ai-ml/regression-analysis-tool",
-      "description": "Regression analysis and modeling",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "regression",
-        "prediction",
-        "linear",
-        "polynomial",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sentiment-analysis-tool",
-      "source": "./plugins/ai-ml/sentiment-analysis-tool",
-      "description": "Sentiment analysis on text data",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "sentiment",
-        "opinion",
-        "emotion",
-        "polarity",
-        "nlp"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "time-series-forecaster",
-      "source": "./plugins/ai-ml/time-series-forecaster",
-      "description": "Time series forecasting and analysis",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "time-series",
-        "forecasting",
-        "arima",
-        "prophet",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "transfer-learning-adapter",
-      "source": "./plugins/ai-ml/transfer-learning-adapter",
-      "description": "Transfer learning adaptation",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "transfer-learning",
-        "fine-tuning",
-        "pretrained",
-        "adapters",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "web-analytics",
-      "source": "./plugins/analytics/web-analytics",
-      "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
-      "version": "1.4.0",
-      "category": "analytics",
-      "keywords": [
-        "analytics",
-        "umami",
-        "ga4",
-        "traffic",
-        "mcp",
-        "self-hosted",
+        "orchestration",
         "multi-agent",
-        "push-based"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 9
-      },
-      "verification": {
-        "score": 85,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-05-20T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-authentication-builder",
-      "source": "./plugins/api-development/api-authentication-builder",
-      "description": "Build authentication systems with JWT, OAuth2, and API keys",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "authentication",
-        "jwt",
-        "oauth",
-        "security"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-batch-processor",
-      "source": "./plugins/api-development/api-batch-processor",
-      "description": "Implement batch API operations with bulk processing and job queues",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "batch",
-        "bulk",
-        "queue",
-        "job-processing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-cache-manager",
-      "source": "./plugins/api-development/api-cache-manager",
-      "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "caching",
-        "redis",
-        "cdn",
-        "performance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-contract-generator",
-      "source": "./plugins/api-development/api-contract-generator",
-      "description": "Generate API contracts for consumer-driven contract testing",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "contract",
-        "pact",
-        "testing",
-        "microservices"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-documentation-generator",
-      "source": "./plugins/api-development/api-documentation-generator",
-      "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
-      "version": "1.27.0",
-      "category": "api-development",
-      "keywords": [
-        "api",
-        "documentation",
-        "openapi",
-        "swagger",
-        "docs"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-error-handler",
-      "source": "./plugins/api-development/api-error-handler",
-      "description": "Implement standardized error handling with proper HTTP status codes",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "error-handling",
-        "api",
-        "http-status",
-        "exceptions"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-event-emitter",
-      "source": "./plugins/api-development/api-event-emitter",
-      "description": "Implement event-driven APIs with message queues and event streaming",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "events",
-        "messaging",
-        "kafka",
-        "rabbitmq",
-        "event-driven"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-gateway-builder",
-      "source": "./plugins/api-development/api-gateway-builder",
-      "description": "Build API gateway with routing, authentication, and rate limiting",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "api-gateway",
-        "routing",
-        "proxy",
-        "microservices"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-load-tester",
-      "source": "./plugins/api-development/api-load-tester",
-      "description": "Load test APIs with k6, Gatling, or Artillery",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "load-testing",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "research",
+        "games",
+        "accessibility",
         "performance",
-        "k6",
-        "stress-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-migration-tool",
-      "source": "./plugins/api-development/api-migration-tool",
-      "description": "Migrate APIs between versions with backward compatibility",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "migration",
-        "versioning",
-        "api",
-        "backward-compatibility"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-mock-server",
-      "source": "./plugins/api-development/api-mock-server",
-      "description": "Create mock API servers from OpenAPI specs for testing",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "mock",
-        "testing",
-        "openapi",
-        "stub"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-monitoring-dashboard",
-      "source": "./plugins/api-development/api-monitoring-dashboard",
-      "description": "Create monitoring dashboards for API health, metrics, and alerts",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "monitoring",
-        "metrics",
-        "observability",
-        "dashboard"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-rate-limiter",
-      "source": "./plugins/api-development/api-rate-limiter",
-      "description": "Implement rate limiting with token bucket, sliding window, and Redis",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "rate-limiting",
-        "throttling",
-        "api",
-        "redis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-request-logger",
-      "source": "./plugins/api-development/api-request-logger",
-      "description": "Log API requests with structured logging and correlation IDs",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "logging",
-        "observability",
-        "audit",
-        "correlation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-response-validator",
-      "source": "./plugins/api-development/api-response-validator",
-      "description": "Validate API responses against schemas and contracts",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "validation",
-        "schema",
-        "testing",
-        "api"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-schema-validator",
-      "source": "./plugins/api-development/api-schema-validator",
-      "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "schema",
-        "validation",
-        "json-schema",
-        "joi",
-        "zod"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-sdk-generator",
-      "source": "./plugins/api-development/api-sdk-generator",
-      "description": "Generate client SDKs from OpenAPI specs for multiple languages",
-      "version": "1.22.0",
-      "category": "api-development",
-      "keywords": [
-        "sdk",
-        "client",
-        "openapi",
-        "codegen"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-security-scanner",
-      "source": "./plugins/api-development/api-security-scanner",
-      "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "security",
-        "api",
-        "owasp",
-        "vulnerability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-throttling-manager",
-      "source": "./plugins/api-development/api-throttling-manager",
-      "description": "Manage API throttling with dynamic rate limits and quota management",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "throttling",
-        "rate-limiting",
-        "quota",
-        "traffic-management"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-versioning-manager",
-      "source": "./plugins/api-development/api-versioning-manager",
-      "description": "Manage API versions with migration strategies and backward compatibility",
-      "version": "1.26.0",
-      "category": "api-development",
-      "keywords": [
-        "api",
-        "versioning",
-        "migration",
-        "backward-compatibility"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "graphql-server-builder",
-      "source": "./plugins/api-development/graphql-server-builder",
-      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
-      "version": "1.22.0",
-      "category": "api-development",
-      "keywords": [
-        "graphql",
-        "api",
-        "server",
-        "apollo",
-        "schema",
-        "resolvers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "grpc-service-generator",
-      "source": "./plugins/api-development/grpc-service-generator",
-      "description": "Generate gRPC services with Protocol Buffers and streaming support",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "grpc",
-        "protobuf",
-        "microservices",
-        "streaming"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "rest-api-generator",
-      "source": "./plugins/api-development/rest-api-generator",
-      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "api",
-        "rest",
-        "generator",
-        "openapi",
-        "swagger",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "webhook-handler-creator",
-      "source": "./plugins/api-development/webhook-handler-creator",
-      "description": "Create secure webhook endpoints with signature verification and retry logic",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "webhook",
-        "events",
-        "signature",
-        "security"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "websocket-server-builder",
-      "source": "./plugins/api-development/websocket-server-builder",
-      "description": "Build WebSocket servers for real-time bidirectional communication",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "websocket",
-        "real-time",
-        "socket.io",
-        "ws"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "x-twitter-scraper",
-      "source": "./plugins/api-development/x-twitter-scraper",
-      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
-      "version": "0.1.0",
-      "category": "api-development",
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
-      "license": "MIT"
-    },
-    {
-      "name": "brand-strategy-framework",
-      "source": "./plugins/business-tools/brand-strategy-framework",
-      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
-      "version": "1.7.0",
-      "category": "business-tools",
-      "keywords": [
-        "brand-strategy",
-        "marketing",
-        "branding",
-        "positioning",
-        "messaging",
-        "brand-guidelines",
-        "audience-architecture",
-        "brand-identity"
-      ],
-      "author": {
-        "name": "Rowan Brooks",
-        "email": "rowanbrooks100@github.com"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "excel-analyst-pro",
-      "source": "./plugins/business-tools/excel-analyst-pro",
-      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
-      "version": "1.21.0",
-      "category": "business-tools",
-      "keywords": [
-        "excel",
-        "financial-modeling",
-        "dcf",
-        "lbo",
-        "valuation",
-        "variance-analysis",
-        "pivot-tables",
-        "investment-banking",
-        "private-equity",
-        "financial-analysis",
-        "skills",
+        "flask",
+        "react",
+        "godot",
+        "corpus-linguistics",
         "mcp"
       ],
       "author": {
-        "name": "ClaudeCodePlugins",
-        "email": "plugins@tonsofskills.com"
+        "name": "Luke Steuber",
+        "url": "https://github.com/lukeslp"
       },
-      "featured": true,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
       "components": {
+        "agents": 51,
+        "total": 51
+      }
+    },
+    {
+      "name": "sprint",
+      "source": "./plugins/community/sprint",
+      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
+      "version": "1.20.0",
+      "category": "community",
+      "keywords": [
+        "autonomous",
+        "agentic",
+        "yolo",
+        "self-iterating",
+        "multi-agent",
+        "hands-off",
+        "auto-pilot",
+        "orchestration",
+        "sprint",
+        "testing",
+        "qa",
+        "mcp"
+      ],
+      "author": {
+        "name": "Damien Laine",
+        "email": "damien.laine@gmail.com",
+        "url": "https://github.com/damienlaine"
+      },
+      "components": {
+        "agents": 9,
+        "commands": 6,
         "skills": 4,
+        "total": 19
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "vibe-guide",
+      "source": "./plugins/productivity/vibe-guide",
+      "description": "Non-technical progress summaries for Claude Code work (hides diffs/log noise).",
+      "version": "1.16.0",
+      "category": "productivity",
+      "keywords": [
+        "ux",
+        "accessibility",
+        "explain",
+        "pairing",
+        "non-technical",
+        "beginner-friendly",
+        "explanations",
+        "noise-filtering"
+      ],
+      "author": {
+        "name": "Intent Solutions",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 3,
+        "commands": 7,
+        "hooks": 1,
+        "total": 11
+      },
+      "tags": ["beginner-friendly", "explanations", "noise-filtering"],
+      "strict": true
+    },
+    {
+      "name": "jeremy-adk-software-engineer",
+      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
+      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
+      "version": "2.19.0",
+      "category": "ai-ml",
+      "keywords": ["adk", "software-engineer", "agent-development", "vertex-ai"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "mcp",
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "geepers",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Luke Steuber"
+      },
+      "homepage": "https://dr.eamer.dev/geepers/",
+      "repository": "https://github.com/lukeslp/geepers",
+      "components": {
+        "agents": 51
+      }
+    },
+    {
+      "name": "jeremy-firebase",
+      "source": "./plugins/community/jeremy-firebase",
+      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
+      "version": "2.23.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "vertex-ai",
+        "gemini",
+        "authentication",
+        "storage",
+        "hosting",
+        "cloud-functions",
+        "analytics",
+        "ai-integration",
+        "google-cloud",
+        "embeddings",
+        "model-deployment",
+        "ai-powered",
+        "production-ready"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wallet-security-auditor",
+      "source": "./plugins/crypto/wallet-security-auditor",
+      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
+      "version": "1.17.0",
+      "category": "crypto",
+      "keywords": ["crypto", "wallet", "security", "audit", "web3"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mattyp-changelog",
+      "source": "./plugins/devops/mattyp-changelog",
+      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
+      "version": "0.3.0",
+      "category": "devops",
+      "keywords": ["changelog", "release-notes", "weekly-update", "git", "github", "automation"],
+      "author": {
+        "name": "Mattyp",
+        "email": "mattyp@tonsofskills.com",
+        "url": "https://tonsofskills.com"
+      },
+      "components": {
+        "skills": 1,
         "commands": 3
       },
       "verification": {
@@ -1857,90 +5656,1538 @@
       }
     },
     {
-      "name": "executive-assistant-skills",
-      "source": "./plugins/business-tools/executive-assistant-skills",
-      "version": "1.8.0",
-      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
-      "author": {
-        "name": "Martin Gontovnikas",
-        "email": "gonto@hypergrowthpartners.com",
-        "url": "https://github.com/mgonto"
-      },
-      "category": "business-tools",
+      "name": "supabase-pack",
+      "source": "./plugins/saas-packs/supabase-pack",
+      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.53.0",
+      "category": "saas-packs",
       "keywords": [
-        "executive-assistant",
-        "meeting-prep",
-        "email",
-        "productivity",
-        "automation",
-        "todoist"
-      ],
-      "license": "MIT",
-      "repository": "https://github.com/mgonto/executive-assistant-skills",
-      "featured": true,
-      "components": {
-        "skills": 5
-      }
-    },
-    {
-      "name": "openbb-terminal",
-      "source": "./plugins/business-tools/openbb-terminal",
-      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
-      "version": "1.6.0",
-      "category": "business-tools",
-      "keywords": [
-        "finance",
-        "investment",
-        "openbb",
-        "stocks",
-        "crypto",
-        "portfolio",
-        "trading",
-        "financial-analysis",
-        "market-data",
-        "equity-research",
-        "options",
-        "forex",
-        "macroeconomics",
-        "quant",
-        "ai-finance"
+        "supabase",
+        "postgres",
+        "database",
+        "authentication",
+        "realtime",
+        "storage",
+        "edge-functions",
+        "rls",
+        "row-level-security",
+        "baas",
+        "backend-as-a-service",
+        "firebase-alternative"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
       },
-      "featured": true,
       "components": {
-        "commands": 6,
-        "agents": 4,
-        "total": 10
+        "skills": 30
+      },
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
-      "name": "promptbook",
-      "source": "./plugins/business-tools/promptbook",
-      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
-      "version": "1.4.0",
-      "category": "business-tools",
+      "name": "vercel-pack",
+      "source": "./plugins/saas-packs/vercel-pack",
+      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
       "keywords": [
-        "analytics",
-        "telemetry",
-        "builds",
-        "portfolio",
-        "tracking",
-        "metrics",
-        "sessions"
+        "vercel",
+        "deployment",
+        "edge-functions",
+        "serverless",
+        "preview",
+        "ci-cd",
+        "hosting",
+        "next-js",
+        "jamstack",
+        "frontend-cloud"
       ],
       "author": {
-        "name": "Promptbook",
-        "email": "contact@promptbook.gg"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
       },
-      "homepage": "https://promptbook.gg",
-      "repository": "https://github.com/promptbookgg/claude-code-plugin",
-      "license": "MIT",
       "components": {
-        "skills": 2,
-        "hooks": 4
+        "skills": 30
+      },
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "clay-pack",
+      "source": "./plugins/saas-packs/clay-pack",
+      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clay",
+        "data-enrichment",
+        "waterfall",
+        "gtm",
+        "sales-ops",
+        "lead-enrichment",
+        "ai-agents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cursor-pack",
+      "source": "./plugins/saas-packs/cursor-pack",
+      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "cursor",
+        "ai-editor",
+        "code-editor",
+        "composer",
+        "ai-coding",
+        "vscode-fork",
+        "copilot-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "exa-pack",
+      "source": "./plugins/saas-packs/exa-pack",
+      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "exa",
+        "neural-search",
+        "semantic-search",
+        "web-search",
+        "ai-search",
+        "retrieval",
+        "embeddings"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "firecrawl-pack",
+      "source": "./plugins/saas-packs/firecrawl-pack",
+      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "firecrawl",
+        "web-scraping",
+        "crawling",
+        "markdown",
+        "llm-ready",
+        "data-extraction",
+        "scraper"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "klingai-pack",
+      "source": "./plugins/saas-packs/klingai-pack",
+      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "klingai",
+        "kling",
+        "video-generation",
+        "text-to-video",
+        "ai-video",
+        "generative-ai",
+        "creative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "openrouter-pack",
+      "source": "./plugins/saas-packs/openrouter-pack",
+      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
+      "version": "1.20.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openrouter",
+        "llm-routing",
+        "model-selection",
+        "ai-gateway",
+        "multi-model",
+        "cost-optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "perplexity-pack",
+      "source": "./plugins/saas-packs/perplexity-pack",
+      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "perplexity",
+        "ai-search",
+        "research",
+        "citations",
+        "real-time",
+        "knowledge",
+        "answers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "replit-pack",
+      "source": "./plugins/saas-packs/replit-pack",
+      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "replit",
+        "cloud-ide",
+        "deployments",
+        "collaborative",
+        "ai-coding",
+        "browser-ide",
+        "hosting"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "retellai-pack",
+      "source": "./plugins/saas-packs/retellai-pack",
+      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
+      "version": "1.9.0",
+      "category": "saas-packs",
+      "keywords": [
+        "retellai",
+        "retell",
+        "voice-ai",
+        "phone-agents",
+        "conversational-ai",
+        "call-center",
+        "ivr"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sentry-pack",
+      "source": "./plugins/saas-packs/sentry-pack",
+      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
+      "version": "1.51.0",
+      "category": "saas-packs",
+      "keywords": [
+        "sentry",
+        "error-monitoring",
+        "performance",
+        "observability",
+        "debugging",
+        "crash-reporting",
+        "apm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "windsurf-pack",
+      "source": "./plugins/saas-packs/windsurf-pack",
+      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "windsurf",
+        "ai-editor",
+        "cascade",
+        "codeium",
+        "ai-coding",
+        "code-completion",
+        "refactoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "coderabbit-pack",
+      "source": "./plugins/saas-packs/coderabbit-pack",
+      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "coderabbit",
+        "code-review",
+        "pr-automation",
+        "ai-review",
+        "code-quality",
+        "github-integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "fireflies-pack",
+      "source": "./plugins/saas-packs/fireflies-pack",
+      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "fireflies",
+        "meeting-transcription",
+        "ai-notes",
+        "conversation-intelligence",
+        "summaries"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "groq-pack",
+      "source": "./plugins/saas-packs/groq-pack",
+      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "groq",
+        "lpu",
+        "fast-inference",
+        "llm",
+        "groq-cloud",
+        "low-latency",
+        "ai-acceleration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ideogram-pack",
+      "source": "./plugins/saas-packs/ideogram-pack",
+      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
+      "version": "1.10.0",
+      "category": "saas-packs",
+      "keywords": [
+        "ideogram",
+        "image-generation",
+        "text-to-image",
+        "ai-art",
+        "typography",
+        "creative",
+        "design"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "instantly-pack",
+      "source": "./plugins/saas-packs/instantly-pack",
+      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "instantly",
+        "cold-email",
+        "outreach",
+        "email-automation",
+        "lead-generation",
+        "sales"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "posthog-pack",
+      "source": "./plugins/saas-packs/posthog-pack",
+      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "posthog",
+        "product-analytics",
+        "feature-flags",
+        "session-replay",
+        "ab-testing",
+        "experimentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "vastai-pack",
+      "source": "./plugins/saas-packs/vastai-pack",
+      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vastai",
+        "vast-ai",
+        "gpu-marketplace",
+        "cloud-gpu",
+        "ml-infrastructure",
+        "compute",
+        "training"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "apollo-pack",
+      "source": "./plugins/saas-packs/apollo-pack",
+      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "apollo",
+        "sales",
+        "prospecting",
+        "sequences",
+        "outbound",
+        "crm",
+        "sales-engagement",
+        "lead-generation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 65,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "deepgram-pack",
+      "source": "./plugins/saas-packs/deepgram-pack",
+      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "deepgram",
+        "speech-to-text",
+        "transcription",
+        "voice",
+        "audio",
+        "asr",
+        "real-time",
+        "voice-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 65,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "juicebox-pack",
+      "source": "./plugins/saas-packs/juicebox-pack",
+      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
+      "version": "1.16.0",
+      "category": "saas-packs",
+      "keywords": [
+        "juicebox",
+        "people-data",
+        "enrichment",
+        "contacts",
+        "search",
+        "data-api",
+        "lead-enrichment"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 71,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "customerio-pack",
+      "source": "./plugins/saas-packs/customerio-pack",
+      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "customerio",
+        "customer-io",
+        "marketing",
+        "email",
+        "automation",
+        "campaigns",
+        "sms",
+        "push-notifications"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 68,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "langchain-py-pack",
+      "source": "./plugins/saas-packs/langchain-py-pack",
+      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
+      "version": "2.5.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langchain",
+        "langgraph",
+        "python",
+        "llm",
+        "agents",
+        "rag",
+        "checkpointing",
+        "streaming",
+        "middleware",
+        "langsmith"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 2
+      }
+    },
+    {
+      "name": "lindy-pack",
+      "source": "./plugins/saas-packs/lindy-pack",
+      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
+      "version": "1.15.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lindy",
+        "ai-assistant",
+        "automation",
+        "workflows",
+        "tasks",
+        "intelligent-automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 75,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "granola-pack",
+      "source": "./plugins/saas-packs/granola-pack",
+      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "granola",
+        "meeting-notes",
+        "transcription",
+        "summaries",
+        "meetings",
+        "ai-notes",
+        "meeting-intelligence"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 72,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ga4-pack",
+      "source": "./plugins/saas-packs/ga4-pack",
+      "description": "Claude Code skill pack for Google Analytics 4 \u2014 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+      "version": "1.2.0",
+      "category": "saas-packs",
+      "keywords": [
+        "google-analytics",
+        "ga4",
+        "analytics",
+        "data-api",
+        "bigquery",
+        "reporting",
+        "dau-mau",
+        "cohort-retention"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 5
+      },
+      "verification": {
+        "score": 70,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gamma-pack",
+      "source": "./plugins/saas-packs/gamma-pack",
+      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "gamma",
+        "presentations",
+        "documents",
+        "ai-generation",
+        "templates",
+        "slides",
+        "visual-content"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 71,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "clerk-pack",
+      "source": "./plugins/saas-packs/clerk-pack",
+      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clerk",
+        "authentication",
+        "auth",
+        "users",
+        "identity",
+        "sso",
+        "embeddable-ui",
+        "user-management"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "linear-pack",
+      "source": "./plugins/saas-packs/linear-pack",
+      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "linear",
+        "issues",
+        "project-management",
+        "tracking",
+        "workflows",
+        "agile",
+        "team-collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 67,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "databricks-pack",
+      "source": "./plugins/saas-packs/databricks-pack",
+      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
+      "version": "2.27.0",
+      "category": "saas-packs",
+      "keywords": [
+        "databricks",
+        "delta-lake",
+        "mlflow",
+        "spark",
+        "notebooks",
+        "clusters",
+        "data-engineering",
+        "lakehouse"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mistral-pack",
+      "source": "./plugins/saas-packs/mistral-pack",
+      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "mistral",
+        "llm",
+        "inference",
+        "embeddings",
+        "fine-tuning",
+        "ai",
+        "machine-learning"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 68,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "langfuse-pack",
+      "source": "./plugins/saas-packs/langfuse-pack",
+      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langfuse",
+        "observability",
+        "tracing",
+        "prompts",
+        "evaluation",
+        "llm-ops",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 67,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "obsidian-pack",
+      "source": "./plugins/saas-packs/obsidian-pack",
+      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "obsidian",
+        "notes",
+        "vault",
+        "plugins",
+        "markdown",
+        "knowledge-management",
+        "pkm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "documenso-pack",
+      "source": "./plugins/saas-packs/documenso-pack",
+      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "documenso",
+        "document-signing",
+        "e-signature",
+        "templates",
+        "workflows",
+        "contracts",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 66,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "evernote-pack",
+      "source": "./plugins/saas-packs/evernote-pack",
+      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "evernote",
+        "notes",
+        "notebooks",
+        "tags",
+        "search",
+        "productivity",
+        "organization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "guidewire-pack",
+      "source": "./plugins/saas-packs/guidewire-pack",
+      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
+      "version": "1.25.0",
+      "category": "saas-packs",
+      "keywords": [
+        "guidewire",
+        "insurance",
+        "policycenter",
+        "claimcenter",
+        "billingcenter",
+        "insurancesuite",
+        "enterprise"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 62,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "lokalise-pack",
+      "source": "./plugins/saas-packs/lokalise-pack",
+      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lokalise",
+        "translation",
+        "localization",
+        "i18n",
+        "l10n",
+        "tms",
+        "internationalization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "maintainx-pack",
+      "source": "./plugins/saas-packs/maintainx-pack",
+      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "maintainx",
+        "cmms",
+        "work-orders",
+        "maintenance",
+        "assets",
+        "facilities",
+        "operations"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "openevidence-pack",
+      "source": "./plugins/saas-packs/openevidence-pack",
+      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openevidence",
+        "medical-ai",
+        "clinical",
+        "healthcare",
+        "evidence-based",
+        "decision-support",
+        "medicine"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 66,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "speak-pack",
+      "source": "./plugins/saas-packs/speak-pack",
+      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "speak",
+        "language-learning",
+        "speech",
+        "ai-tutor",
+        "education",
+        "conversation",
+        "edtech"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 68,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "twinmind-pack",
+      "source": "./plugins/saas-packs/twinmind-pack",
+      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "twinmind",
+        "meetings",
+        "transcription",
+        "summaries",
+        "ai-assistant",
+        "productivity",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 66,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gastown",
+      "source": "./plugins/community/gastown",
+      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "multi-agent",
+        "orchestration",
+        "automation",
+        "polecats",
+        "convoys",
+        "beads",
+        "work-tracking",
+        "ai-factory",
+        "gastown",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      },
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "numman-ali/n-skills",
+        "source_path": "skills/tools/gastown"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "zai-cli",
+      "source": "./plugins/community/zai-cli",
+      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "vision",
+        "image-analysis",
+        "ocr",
+        "web-search",
+        "web-reader",
+        "github",
+        "mcp",
+        "z-ai",
+        "glm-4",
+        "multimodal"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      },
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "numman-ali/n-skills",
+        "source_path": "skills/tools/zai-cli"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "claude-reflect",
+      "source": "./plugins/community/claude-reflect",
+      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": [
+        "claude-code",
+        "self-learning",
+        "corrections",
+        "CLAUDE.md",
+        "memory",
+        "learnings",
+        "hooks",
+        "automation"
+      ],
+      "author": {
+        "name": "Bayram Annakov",
+        "url": "https://github.com/bayramannakov"
+      },
+      "repository": "https://github.com/bayramannakov/claude-reflect",
+      "components": {
+        "commands": 3,
+        "skills": 1,
+        "hooks": 2
+      }
+    },
+    {
+      "name": "contributing-clanker",
+      "source": "./plugins/community/contributing-clanker",
+      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
+      "version": "0.8.0",
+      "category": "community",
+      "keywords": [
+        "oss",
+        "contributions",
+        "github",
+        "ai-slop-prevention",
+        "code-review",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
+      "repository": "https://github.com/jeremylongshore/contributing-clanker",
+      "license": "MIT"
+    },
+    {
+      "name": "neurodivergent-visual-org",
+      "source": "./plugins/productivity/neurodivergent-visual-org",
+      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
+      "version": "3.10.0",
+      "category": "productivity",
+      "keywords": [
+        "neurodivergent",
+        "adhd",
+        "autism",
+        "accessibility",
+        "mermaid-diagrams",
+        "visual-organization",
+        "task-breakdown",
+        "decision-trees"
+      ],
+      "author": {
+        "name": "Jack Reis",
+        "url": "https://github.com/JackReis"
+      },
+      "repository": "https://github.com/JackReis/neurodivergent-visual-org",
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 52,
+        "grade": "F",
+        "badge": null,
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gh-dash",
+      "source": "./plugins/devops/gh-dash",
+      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
+      "version": "1.6.0",
+      "category": "devops",
+      "keywords": [
+        "github",
+        "pull-request",
+        "ci-cd",
+        "dashboard",
+        "devops",
+        "merge",
+        "code-review"
+      ],
+      "author": {
+        "name": "Jake Kozloski",
+        "email": "jakozloski@gmail.com"
+      },
+      "components": {
+        "commands": 1
+      },
+      "featured": true
+    },
+    {
+      "name": "youtube-strategy",
+      "source": "./plugins/productivity/youtube-strategy",
+      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
+      "version": "1.10.0",
+      "category": "productivity",
+      "keywords": [
+        "youtube",
+        "content-strategy",
+        "video-production",
+        "ideation",
+        "research",
+        "thumbnails",
+        "titles",
+        "outlining",
+        "content-creation"
+      ],
+      "author": {
+        "name": "Claude Code Plugins"
+      },
+      "components": {
+        "skills": 5,
+        "commands": 7,
+        "agents": 3
+      },
+      "verification": {
+        "score": 67,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "b12-claude-plugin",
+      "source": "./plugins/community/b12-claude-plugin",
+      "description": "B12 Website Generator \u2014 an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+      "version": "1.9.0",
+      "category": "community",
+      "keywords": [
+        "website",
+        "b12",
+        "hosting",
+        "web-design",
+        "ai-website",
+        "website-generator",
+        "saas"
+      ],
+      "author": {
+        "name": "B12.io",
+        "url": "https://github.com/b12io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 75,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -2092,6 +7339,80 @@
       }
     },
     {
+      "name": "wondelai-design-everyday-things",
+      "source": "./plugins/design/wondelai-design-everyday-things",
+      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "design",
+        "ux",
+        "affordances",
+        "signifiers",
+        "human-centered-design",
+        "usability",
+        "don-norman",
+        "hcd"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "design-everyday-things"
+      },
+      "verification": {
+        "score": 62,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-design-sprint",
+      "source": "./plugins/productivity/wondelai-design-sprint",
+      "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "design-sprint",
+        "prototyping",
+        "user-testing",
+        "validation",
+        "gv",
+        "product-design",
+        "rapid-iteration",
+        "mvp"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "design-sprint"
+      },
+      "verification": {
+        "score": 58,
+        "grade": "F",
+        "badge": null,
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "wondelai-drive-motivation",
       "source": "./plugins/business-tools/wondelai-drive-motivation",
       "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
@@ -2123,6 +7444,43 @@
       },
       "verification": {
         "score": 62,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-hooked-ux",
+      "source": "./plugins/design/wondelai-hooked-ux",
+      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "habits",
+        "engagement",
+        "retention",
+        "hook-model",
+        "triggers",
+        "rewards",
+        "onboarding",
+        "ux"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "hooked-ux"
+      },
+      "verification": {
+        "score": 64,
         "grade": "D",
         "badge": "bronze",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -2203,6 +7561,43 @@
       }
     },
     {
+      "name": "wondelai-ios-hig-design",
+      "source": "./plugins/design/wondelai-ios-hig-design",
+      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ios",
+        "apple",
+        "hig",
+        "swiftui",
+        "uikit",
+        "mobile-design",
+        "accessibility",
+        "interface-guidelines"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "ios-hig-design"
+      },
+      "verification": {
+        "score": 57,
+        "grade": "F",
+        "badge": null,
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "wondelai-jobs-to-be-done",
       "source": "./plugins/business-tools/wondelai-jobs-to-be-done",
       "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
@@ -2237,6 +7632,84 @@
         "grade": "D",
         "badge": "bronze",
         "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-lean-startup",
+      "source": "./plugins/productivity/wondelai-lean-startup",
+      "description": "Lean Startup methodology for validated learning, MVPs, and innovation accounting. Design experiments, decide when to pivot vs. persevere, and reduce development waste.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "lean-startup",
+        "mvp",
+        "validated-learning",
+        "pivot",
+        "metrics",
+        "innovation-accounting",
+        "experimentation",
+        "build-measure-learn"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "lean-startup"
+      },
+      "verification": {
+        "score": 63,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "navigating-github",
+      "source": "./plugins/productivity/navigating-github",
+      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
+      "version": "2.5.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "git",
+        "learning",
+        "onboarding",
+        "beginner-friendly",
+        "interactive-learning",
+        "version-control",
+        "vibe-coding",
+        "setup",
+        "collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/jeremylongshore/navigating-github",
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "jeremylongshore/navigating-github",
+        "source_path": "."
+      },
+      "verification": {
+        "score": 98,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-16T00:00:00.000Z"
       }
     },
     {
@@ -2426,6 +7899,43 @@
       }
     },
     {
+      "name": "wondelai-refactoring-ui",
+      "source": "./plugins/design/wondelai-refactoring-ui",
+      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ui-design",
+        "visual-hierarchy",
+        "typography",
+        "color-palette",
+        "tailwind",
+        "shadows",
+        "spacing",
+        "refactoring-ui"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "refactoring-ui"
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "wondelai-scorecard-marketing",
       "source": "./plugins/business-tools/wondelai-scorecard-marketing",
       "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
@@ -2500,2103 +8010,6 @@
       }
     },
     {
-      "name": "wondelai-traction-eos",
-      "source": "./plugins/business-tools/wondelai-traction-eos",
-      "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "eos",
-        "traction",
-        "operating-system",
-        "rocks",
-        "l10-meetings",
-        "accountability",
-        "vision",
-        "execution"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "traction-eos"
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "b12-claude-plugin",
-      "source": "./plugins/community/b12-claude-plugin",
-      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
-      "version": "1.9.0",
-      "category": "community",
-      "keywords": [
-        "website",
-        "b12",
-        "hosting",
-        "web-design",
-        "ai-website",
-        "website-generator",
-        "saas"
-      ],
-      "author": {
-        "name": "B12.io",
-        "url": "https://github.com/b12io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 75,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "boycott-filter",
-      "source": "./plugins/community/boycott-filter",
-      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
-      "version": "1.2.0",
-      "category": "community",
-      "keywords": [
-        "boycott",
-        "consumer",
-        "shopping",
-        "brands",
-        "chrome-extension",
-        "conversational",
-        "privacy",
-        "ethical-consumption"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/vdk888/boycott-filter"
-    },
-    {
-      "name": "claude-never-forgets",
-      "source": "./plugins/community/claude-never-forgets",
-      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
-      "version": "1.21.0",
-      "category": "community",
-      "keywords": [
-        "memory",
-        "context",
-        "persistent",
-        "preferences",
-        "sessions",
-        "recall"
-      ],
-      "author": {
-        "name": "yldrmahmet",
-        "url": "https://github.com/yldrmahmet"
-      },
-      "components": {
-        "hooks": 4,
-        "commands": 3,
-        "skills": 1,
-        "total": 8
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "claude-reflect",
-      "source": "./plugins/community/claude-reflect",
-      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": [
-        "claude-code",
-        "self-learning",
-        "corrections",
-        "CLAUDE.md",
-        "memory",
-        "learnings",
-        "hooks",
-        "automation"
-      ],
-      "author": {
-        "name": "Bayram Annakov",
-        "url": "https://github.com/bayramannakov"
-      },
-      "repository": "https://github.com/bayramannakov/claude-reflect",
-      "components": {
-        "commands": 3,
-        "skills": 1,
-        "hooks": 2
-      }
-    },
-    {
-      "name": "contributing-clanker",
-      "source": "./plugins/community/contributing-clanker",
-      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
-      "version": "0.8.0",
-      "category": "community",
-      "keywords": [
-        "oss",
-        "contributions",
-        "github",
-        "ai-slop-prevention",
-        "code-review",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
-      "repository": "https://github.com/jeremylongshore/contributing-clanker",
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-anti-deception",
-      "source": "./plugins/community/ejentum-anti-deception",
-      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-code",
-      "source": "./plugins/community/ejentum-code",
-      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-memory",
-      "source": "./plugins/community/ejentum-memory",
-      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-reasoning",
-      "source": "./plugins/community/ejentum-reasoning",
-      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "fairdb-ops-manager",
-      "source": "./plugins/community/fairdb-ops-manager",
-      "description": "Database operations management for FairDB PostgreSQL clusters",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": [
-        "database",
-        "postgresql",
-        "operations"
-      ],
-      "author": {
-        "name": "Community"
-      }
-    },
-    {
-      "name": "framecraft",
-      "source": "./plugins/community/framecraft",
-      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
-      "version": "1.3.0",
-      "category": "community",
-      "keywords": [
-        "demo-video",
-        "video-generation",
-        "playwright",
-        "ffmpeg",
-        "edge-tts",
-        "mcp"
-      ],
-      "author": {
-        "name": "vaddisrinivas",
-        "url": "https://github.com/vaddisrinivas"
-      },
-      "components": {
-        "skills": 1
-      },
-      "featured": false
-    },
-    {
-      "name": "gastown",
-      "source": "./plugins/community/gastown",
-      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "multi-agent",
-        "orchestration",
-        "automation",
-        "polecats",
-        "convoys",
-        "beads",
-        "work-tracking",
-        "ai-factory",
-        "gastown",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      },
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "numman-ali/n-skills",
-        "source_path": "skills/tools/gastown"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "research",
-        "games",
-        "accessibility",
-        "performance",
-        "flask",
-        "react",
-        "godot",
-        "corpus-linguistics",
-        "mcp"
-      ],
-      "author": {
-        "name": "Luke Steuber",
-        "url": "https://github.com/lukeslp"
-      },
-      "components": {
-        "agents": 51,
-        "total": 51
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "mcp",
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "geepers",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Luke Steuber"
-      },
-      "homepage": "https://dr.eamer.dev/geepers/",
-      "repository": "https://github.com/lukeslp/geepers",
-      "components": {
-        "agents": 51
-      }
-    },
-    {
-      "name": "hermes-tweet",
-      "source": "./plugins/community/hermes-tweet",
-      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
-      "version": "0.1.6",
-      "category": "community",
-      "keywords": [
-        "hermes-agent",
-        "hermes-plugin",
-        "xquik",
-        "twitter",
-        "x",
-        "social-media",
-        "automation"
-      ],
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
-      "repository": "https://github.com/Xquik-dev/hermes-tweet",
-      "license": "MIT"
-    },
-    {
-      "name": "jeremy-firebase",
-      "source": "./plugins/community/jeremy-firebase",
-      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
-      "version": "2.23.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "vertex-ai",
-        "gemini",
-        "authentication",
-        "storage",
-        "hosting",
-        "cloud-functions",
-        "analytics",
-        "ai-integration",
-        "google-cloud",
-        "embeddings",
-        "model-deployment",
-        "ai-powered",
-        "production-ready"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-firestore",
-      "source": "./plugins/community/jeremy-firestore",
-      "description": "Firestore database specialist for schema design, queries, and real-time sync",
-      "version": "2.20.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "firestore",
-        "database",
-        "crud",
-        "security-rules",
-        "cloud-functions",
-        "batch-operations",
-        "data-migration",
-        "performance",
-        "cost-optimization",
-        "nosql",
-        "google-cloud",
-        "a2a",
-        "agent-to-agent",
-        "mcp",
-        "cloud-run",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]",
-        "url": "https://intentsolutions.io"
-      },
-      "featured": true,
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "llm-box",
-      "source": "./plugins/community/llm-box",
-      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
-      "version": "0.3.0",
-      "category": "community",
-      "keywords": [
-        "workflow",
-        "automation",
-        "terminal",
-        "cli",
-        "yaml",
-        "llm",
-        "mcp"
-      ],
-      "author": {
-        "name": "alib8b8",
-        "url": "https://github.com/alib8b8"
-      },
-      "homepage": "https://github.com/alib8b8/llm-box",
-      "repository": "https://github.com/alib8b8/llm-box",
-      "license": "MIT"
-    },
-    {
-      "name": "mnemos",
-      "source": "./plugins/community/mnemos",
-      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
-      "version": "0.9.0",
-      "category": "community",
-      "keywords": [
-        "memory",
-        "mcp",
-        "claude-code",
-        "persistent-memory",
-        "agent-memory",
-        "knowledge-graph",
-        "context",
-        "skill",
-        "observations",
-        "provenance",
-        "learning-loop",
-        "golang"
-      ],
-      "author": {
-        "name": "André Figueira",
-        "url": "https://polyxmedia.com",
-        "email": "andre@polyxmedia.com"
-      },
-      "homepage": "https://github.com/polyxmedia/mnemos",
-      "repository": "https://github.com/polyxmedia/mnemos",
-      "license": "MIT"
-    },
-    {
-      "name": "portaljs",
-      "source": "./plugins/community/portaljs",
-      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
-      "version": "0.1.0",
-      "category": "community",
-      "keywords": [
-        "portaljs",
-        "data-portal",
-        "ckan",
-        "nextjs",
-        "data-catalog"
-      ],
-      "author": {
-        "name": "Datopian",
-        "url": "https://www.datopian.com"
-      },
-      "homepage": "https://github.com/datopian/portaljs",
-      "repository": "https://github.com/datopian/portaljs",
-      "license": "MIT"
-    },
-    {
-      "name": "quit-sponsor",
-      "source": "./plugins/community/quit-sponsor",
-      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "metr0x",
-        "url": "https://github.com/metrox-eth"
-      },
-      "repository": "https://github.com/metrox-eth/quit-sponsor",
-      "license": "MIT"
-    },
-    {
-      "name": "skills-janitor",
-      "source": "./plugins/community/skills-janitor",
-      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
-      "version": "0.1.0",
-      "category": "community",
-      "keywords": [
-        "skills",
-        "cleanup",
-        "context-window",
-        "token-budget",
-        "maintenance",
-        "tui"
-      ],
-      "author": {
-        "name": "Krzysztof Hendzel",
-        "url": "https://github.com/khendzel",
-        "email": "krzysztoff.hendzel@gmail.com"
-      },
-      "repository": "https://github.com/khendzel/skills-janitor",
-      "license": "MIT"
-    },
-    {
-      "name": "sprint",
-      "source": "./plugins/community/sprint",
-      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
-      "version": "1.20.0",
-      "category": "community",
-      "keywords": [
-        "autonomous",
-        "agentic",
-        "yolo",
-        "self-iterating",
-        "multi-agent",
-        "hands-off",
-        "auto-pilot",
-        "orchestration",
-        "sprint",
-        "testing",
-        "qa",
-        "mcp"
-      ],
-      "author": {
-        "name": "Damien Laine",
-        "email": "damien.laine@gmail.com",
-        "url": "https://github.com/damienlaine"
-      },
-      "components": {
-        "agents": 9,
-        "commands": 6,
-        "skills": 4,
-        "total": 19
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "walkie-talkie",
-      "source": "./plugins/community/walkie-talkie",
-      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Walkie-Talkie Maintainers",
-        "url": "https://github.com/walkie-talkie-skill"
-      },
-      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
-      "license": "MIT"
-    },
-    {
-      "name": "zai-cli",
-      "source": "./plugins/community/zai-cli",
-      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "vision",
-        "image-analysis",
-        "ocr",
-        "web-search",
-        "web-reader",
-        "github",
-        "mcp",
-        "z-ai",
-        "glm-4",
-        "multimodal"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      },
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "numman-ali/n-skills",
-        "source_path": "skills/tools/zai-cli"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "aomi",
-      "source": "./plugins/crypto/aomi",
-      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
-      "version": "0.10.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "defi",
-        "web3",
-        "evm",
-        "ethereum",
-        "wallet",
-        "account-abstraction",
-        "trading",
-        "agent",
-        "mcp"
-      ],
-      "author": {
-        "name": "aomi-labs",
-        "url": "https://aomi.dev",
-        "email": "info@aomi.dev"
-      },
-      "featured": false
-    },
-    {
-      "name": "arbitrage-opportunity-finder",
-      "source": "./plugins/crypto/arbitrage-opportunity-finder",
-      "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "arbitrage",
-        "trading",
-        "defi",
-        "mev",
-        "profit"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "blockchain-explorer-cli",
-      "source": "./plugins/crypto/blockchain-explorer-cli",
-      "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "blockchain",
-        "explorer",
-        "etherscan",
-        "transactions",
-        "addresses",
-        "contracts"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cross-chain-bridge-monitor",
-      "source": "./plugins/crypto/cross-chain-bridge-monitor",
-      "description": "Monitor cross-chain bridge activity, track transfers, analyze security, and detect bridge exploits",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "cross-chain",
-        "bridge",
-        "security",
-        "monitoring",
-        "layer2",
-        "multichain",
-        "defi"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-derivatives-tracker",
-      "source": "./plugins/crypto/crypto-derivatives-tracker",
-      "description": "Track crypto futures, options, perpetual swaps with funding rates, open interest, and derivatives market analysis",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "derivatives",
-        "futures",
-        "options",
-        "perpetuals",
-        "funding-rate",
-        "open-interest",
-        "trading"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-news-aggregator",
-      "source": "./plugins/crypto/crypto-news-aggregator",
-      "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": [
-        "news",
-        "aggregator",
-        "sentiment",
-        "crypto",
-        "media"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-portfolio-tracker",
-      "source": "./plugins/crypto/crypto-portfolio-tracker",
-      "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "portfolio",
-        "trading",
-        "investment",
-        "bitcoin",
-        "ethereum",
-        "defi"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-signal-generator",
-      "source": "./plugins/crypto/crypto-signal-generator",
-      "description": "Generate trading signals from technical indicators and market analysis",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "trading",
-        "signals",
-        "technical-analysis",
-        "indicators",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-tax-calculator",
-      "source": "./plugins/crypto/crypto-tax-calculator",
-      "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "tax",
-        "calculator",
-        "fifo",
-        "lifo",
-        "capital gains"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "defi-yield-optimizer",
-      "source": "./plugins/crypto/defi-yield-optimizer",
-      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "defi",
-        "yield",
-        "farming",
-        "liquidity",
-        "apy",
-        "optimization",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 80,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "dex-aggregator-router",
-      "source": "./plugins/crypto/dex-aggregator-router",
-      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": [
-        "dex",
-        "swap",
-        "trading",
-        "defi",
-        "aggregator",
-        "routing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "flash-loan-simulator",
-      "source": "./plugins/crypto/flash-loan-simulator",
-      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "flash-loans",
-        "defi",
-        "aave",
-        "arbitrage",
-        "liquidation",
-        "ethereum",
-        "simulation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 86,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gas-fee-optimizer",
-      "source": "./plugins/crypto/gas-fee-optimizer",
-      "description": "Optimize transaction gas fees with timing and routing recommendations",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "gas",
-        "fees",
-        "ethereum",
-        "optimization",
-        "transaction",
-        "l2"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 88,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "liquidity-pool-analyzer",
-      "source": "./plugins/crypto/liquidity-pool-analyzer",
-      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
-      "version": "1.23.0",
-      "category": "crypto",
-      "keywords": [
-        "liquidity",
-        "pool",
-        "defi",
-        "impermanent",
-        "loss",
-        "apy"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "market-movers-scanner",
-      "source": "./plugins/crypto/market-movers-scanner",
-      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "market",
-        "scanner",
-        "movers",
-        "gainers",
-        "losers",
-        "volume",
-        "trading"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 82,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "market-price-tracker",
-      "source": "./plugins/crypto/market-price-tracker",
-      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "market",
-        "price",
-        "tracking",
-        "trading",
-        "crypto",
-        "stocks",
-        "forex"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "market-sentiment-analyzer",
-      "source": "./plugins/crypto/market-sentiment-analyzer",
-      "description": "Analyze market sentiment from social media, news, and on-chain data",
-      "version": "1.24.0",
-      "category": "crypto",
-      "keywords": [
-        "sentiment",
-        "analysis",
-        "social",
-        "news",
-        "market",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mempool-analyzer",
-      "source": "./plugins/crypto/mempool-analyzer",
-      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
-      "version": "1.32.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "mempool",
-        "mev",
-        "ethereum",
-        "blockchain",
-        "gas",
-        "pending-transactions",
-        "arbitrage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 85,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "nft-rarity-analyzer",
-      "source": "./plugins/crypto/nft-rarity-analyzer",
-      "description": "Analyze NFT rarity scores and valuations across collections",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": [
-        "nft",
-        "rarity",
-        "valuation",
-        "traits",
-        "opensea",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 88,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "on-chain-analytics",
-      "source": "./plugins/crypto/on-chain-analytics",
-      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "on-chain",
-        "analytics",
-        "whale",
-        "metrics",
-        "blockchain"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "options-flow-analyzer",
-      "source": "./plugins/crypto/options-flow-analyzer",
-      "description": "Track institutional options flow, unusual activity, and smart money movements",
-      "version": "1.29.0",
-      "category": "crypto",
-      "keywords": [
-        "options",
-        "flow",
-        "institutional",
-        "trading",
-        "derivatives",
-        "smart money"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "staking-rewards-optimizer",
-      "source": "./plugins/crypto/staking-rewards-optimizer",
-      "description": "Optimize staking rewards across multiple protocols and chains",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "staking",
-        "defi",
-        "yield",
-        "optimization",
-        "rewards"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 82,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "token-launch-tracker",
-      "source": "./plugins/crypto/token-launch-tracker",
-      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "token-launch",
-        "rugpull",
-        "security",
-        "scam-detection",
-        "contract-analysis",
-        "defi",
-        "new-tokens"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "trading-strategy-backtester",
-      "source": "./plugins/crypto/trading-strategy-backtester",
-      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "trading",
-        "backtesting",
-        "strategy",
-        "historical",
-        "performance",
-        "risk"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 82,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wallet-portfolio-tracker",
-      "source": "./plugins/crypto/wallet-portfolio-tracker",
-      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
-      "version": "1.12.0",
-      "category": "crypto",
-      "keywords": [
-        "wallet",
-        "portfolio",
-        "tracking",
-        "blockchain",
-        "defi",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "wallet-security-auditor",
-      "source": "./plugins/crypto/wallet-security-auditor",
-      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
-      "version": "1.17.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "wallet",
-        "security",
-        "audit",
-        "web3"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "whale-alert-monitor",
-      "source": "./plugins/crypto/whale-alert-monitor",
-      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "whale",
-        "alert",
-        "monitor",
-        "large",
-        "transactions"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-seeder-generator",
-      "source": "./plugins/database/data-seeder-generator",
-      "description": "Generate realistic test data and database seed scripts for development and testing environments",
-      "version": "1.22.0",
-      "category": "database",
-      "keywords": [
-        "seeding",
-        "test-data",
-        "fixtures",
-        "database",
-        "testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-validation-engine",
-      "source": "./plugins/database/data-validation-engine",
-      "description": "Database plugin for data-validation-engine",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "validation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-archival-system",
-      "source": "./plugins/database/database-archival-system",
-      "description": "Database plugin for database-archival-system",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "archival"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-audit-logger",
-      "source": "./plugins/database/database-audit-logger",
-      "description": "Database plugin for database-audit-logger",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "audit"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-backup-automator",
-      "source": "./plugins/database/database-backup-automator",
-      "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
-      "version": "1.26.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backup",
-        "automation",
-        "disaster-recovery",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 74,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-cache-layer",
-      "source": "./plugins/database/database-cache-layer",
-      "description": "Database plugin for database-cache-layer",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "cache"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-connection-pooler",
-      "source": "./plugins/database/database-connection-pooler",
-      "description": "Implement and optimize database connection pooling for improved performance and resource management",
-      "version": "1.23.0",
-      "category": "database",
-      "keywords": [
-        "connection-pool",
-        "database",
-        "performance",
-        "backend",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-deadlock-detector",
-      "source": "./plugins/database/database-deadlock-detector",
-      "description": "Database plugin for database-deadlock-detector",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "deadlock"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-diff-tool",
-      "source": "./plugins/database/database-diff-tool",
-      "description": "Database plugin for database-diff-tool",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "diff"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-documentation-gen",
-      "source": "./plugins/database/database-documentation-gen",
-      "description": "Database plugin for database-documentation-gen",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "documentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-health-monitor",
-      "source": "./plugins/database/database-health-monitor",
-      "description": "Database plugin for database-health-monitor",
-      "version": "1.25.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "health"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-index-advisor",
-      "source": "./plugins/database/database-index-advisor",
-      "description": "Analyze query patterns and recommend optimal database indexes with impact analysis",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "indexes",
-        "optimization",
-        "performance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-migration-manager",
-      "source": "./plugins/database/database-migration-manager",
-      "description": "Manage database migrations with version control, rollback capabilities, and automated schema evolution tracking",
-      "version": "1.23.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "migration",
-        "schema",
-        "version-control",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-partition-manager",
-      "source": "./plugins/database/database-partition-manager",
-      "description": "Database plugin for database-partition-manager",
-      "version": "1.25.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "partition"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-recovery-manager",
-      "source": "./plugins/database/database-recovery-manager",
-      "description": "Database plugin for database-recovery-manager",
-      "version": "1.26.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "recovery"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-replication-manager",
-      "source": "./plugins/database/database-replication-manager",
-      "description": "Manage database replication, failover, and high availability configurations",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": [
-        "replication",
-        "high-availability",
-        "failover",
-        "database",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-schema-designer",
-      "source": "./plugins/database/database-schema-designer",
-      "description": "Design and visualize database schemas with normalization guidance, relationship mapping, and ERD generation",
-      "version": "1.24.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "schema",
-        "design",
-        "erd",
-        "normalization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-security-scanner",
-      "source": "./plugins/database/database-security-scanner",
-      "description": "Database plugin for database-security-scanner",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "security"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-sharding-manager",
-      "source": "./plugins/database/database-sharding-manager",
-      "description": "Database plugin for database-sharding-manager",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "sharding"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-transaction-monitor",
-      "source": "./plugins/database/database-transaction-monitor",
-      "description": "Database plugin for database-transaction-monitor",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "transaction"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "freshie-inventory-manager",
-      "source": "./plugins/database/freshie-inventory-manager",
-      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
-      "version": "1.5.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "inventory",
-        "freshie",
-        "compliance",
-        "sqlite",
-        "ecosystem",
-        "audit",
-        "subagents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 3
-      }
-    },
-    {
-      "name": "nosql-data-modeler",
-      "source": "./plugins/database/nosql-data-modeler",
-      "description": "Database plugin for nosql-data-modeler",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "data"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "orm-code-generator",
-      "source": "./plugins/database/orm-code-generator",
-      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": [
-        "orm",
-        "models",
-        "code-generation",
-        "database",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "query-performance-analyzer",
-      "source": "./plugins/database/query-performance-analyzer",
-      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "performance",
-        "query",
-        "optimization",
-        "explain",
-        "database"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sql-query-optimizer",
-      "source": "./plugins/database/sql-query-optimizer",
-      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "sql",
-        "optimization",
-        "performance",
-        "database",
-        "query"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "stored-procedure-generator",
-      "source": "./plugins/database/stored-procedure-generator",
-      "description": "Database plugin for stored-procedure-generator",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "procedure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 76,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "brand-forge",
-      "source": "./plugins/design/brand-forge",
-      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
-      "version": "0.5.1",
-      "category": "design",
-      "keywords": [
-        "branding",
-        "logo",
-        "brand-identity",
-        "design",
-        "svg",
-        "templates",
-        "image-generation"
-      ],
-      "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
-      },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
-      "repository": "https://github.com/localplugins/plugins",
-      "license": "MIT"
-    },
-    {
-      "name": "wondelai-design-everyday-things",
-      "source": "./plugins/design/wondelai-design-everyday-things",
-      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "design",
-        "ux",
-        "affordances",
-        "signifiers",
-        "human-centered-design",
-        "usability",
-        "don-norman",
-        "hcd"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "design-everyday-things"
-      },
-      "verification": {
-        "score": 62,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-hooked-ux",
-      "source": "./plugins/design/wondelai-hooked-ux",
-      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "habits",
-        "engagement",
-        "retention",
-        "hook-model",
-        "triggers",
-        "rewards",
-        "onboarding",
-        "ux"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "hooked-ux"
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-ios-hig-design",
-      "source": "./plugins/design/wondelai-ios-hig-design",
-      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ios",
-        "apple",
-        "hig",
-        "swiftui",
-        "uikit",
-        "mobile-design",
-        "accessibility",
-        "interface-guidelines"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "ios-hig-design"
-      },
-      "verification": {
-        "score": 57,
-        "grade": "F",
-        "badge": null,
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-refactoring-ui",
-      "source": "./plugins/design/wondelai-refactoring-ui",
-      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ui-design",
-        "visual-hierarchy",
-        "typography",
-        "color-palette",
-        "tailwind",
-        "shadows",
-        "spacing",
-        "refactoring-ui"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "refactoring-ui"
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "wondelai-top-design",
       "source": "./plugins/design/wondelai-top-design",
       "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
@@ -4628,6 +8041,43 @@
       },
       "verification": {
         "score": 61,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-traction-eos",
+      "source": "./plugins/business-tools/wondelai-traction-eos",
+      "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "eos",
+        "traction",
+        "operating-system",
+        "rocks",
+        "l10-meetings",
+        "accountability",
+        "vision",
+        "execution"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "traction-eos"
+      },
+      "verification": {
+        "score": 64,
         "grade": "D",
         "badge": "bronze",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -4708,3167 +8158,12 @@
       }
     },
     {
-      "name": "ansible-playbook-creator",
-      "source": "./plugins/devops/ansible-playbook-creator",
-      "description": "Create Ansible playbooks for configuration management",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "ansible",
-        "automation",
-        "configuration",
-        "playbooks",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "auto-scaling-configurator",
-      "source": "./plugins/devops/auto-scaling-configurator",
-      "description": "Configure auto-scaling policies for applications and infrastructure",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "autoscaling",
-        "scaling",
-        "hpa",
-        "kubernetes",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "backup-strategy-implementor",
-      "source": "./plugins/devops/backup-strategy-implementor",
-      "description": "Implement backup strategies for databases and applications",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "backup",
-        "disaster-recovery",
-        "restoration",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ci-cd-pipeline-builder",
-      "source": "./plugins/devops/ci-cd-pipeline-builder",
-      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "ci-cd",
-        "github-actions",
-        "gitlab-ci",
-        "jenkins",
-        "devops",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cloud-cost-optimizer",
-      "source": "./plugins/devops/cloud-cost-optimizer",
-      "description": "Optimize cloud costs and generate cost reports",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "cost",
-        "optimization",
-        "finops",
-        "cloud",
-        "aws",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "compliance-checker",
-      "source": "./plugins/devops/compliance-checker",
-      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "compliance",
-        "security",
-        "audit",
-        "soc2",
-        "hipaa",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "container-registry-manager",
-      "source": "./plugins/devops/container-registry-manager",
-      "description": "Manage container registries (ECR, GCR, Harbor)",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "registry",
-        "containers",
-        "docker",
-        "ecr",
-        "gcr",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "container-security-scanner",
-      "source": "./plugins/devops/container-security-scanner",
-      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "security",
-        "containers",
-        "scanning",
-        "vulnerabilities",
-        "trivy",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "deployment-pipeline-orchestrator",
-      "source": "./plugins/devops/deployment-pipeline-orchestrator",
-      "description": "Orchestrate complex multi-stage deployment pipelines",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "pipeline",
-        "orchestration",
-        "deployment",
-        "cicd",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "deployment-rollback-manager",
-      "source": "./plugins/devops/deployment-rollback-manager",
-      "description": "Manage and execute deployment rollbacks with safety checks",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "rollback",
-        "deployment",
-        "kubernetes",
-        "recovery",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "disaster-recovery-planner",
-      "source": "./plugins/devops/disaster-recovery-planner",
-      "description": "Plan and implement disaster recovery procedures",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "disaster-recovery",
-        "dr",
-        "business-continuity",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "docker-compose-generator",
-      "source": "./plugins/devops/docker-compose-generator",
-      "description": "Generate Docker Compose configurations for multi-container applications with best practices",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "docker",
-        "docker-compose",
-        "containers",
-        "orchestration",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "engineer-design-diagram",
-      "source": "./plugins/devops/engineer-design-diagram",
-      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
-      "version": "0.5.0",
-      "category": "devops",
-      "keywords": [
-        "architecture",
-        "diagram",
-        "visualization",
-        "svg",
-        "html",
-        "pr-review",
-        "drift-detection",
-        "sequence-diagram",
-        "engineering-design",
-        "documentation",
-        "onboarding"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "components": {
-        "skills": 1
-      }
-    },
-    {
-      "name": "environment-config-manager",
-      "source": "./plugins/devops/environment-config-manager",
-      "description": "Manage environment configurations and secrets across deployments",
-      "version": "1.23.0",
-      "category": "devops",
-      "keywords": [
-        "config",
-        "environment",
-        "secrets",
-        "configuration",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "fairdb-operations-kit",
-      "source": "./plugins/devops/fairdb-operations-kit",
-      "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "fairdb",
-        "postgresql",
-        "database",
-        "saas",
-        "operations",
-        "devops",
-        "backup",
-        "monitoring",
-        "vps",
-        "contabo",
-        "wasabi",
-        "pgbackrest",
-        "automation",
-        "incident-response"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "featured": false,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gh-dash",
-      "source": "./plugins/devops/gh-dash",
-      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
-      "version": "1.6.0",
-      "category": "devops",
-      "keywords": [
-        "github",
-        "pull-request",
-        "ci-cd",
-        "dashboard",
-        "devops",
-        "merge",
-        "code-review"
-      ],
-      "author": {
-        "name": "Jake Kozloski",
-        "email": "jakozloski@gmail.com"
-      },
-      "components": {
-        "commands": 1
-      },
-      "featured": true
-    },
-    {
-      "name": "git-commit-smart",
-      "source": "./plugins/devops/git-commit-smart",
-      "description": "AI-powered conventional commit message generator with smart analysis",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "git",
-        "commits",
-        "conventional-commits",
-        "automation",
-        "devops",
-        "productivity"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gitops-workflow-builder",
-      "source": "./plugins/devops/gitops-workflow-builder",
-      "description": "Build GitOps workflows with ArgoCD and Flux",
-      "version": "1.22.0",
-      "category": "devops",
-      "keywords": [
-        "gitops",
-        "argocd",
-        "flux",
-        "cd",
-        "kubernetes",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "helm-chart-generator",
-      "source": "./plugins/devops/helm-chart-generator",
-      "description": "Generate Helm charts for Kubernetes applications",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "helm",
-        "kubernetes",
-        "packaging",
-        "charts",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "infrastructure-as-code-generator",
-      "source": "./plugins/devops/infrastructure-as-code-generator",
-      "description": "Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "iac",
-        "terraform",
-        "cloudformation",
-        "pulumi",
-        "infrastructure",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "infrastructure-drift-detector",
-      "source": "./plugins/devops/infrastructure-drift-detector",
-      "description": "Detect infrastructure drift from desired state",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "drift",
-        "terraform",
-        "infrastructure",
-        "monitoring",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-adk-terraform",
-      "source": "./plugins/devops/jeremy-adk-terraform",
-      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
-      "version": "2.22.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "adk",
-        "agent-engine",
-        "vertex-ai",
-        "infrastructure",
-        "vpc-sc"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-genkit-terraform",
-      "source": "./plugins/devops/jeremy-genkit-terraform",
-      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
-      "version": "2.21.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "genkit",
-        "firebase",
-        "cloud-run",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-github-actions-gcp",
-      "source": "./plugins/devops/jeremy-github-actions-gcp",
-      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
-      "version": "2.27.0",
-      "category": "devops",
-      "keywords": [
-        "github-actions",
-        "google-cloud",
-        "workload-identity-federation",
-        "wif",
-        "vertex-ai",
-        "agent-engine",
-        "deployment",
-        "ci-cd",
-        "security",
-        "best-practices",
-        "oidc",
-        "iam"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 1,
-        "skills": 1,
-        "hooks": 1
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-vertex-terraform",
-      "source": "./plugins/devops/jeremy-vertex-terraform",
-      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
-      "version": "2.22.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "vertex-ai",
-        "gemini",
-        "model-garden",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "kubernetes-deployment-creator",
-      "source": "./plugins/devops/kubernetes-deployment-creator",
-      "description": "Create Kubernetes deployments, services, and configurations with best practices",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "kubernetes",
-        "k8s",
-        "deployment",
-        "orchestration",
-        "containers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 63,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "load-balancer-configurator",
-      "source": "./plugins/devops/load-balancer-configurator",
-      "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "load-balancer",
-        "alb",
-        "nginx",
-        "haproxy",
-        "networking",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "log-aggregation-setup",
-      "source": "./plugins/devops/log-aggregation-setup",
-      "description": "Set up log aggregation (ELK, Loki, Splunk)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "logging",
-        "elk",
-        "loki",
-        "splunk",
-        "observability",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mattyp-changelog",
-      "source": "./plugins/devops/mattyp-changelog",
-      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
-      "version": "0.3.0",
-      "category": "devops",
-      "keywords": [
-        "changelog",
-        "release-notes",
-        "weekly-update",
-        "git",
-        "github",
-        "automation"
-      ],
-      "author": {
-        "name": "Mattyp",
-        "email": "mattyp@tonsofskills.com",
-        "url": "https://tonsofskills.com"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 3
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "monitoring-stack-deployer",
-      "source": "./plugins/devops/monitoring-stack-deployer",
-      "description": "Deploy monitoring stacks (Prometheus, Grafana, Datadog)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "monitoring",
-        "prometheus",
-        "grafana",
-        "observability",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "network-policy-manager",
-      "source": "./plugins/devops/network-policy-manager",
-      "description": "Manage Kubernetes network policies and firewall rules",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "network-policy",
-        "security",
-        "kubernetes",
-        "firewall",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "secrets-manager-integrator",
-      "source": "./plugins/devops/secrets-manager-integrator",
-      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "secrets",
-        "vault",
-        "aws",
-        "security",
-        "credentials",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "service-mesh-configurator",
-      "source": "./plugins/devops/service-mesh-configurator",
-      "description": "Configure service mesh (Istio, Linkerd) for microservices",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "service-mesh",
-        "istio",
-        "linkerd",
-        "microservices",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sugar",
-      "source": "./plugins/devops/sugar",
-      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
-      "version": "2.0.0",
-      "category": "devops",
-      "keywords": [
-        "autonomous",
-        "development",
-        "ai",
-        "task-management",
-        "automation",
-        "agents",
-        "enterprise",
-        "workflow",
-        "productivity",
-        "mcp"
-      ],
-      "author": {
-        "name": "Steven Leggett",
-        "email": "contact@roboticforce.io"
-      },
-      "featured": true,
-      "mcpTools": 7,
-      "repository": "https://github.com/cdnsteve/sugar",
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "terraform-module-builder",
-      "source": "./plugins/devops/terraform-module-builder",
-      "description": "Build reusable Terraform modules",
-      "version": "1.23.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "iac",
-        "modules",
-        "infrastructure",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "tweetclaw",
-      "source": "./plugins/devops/tweetclaw",
-      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
-      "version": "1.5.3",
-      "category": "devops",
-      "keywords": [
-        "twitter",
-        "x",
-        "automation",
-        "social-media",
-        "tweets",
-        "monitoring",
-        "giveaway",
-        "scraping"
-      ],
-      "author": {
-        "name": "Burak Bayir",
-        "email": "burak@xquik.com",
-        "url": "https://xquik.com"
-      },
-      "repository": "https://github.com/Xquik-dev/tweetclaw",
-      "homepage": "https://xquik.com",
-      "license": "MIT",
-      "pricing": "paid",
-      "components": {
-        "skills": 1,
-        "commands": 2
-      }
-    },
-    {
-      "name": "formatter",
-      "source": "./plugins/examples/formatter",
-      "description": "Code formatting plugin using hooks to auto-format on save",
-      "version": "2.26.0",
-      "category": "examples",
-      "keywords": [
-        "formatting",
-        "hooks",
-        "automation"
-      ],
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "hello-world",
-      "source": "./plugins/examples/hello-world",
-      "description": "Simple example plugin demonstrating basic slash commands",
-      "version": "1.12.0",
-      "category": "examples",
-      "keywords": [
-        "example",
-        "tutorial",
-        "beginner"
-      ],
-      "author": {
-        "name": "Jeremy Longshore"
-      }
-    },
-    {
-      "name": "jeremy-plugin-tool",
-      "source": "./plugins/examples/jeremy-plugin-tool",
-      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
-      "version": "2.19.0",
-      "category": "examples",
-      "keywords": [
-        "skills",
-        "agent-skills",
-        "plugin-management",
-        "marketplace",
-        "validation",
-        "audit",
-        "versioning",
-        "meta-plugin",
-        "repository-tools"
-      ],
-      "author": {
-        "name": "Claude Code Plugins",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "pi-pathfinder",
-      "source": "./plugins/examples/pi-pathfinder",
-      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
-      "version": "1.24.0",
-      "category": "examples",
-      "keywords": [
-        "agent-skills",
-        "pi",
-        "pathfinder",
-        "plugin-intelligence",
-        "task-router",
-        "auto-selector",
-        "skill-extraction",
-        "easy-mode",
-        "automatic",
-        "no-thinking-required"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "components": {
-        "skills": 1
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-agent",
-      "source": "./plugins/examples/security-agent",
-      "description": "Security review subagent for code analysis",
-      "version": "1.28.0",
-      "category": "examples",
-      "keywords": [
-        "security",
-        "agent",
-        "code-review"
-      ],
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "a2a-client",
-      "source": "./plugins/mcp/a2a-client",
-      "description": "Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "a2a",
-        "agent2agent",
-        "agent-card",
-        "multi-agent",
-        "interoperability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "featured": true,
-      "mcpTools": 7
-    },
-    {
-      "name": "ai-experiment-logger",
-      "source": "./plugins/mcp/ai-experiment-logger",
-      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
-      "version": "1.12.0",
-      "category": "mcp",
-      "keywords": [
-        "ai",
-        "experiments",
-        "logging",
-        "mcp"
-      ],
-      "author": {
-        "name": "Claude Code Plugins"
-      },
-      "zcf_metadata": {
-        "preset_id": "ai-experiment-logger",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "ai-ml"
-      }
-    },
-    {
-      "name": "beads-dolt",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "beads",
-        "bd",
-        "dolt",
-        "dolthub",
-        "task-tracking",
-        "mcp",
-        "version-control",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "conversational-api-debugger",
-      "source": "./plugins/mcp/conversational-api-debugger",
-      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "api",
-        "debugging",
-        "openapi",
-        "har",
-        "rest",
-        "curl",
-        "http"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 4,
-      "zcf_metadata": {
-        "preset_id": "conversational-api-debugger",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "api"
-      }
-    },
-    {
-      "name": "databricks-workspace-mcp",
-      "source": "./plugins/mcp/databricks-workspace-mcp",
-      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "model-context-protocol",
-        "databricks",
-        "lakehouse",
-        "unity-catalog",
-        "clusters",
-        "dlt",
-        "finops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://tonsofskills.com/learn/databricks/",
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "license": "MIT",
-      "mcpTools": 8
-    },
-    {
-      "name": "design-to-code",
-      "source": "./plugins/mcp/design-to-code",
-      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "design",
-        "figma",
-        "react",
-        "svelte",
-        "vue",
-        "accessibility",
-        "component-generation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 3,
-      "zcf_metadata": {
-        "preset_id": "design-to-code",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "design"
-      }
-    },
-    {
-      "name": "dolt-mcp-vcs",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "dolt-mcp-vcs",
-        "dolt",
-        "dolthub",
-        "dolt-mcp",
-        "version-control",
-        "vcs",
-        "mcp",
-        "sql",
-        "beads",
-        "bd"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "domain-memory-agent",
-      "source": "./plugins/mcp/domain-memory-agent",
-      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
-      "version": "1.17.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "knowledge-base",
-        "semantic-search",
-        "tfidf",
-        "summarization",
-        "rag",
-        "documentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 6,
-      "zcf_metadata": {
-        "preset_id": "domain-memory-agent",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "knowledge"
-      }
-    },
-    {
-      "name": "governed-second-brain",
-      "source": "./plugins/mcp/governed-second-brain",
-      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
-      "version": "1.1.2",
-      "category": "mcp",
-      "keywords": [
-        "memory",
-        "knowledge",
-        "governance",
-        "qmd",
-        "brain",
-        "citations",
-        "local-first",
-        "second-brain"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "lumera-agent-memory",
-      "source": "./plugins/mcp/lumera-agent-memory",
-      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
-      "version": "1.7.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "memory",
-        "cascade",
-        "storage",
-        "encryption",
-        "search",
-        "fts",
-        "agent"
-      ],
-      "author": {
-        "name": "Intent Solutions IO",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "mcpTools": [
-        "store_memory",
-        "recall_memory",
-        "search_memory",
-        "delete_memory"
-      ]
-    },
-    {
-      "name": "pr-to-spec",
-      "source": "./plugins/mcp/pr-to-spec",
-      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
-      "version": "0.8.0",
-      "category": "mcp",
-      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "license": "MIT",
-      "featured": true,
-      "external_sync": true,
-      "mcpTools": 6,
-      "keywords": [
-        "mcp",
-        "pr-analysis",
-        "intent-drift",
-        "code-review",
-        "agent-protocol"
-      ]
-    },
-    {
-      "name": "project-health-auditor",
-      "source": "./plugins/mcp/project-health-auditor",
-      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
-      "version": "1.18.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "code-quality",
-        "technical-debt",
-        "complexity",
-        "git-churn",
-        "test-coverage",
-        "analytics"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 4,
-      "zcf_metadata": {
-        "preset_id": "project-health-auditor",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "code-quality"
-      }
-    },
-    {
-      "name": "servicegraph",
-      "source": "./plugins/mcp/servicegraph",
-      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
-      "version": "0.2.0",
-      "category": "mcp",
-      "keywords": [
-        "servicegraph",
-        "service-providers",
-        "agencies",
-        "law-firms",
-        "consulting",
-        "accounting",
-        "marketing",
-        "lead-generation",
-        "professional-services",
-        "us-firms",
-        "product-directories",
-        "saas-directories",
-        "mcp-directories",
-        "ai-directories",
-        "product-launch",
-        "backlinks"
-      ],
-      "author": {
-        "name": "Artur Briugeman",
-        "url": "https://servicegraph.co",
-        "email": "artur@nostr.band"
-      },
-      "homepage": "https://servicegraph.co",
-      "repository": "https://github.com/nostrband/servicegraph",
-      "license": "MIT"
-    },
-    {
-      "name": "slack-channel",
-      "source": "./plugins/mcp/slack-channel",
-      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "slack",
-        "channel",
-        "mcp",
-        "socket-mode",
-        "chatops",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT",
-      "featured": true,
-      "pricing": "free",
-      "external_sync": true,
-      "mcpTools": 5,
-      "components": {
-        "skills": 2
-      }
-    },
-    {
-      "name": "workflow-orchestrator",
-      "source": "./plugins/mcp/workflow-orchestrator",
-      "description": "DAG-based workflow automation with parallel task execution and dependency management",
-      "version": "1.15.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "workflow",
-        "dag",
-        "automation",
-        "orchestration",
-        "cicd",
-        "parallel-execution"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 4,
-      "zcf_metadata": {
-        "preset_id": "workflow-orchestrator",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "automation"
-      }
-    },
-    {
-      "name": "x-bug-triage",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "triage",
-        "x-api",
-        "bug-tracking",
-        "clustering"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "license": "MIT"
-    },
-    {
-      "name": "x-bug-triage-plugin",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "keywords": [
-        "bug-triage",
-        "x-twitter",
-        "slack",
-        "devops",
-        "mcp"
-      ],
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT",
-      "featured": false,
-      "pricing": "free",
-      "external_sync": true,
-      "mcpTools": 6,
-      "components": {
-        "skills": 5,
-        "agents": 4
-      }
-    },
-    {
-      "name": "ai-ml-engineering-pack",
-      "source": "./plugins/packages/ai-ml-engineering-pack",
-      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "ai",
-        "ml",
-        "llm",
-        "prompt-engineering",
-        "rag",
-        "vector-database",
-        "ai-safety",
-        "openai",
-        "anthropic",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pluginCount": 12,
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "creator-studio-pack",
-      "source": "./plugins/packages/creator-studio-pack",
-      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
-      "version": "1.16.0",
-      "category": "packages",
-      "keywords": [
-        "video",
-        "content-creation",
-        "youtube",
-        "filmmaking",
-        "creator",
-        "documentation",
-        "screencast",
-        "tutorial",
-        "video-editing",
-        "content-strategy",
-        "distribution",
-        "thumbnails",
-        "subtitles",
-        "repurposing",
-        "batch-recording",
-        "analytics",
-        "package",
-        "premium"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pricing": {
-        "model": "one-time",
-        "price": 149,
-        "currency": "USD"
-      },
-      "components": {
-        "agents": 10,
-        "commands": 10,
-        "total": 20
-      }
-    },
-    {
-      "name": "devops-automation-pack",
-      "source": "./plugins/packages/devops-automation-pack",
-      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "devops",
-        "ci-cd",
-        "docker",
-        "kubernetes",
-        "terraform",
-        "deployment",
-        "infrastructure",
-        "automation",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "fullstack-starter-pack",
-      "source": "./plugins/packages/fullstack-starter-pack",
-      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
-      "version": "1.21.0",
-      "category": "packages",
-      "keywords": [
-        "fullstack",
-        "react",
-        "express",
-        "fastapi",
-        "postgresql",
-        "prisma",
-        "typescript",
-        "mvp",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pluginCount": 15
-    },
-    {
-      "name": "security-pro-pack",
-      "source": "./plugins/packages/security-pro-pack",
-      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
-      "version": "1.31.0",
-      "category": "packages",
-      "keywords": [
-        "security",
-        "vulnerability-scanning",
-        "compliance",
-        "HIPAA",
-        "PCI-DSS",
-        "GDPR",
-        "SOC2",
-        "cryptography",
-        "devsecops",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pluginCount": 10,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "alerting-rule-creator",
-      "source": "./plugins/performance/alerting-rule-creator",
-      "description": "Create intelligent alerting rules for performance monitoring",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "alerting",
-        "monitoring",
-        "sre",
-        "observability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "apm-dashboard-creator",
-      "source": "./plugins/performance/apm-dashboard-creator",
-      "description": "Create Application Performance Monitoring dashboards",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "apm",
-        "monitoring",
-        "dashboard",
-        "grafana",
-        "datadog"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "application-profiler",
-      "source": "./plugins/performance/application-profiler",
-      "description": "Profile application performance with CPU, memory, and execution time analysis",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "performance",
-        "profiling",
-        "monitoring",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "bottleneck-detector",
-      "source": "./plugins/performance/bottleneck-detector",
-      "description": "Detect and resolve performance bottlenecks",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "bottleneck",
-        "performance",
-        "optimization",
-        "profiling"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cache-performance-optimizer",
-      "source": "./plugins/performance/cache-performance-optimizer",
-      "description": "Optimize caching strategies for improved performance",
-      "version": "1.19.0",
-      "category": "performance",
-      "keywords": [
-        "cache",
-        "performance",
-        "optimization",
-        "redis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "capacity-planning-analyzer",
-      "source": "./plugins/performance/capacity-planning-analyzer",
-      "description": "Analyze and plan for capacity requirements",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "capacity-planning",
-        "scaling",
-        "forecasting",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cpu-usage-monitor",
-      "source": "./plugins/performance/cpu-usage-monitor",
-      "description": "Monitor and analyze CPU usage patterns in applications",
-      "version": "1.23.0",
-      "category": "performance",
-      "keywords": [
-        "cpu",
-        "monitoring",
-        "performance",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-query-profiler",
-      "source": "./plugins/performance/database-query-profiler",
-      "description": "Profile and optimize database queries for performance",
-      "version": "1.9.0",
-      "category": "performance",
-      "keywords": [
-        "database",
-        "query",
-        "profiling",
-        "optimization",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "distributed-tracing-setup",
-      "source": "./plugins/performance/distributed-tracing-setup",
-      "description": "Set up distributed tracing for microservices",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "tracing",
-        "observability",
-        "microservices",
-        "opentelemetry"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "error-rate-monitor",
-      "source": "./plugins/performance/error-rate-monitor",
-      "description": "Monitor and analyze application error rates",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "errors",
-        "monitoring",
-        "reliability",
-        "sre"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "infrastructure-metrics-collector",
-      "source": "./plugins/performance/infrastructure-metrics-collector",
-      "description": "Collect comprehensive infrastructure performance metrics",
-      "version": "1.20.0",
-      "category": "performance",
-      "keywords": [
-        "infrastructure",
-        "metrics",
-        "monitoring",
-        "observability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "load-test-runner",
-      "source": "./plugins/performance/load-test-runner",
-      "description": "Create and execute load tests for performance validation",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "load-testing",
-        "performance",
-        "stress-test",
-        "k6"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "log-analysis-tool",
-      "source": "./plugins/performance/log-analysis-tool",
-      "description": "Analyze logs for performance insights and issues",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": [
-        "logs",
-        "analysis",
-        "performance",
-        "debugging"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "memory-leak-detector",
-      "source": "./plugins/performance/memory-leak-detector",
-      "description": "Detect memory leaks and analyze memory usage patterns",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": [
-        "memory",
-        "leak",
-        "detection",
-        "performance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "metrics-aggregator",
-      "source": "./plugins/performance/metrics-aggregator",
-      "description": "Aggregate and centralize performance metrics",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "metrics",
-        "aggregation",
-        "prometheus",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "network-latency-analyzer",
-      "source": "./plugins/performance/network-latency-analyzer",
-      "description": "Analyze network latency and optimize request patterns",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "network",
-        "latency",
-        "performance",
-        "api"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-budget-validator",
-      "source": "./plugins/performance/performance-budget-validator",
-      "description": "Validate application against performance budgets",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "performance-budget",
-        "validation",
-        "ci-cd",
-        "testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-optimization-advisor",
-      "source": "./plugins/performance/performance-optimization-advisor",
-      "description": "Get comprehensive performance optimization recommendations",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "optimization",
-        "performance",
-        "best-practices",
-        "advisor"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-regression-detector",
-      "source": "./plugins/performance/performance-regression-detector",
-      "description": "Detect performance regressions in CI/CD pipeline",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "regression",
-        "performance",
-        "ci-cd",
-        "testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "real-user-monitoring",
-      "source": "./plugins/performance/real-user-monitoring",
-      "description": "Implement Real User Monitoring for actual performance data",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "rum",
-        "monitoring",
-        "performance",
-        "user-experience"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "resource-usage-tracker",
-      "source": "./plugins/performance/resource-usage-tracker",
-      "description": "Track and optimize resource usage across the stack",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "resources",
-        "monitoring",
-        "optimization",
-        "metrics"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "response-time-tracker",
-      "source": "./plugins/performance/response-time-tracker",
-      "description": "Track and optimize application response times",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "response-time",
-        "latency",
-        "performance",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sla-sli-tracker",
-      "source": "./plugins/performance/sla-sli-tracker",
-      "description": "Track SLAs, SLIs, and SLOs for service reliability",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "sla",
-        "sli",
-        "slo",
-        "sre",
-        "reliability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "synthetic-monitoring-setup",
-      "source": "./plugins/performance/synthetic-monitoring-setup",
-      "description": "Set up synthetic monitoring for proactive performance tracking",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "synthetic-monitoring",
-        "uptime",
-        "performance",
-        "testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "throughput-analyzer",
-      "source": "./plugins/performance/throughput-analyzer",
-      "description": "Analyze and optimize system throughput",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": [
-        "throughput",
-        "performance",
-        "capacity",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "000-jeremy-content-consistency-validator",
-      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
-      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
-      "version": "3.29.0",
-      "category": "productivity",
-      "maintainer": "@jeremylongshore",
-      "keywords": [
-        "documentation",
-        "consistency",
-        "validation",
-        "drift-detection",
-        "source-of-truth",
-        "authority-registry",
-        "content-audit",
-        "quality-assurance",
-        "release-gate",
-        "standards"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "002-jeremy-yaml-master-agent",
-      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
-      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
-      "version": "2.21.0",
-      "category": "productivity",
-      "keywords": [
-        "yaml",
-        "validation",
-        "linting",
-        "schema",
-        "json",
-        "conversion",
-        "parsing",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 1
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "003-jeremy-vertex-ai-media-master",
-      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
-      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
-      "version": "2.25.0",
-      "category": "productivity",
-      "keywords": [
-        "vertex-ai",
-        "gemini",
-        "multimodal",
-        "video-processing",
-        "audio-generation",
-        "image-generation",
-        "marketing",
-        "campaigns",
-        "content-generation",
-        "imagen",
-        "media-production",
-        "google-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "004-jeremy-google-cloud-agent-sdk",
-      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
-      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
-      "version": "2.24.0",
-      "category": "productivity",
-      "keywords": [
-        "agent-development-kit",
-        "adk",
-        "agent-starter-pack",
-        "multi-agent",
-        "containerized-agents",
-        "cloud-run",
-        "gke",
-        "agent-engine",
-        "rag-agents",
-        "react-agents",
-        "google-cloud",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "agent-context-manager",
-      "source": "./plugins/productivity/agent-context-manager",
-      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
-      "version": "1.23.0",
-      "category": "productivity",
-      "keywords": [
-        "agents",
-        "context",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ai-commit-gen",
-      "source": "./plugins/productivity/ai-commit-gen",
-      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
-      "version": "1.10.0",
-      "category": "productivity",
-      "keywords": [
-        "git",
-        "commit",
-        "conventional-commits",
-        "ai",
-        "automation",
-        "productivity",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "components": {
-        "commands": 1,
-        "total": 1
-      }
-    },
-    {
-      "name": "box-cloud-filesystem",
-      "source": "./plugins/productivity/box-cloud-filesystem",
-      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "box",
-        "cloud-storage",
-        "filesystem",
-        "file-sync",
-        "box-cli",
-        "upload",
-        "download",
-        "document-management",
-        "collaboration",
-        "ai-agent-storage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT",
-      "featured": true,
-      "pricing": "free",
-      "external_sync": true,
-      "components": {
-        "skills": 1,
-        "hooks": 2
-      },
-      "verification": {
-        "score": 0,
-        "grade": "N/A",
-        "badge": "none",
-        "lastValidated": "2026-03-17T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "claude-workflow-skills",
-      "source": "./plugins/productivity/claude-workflow-skills",
-      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
-      "version": "1.7.1",
-      "category": "productivity",
-      "keywords": [
-        "workflow",
-        "promote",
-        "release",
-        "audit",
-        "standards",
-        "improve",
-        "triage",
-        "git",
-        "review",
-        "pull-request"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
-      "repository": "https://github.com/ali5ter/claude-workflow-skills",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "cli-power-skills",
-      "source": "./plugins/productivity/cli-power-skills",
-      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "cli-tools",
-        "agentic-skills",
-        "data-processing",
-        "security",
-        "web-crawling",
-        "python",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Yuriy Kotik",
-        "url": "https://github.com/ykotik"
-      },
-      "repository": "https://github.com/ykotik/cli-power-skills",
-      "license": "MIT"
-    },
-    {
-      "name": "content-multiplier",
-      "source": "./plugins/productivity/content-multiplier",
-      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
-      "version": "0.2.1",
-      "category": "productivity",
-      "keywords": [
-        "marketing",
-        "content",
-        "repurposing",
-        "brand-voice",
-        "localization",
-        "social-media"
-      ],
-      "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
-      },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
-      "repository": "https://github.com/localplugins/plugins",
-      "license": "MIT"
-    },
-    {
-      "name": "hyperfocus",
-      "source": "./plugins/productivity/hyperfocus",
-      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
-      "version": "0.2.0",
-      "category": "productivity",
-      "author": {
-        "name": "Nestor Magalhaes",
-        "email": "nestor.magalhaes@appex.world"
-      },
-      "keywords": [
-        "accessibility",
-        "adhd",
-        "neurodivergent",
-        "formatting",
-        "readability",
-        "productivity",
-        "cognitive-accessibility"
-      ],
-      "repository": "https://github.com/nextor2k/hyperfocus",
-      "homepage": "https://github.com/nextor2k/hyperfocus",
-      "license": "MIT",
-      "featured": false,
-      "pricing": "free",
-      "components": {
-        "skills": 1,
-        "agents": 0
-      }
-    },
-    {
-      "name": "intent-labs-pack",
-      "source": "./plugins/productivity/intent-labs-pack",
-      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "audit-tests",
-        "validate-skillmd",
-        "testing",
-        "skill-validation",
-        "intent-eval",
-        "dogfood"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 2,
-        "commands": 0,
-        "agents": 0,
-        "total": 2
-      }
-    },
-    {
-      "name": "j-rig",
-      "source": "./plugins/productivity/j-rig",
-      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "skill-refiner",
-        "eval-guided",
-        "skill-md",
-        "meta-tooling",
-        "hooks"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "navigating-github",
-      "source": "./plugins/productivity/navigating-github",
-      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
-      "version": "2.5.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "git",
-        "learning",
-        "onboarding",
-        "beginner-friendly",
-        "interactive-learning",
-        "version-control",
-        "vibe-coding",
-        "setup",
-        "collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/jeremylongshore/navigating-github",
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "jeremylongshore/navigating-github",
-        "source_path": "."
-      },
-      "verification": {
-        "score": 98,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-16T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "neurodivergent-visual-org",
-      "source": "./plugins/productivity/neurodivergent-visual-org",
-      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
-      "version": "3.10.0",
-      "category": "productivity",
-      "keywords": [
-        "neurodivergent",
-        "adhd",
-        "autism",
-        "accessibility",
-        "mermaid-diagrams",
-        "visual-organization",
-        "task-breakdown",
-        "decision-trees"
-      ],
-      "author": {
-        "name": "Jack Reis",
-        "url": "https://github.com/JackReis"
-      },
-      "repository": "https://github.com/JackReis/neurodivergent-visual-org",
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 52,
-        "grade": "F",
-        "badge": null,
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "obsidian-project-documentation",
-      "source": "./plugins/productivity/obsidian-project-documentation",
-      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
-      "version": "3.2.5",
-      "category": "productivity",
-      "keywords": [
-        "obsidian",
-        "documentation",
-        "notes",
-        "projects"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
-      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
-      "license": "MIT"
-    },
-    {
-      "name": "over-50s-health",
-      "source": "./plugins/productivity/over-50s-health",
-      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
-      "version": "3.3.0",
-      "category": "productivity",
-      "keywords": [
-        "health",
-        "fitness",
-        "nutrition",
-        "longevity",
-        "50+"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
-      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
-      "license": "MIT"
-    },
-    {
-      "name": "overnight-dev",
-      "source": "./plugins/productivity/overnight-dev",
-      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
-      "version": "1.29.0",
-      "category": "productivity",
-      "keywords": [
-        "overnight",
-        "autonomous",
-        "tdd",
-        "testing",
-        "git-hooks",
-        "automation",
-        "continuous-integration",
-        "test-driven-development",
-        "productivity"
-      ],
-      "author": {
-        "name": "Intent Solutions IO",
-        "url": "https://intentsolutions.io",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "pair-programmer",
-      "source": "./plugins/productivity/pair-programmer",
-      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "pair-programming",
-        "coding",
-        "skill-development",
-        "graduated-assistance"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/pair-programmer",
-      "repository": "https://github.com/ali5ter/pair-programmer",
-      "license": "MIT"
-    },
-    {
-      "name": "plane",
-      "source": "./plugins/productivity/plane",
-      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
-      "tagline": "Team behavior observatory for Plane workspaces",
-      "version": "0.3.0",
-      "category": "productivity",
-      "keywords": [
-        "plane",
-        "project-management",
-        "team-behavior",
-        "observability",
-        "productivity",
-        "agent-skills",
-        "forge-generated"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 2
-      },
-      "generated": true,
-      "author_type": "forge"
-    },
-    {
-      "name": "pm-ai-partner",
-      "source": "./plugins/productivity/pm-ai-partner",
-      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
-      "version": "1.8.0",
-      "category": "productivity",
-      "keywords": [
-        "product-management",
-        "pm",
-        "ai-partner",
-        "skills",
-        "commands",
-        "hooks"
-      ],
-      "author": {
-        "name": "Ahmed Khaled",
-        "email": "ahmd.khaled.a.mohamed@gmail.com"
-      },
-      "components": {
-        "skills": 12,
-        "commands": 6,
-        "hooks": 3,
-        "total": 21
-      }
-    },
-    {
-      "name": "prettier-markdown-hook",
-      "source": "./plugins/productivity/prettier-markdown-hook",
-      "description": "Automatically format markdown files with prettier when Claude stops responding, with configurable organization and path exclusions",
-      "version": "1.8.0",
-      "category": "productivity",
-      "keywords": [
-        "prettier",
-        "markdown",
-        "formatting",
-        "automation",
-        "hook",
-        "stop",
-        "git",
-        "conventional-commits"
-      ],
-      "author": {
-        "name": "Terry Li",
-        "email": "[email protected]",
-        "url": "https://github.com/terrylica"
-      },
-      "components": {
-        "hooks": 1,
-        "total": 1
-      }
-    },
-    {
-      "name": "publishing-skills",
-      "source": "./plugins/productivity/publishing-skills",
-      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "ghost",
-        "blogging",
-        "seo",
-        "content-creation",
-        "publishing",
-        "claude-code",
-        "ai-writing"
-      ],
-      "author": {
-        "name": "AutomateLab",
-        "url": "https://github.com/AutomateLab-tech",
-        "email": "hello@automatelab.tech"
-      },
-      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
-      "license": "MIT-0"
-    },
-    {
-      "name": "schedule-after-usage-reset",
-      "source": "./plugins/productivity/schedule-after-usage-reset",
-      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "schedule",
-        "usage-reset",
-        "rate-limit",
-        "claude-code",
-        "automation"
-      ],
-      "author": {
-        "name": "patricksong1993",
-        "url": "https://github.com/patricksong1993"
-      },
-      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "license": "MIT"
-    },
-    {
-      "name": "skyvern",
-      "source": "./plugins/productivity/skyvern",
-      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
-      "version": "0.1.0",
-      "category": "productivity",
-      "author": {
-        "name": "Skyvern-AI",
-        "url": "https://github.com/Skyvern-AI"
-      },
-      "license": "AGPL-3.0"
-    },
-    {
-      "name": "travel-assistant",
-      "source": "./plugins/productivity/travel-assistant",
-      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
-      "version": "1.15.0",
-      "category": "productivity",
-      "keywords": [
-        "travel",
-        "weather",
-        "currency",
-        "timezone",
-        "itinerary",
-        "vacation",
-        "trip-planning",
-        "ai-travel",
-        "real-time",
-        "api-integration",
-        "budget",
-        "packing-list"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "components": {
-        "commands": 6,
-        "agents": 4,
-        "hooks": 2,
-        "scripts": 3,
-        "total": 15
-      }
-    },
-    {
-      "name": "vibe-guide",
-      "source": "./plugins/productivity/vibe-guide",
-      "description": "Non-technical progress summaries for Claude Code work (hides diffs/log noise).",
-      "version": "1.16.0",
-      "category": "productivity",
-      "keywords": [
-        "ux",
-        "accessibility",
-        "explain",
-        "pairing",
-        "non-technical",
-        "beginner-friendly",
-        "explanations",
-        "noise-filtering"
-      ],
-      "author": {
-        "name": "Intent Solutions",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 3,
-        "commands": 7,
-        "hooks": 1,
-        "total": 11
-      },
-      "tags": [
-        "beginner-friendly",
-        "explanations",
-        "noise-filtering"
-      ],
-      "strict": true
-    },
-    {
-      "name": "wondelai-design-sprint",
-      "source": "./plugins/productivity/wondelai-design-sprint",
-      "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "design-sprint",
-        "prototyping",
-        "user-testing",
-        "validation",
-        "gv",
-        "product-design",
-        "rapid-iteration",
-        "mvp"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "design-sprint"
-      },
-      "verification": {
-        "score": 58,
-        "grade": "F",
-        "badge": null,
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-lean-startup",
-      "source": "./plugins/productivity/wondelai-lean-startup",
-      "description": "Lean Startup methodology for validated learning, MVPs, and innovation accounting. Design experiments, decide when to pivot vs. persevere, and reduce development waste.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "lean-startup",
-        "mvp",
-        "validated-learning",
-        "pivot",
-        "metrics",
-        "innovation-accounting",
-        "experimentation",
-        "build-measure-learn"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "lean-startup"
-      },
-      "verification": {
-        "score": 63,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "youtube-strategy",
-      "source": "./plugins/productivity/youtube-strategy",
-      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
-      "version": "1.10.0",
-      "category": "productivity",
-      "keywords": [
-        "youtube",
-        "content-strategy",
-        "video-production",
-        "ideation",
-        "research",
-        "thumbnails",
-        "titles",
-        "outlining",
-        "content-creation"
-      ],
-      "author": {
-        "name": "Claude Code Plugins"
-      },
-      "components": {
-        "skills": 5,
-        "commands": 7,
-        "agents": 3
-      },
-      "verification": {
-        "score": 67,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "abridge-pack",
       "source": "./plugins/saas-packs/abridge-pack",
       "description": "Claude Code skill pack for Abridge (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "abridge",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["abridge", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -7890,12 +8185,7 @@
       "description": "Claude Code skill pack for Adobe (30 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "adobe",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["adobe", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -7917,12 +8207,7 @@
       "description": "Claude Code skill pack for Alchemy (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "alchemy",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["alchemy", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -7944,12 +8229,7 @@
       "description": "Claude Code skill pack for Algolia (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "algolia",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["algolia", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -7971,12 +8251,7 @@
       "description": "Claude Code skill pack for Anima (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "anima",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["anima", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -7998,12 +8273,7 @@
       "description": "Claude Code skill pack for Anthropic (30 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "anthropic",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["anthropic", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8025,12 +8295,7 @@
       "description": "Claude Code skill pack for Apify (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "apify",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["apify", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8047,48 +8312,12 @@
       }
     },
     {
-      "name": "apollo-pack",
-      "source": "./plugins/saas-packs/apollo-pack",
-      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "apollo",
-        "sales",
-        "prospecting",
-        "sequences",
-        "outbound",
-        "crm",
-        "sales-engagement",
-        "lead-generation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 65,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "appfolio-pack",
       "source": "./plugins/saas-packs/appfolio-pack",
       "description": "Claude Code skill pack for AppFolio (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "appfolio",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["appfolio", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8110,13 +8339,7 @@
       "description": "Claude Code skill pack for Apple Notes (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "apple-notes",
-        "apple notes",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["apple-notes", "apple notes", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8138,12 +8361,7 @@
       "description": "Claude Code skill pack for AssemblyAI (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "assemblyai",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["assemblyai", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8165,12 +8383,7 @@
       "description": "Claude Code skill pack for Attio (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "attio",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["attio", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8192,12 +8405,7 @@
       "description": "Claude Code skill pack for BambooHR (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "bamboohr",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["bamboohr", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8219,13 +8427,7 @@
       "description": "Claude Code skill pack for Bright Data (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "brightdata",
-        "bright data",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["brightdata", "bright data", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8247,12 +8449,7 @@
       "description": "Claude Code skill pack for Canva (30 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "canva",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["canva", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8274,13 +8471,7 @@
       "description": "Claude Code skill pack for Cast AI (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "castai",
-        "cast ai",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["castai", "cast ai", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8302,12 +8493,7 @@
       "description": "Claude Code skill pack for Clari (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "clari",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["clari", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8324,78 +8510,12 @@
       }
     },
     {
-      "name": "clay-pack",
-      "source": "./plugins/saas-packs/clay-pack",
-      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clay",
-        "data-enrichment",
-        "waterfall",
-        "gtm",
-        "sales-ops",
-        "lead-enrichment",
-        "ai-agents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "clerk-pack",
-      "source": "./plugins/saas-packs/clerk-pack",
-      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clerk",
-        "authentication",
-        "auth",
-        "users",
-        "identity",
-        "sso",
-        "embeddable-ui",
-        "user-management"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "clickhouse-pack",
       "source": "./plugins/saas-packs/clickhouse-pack",
       "description": "Claude Code skill pack for ClickHouse (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "clickhouse",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["clickhouse", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8417,12 +8537,7 @@
       "description": "Claude Code skill pack for ClickUp (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "clickup",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["clickup", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8439,46 +8554,12 @@
       }
     },
     {
-      "name": "coderabbit-pack",
-      "source": "./plugins/saas-packs/coderabbit-pack",
-      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "coderabbit",
-        "code-review",
-        "pr-automation",
-        "ai-review",
-        "code-quality",
-        "github-integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "cohere-pack",
       "source": "./plugins/saas-packs/cohere-pack",
       "description": "Claude Code skill pack for Cohere (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "cohere",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["cohere", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8500,12 +8581,7 @@
       "description": "Claude Code skill pack for CoreWeave (23 skills)",
       "version": "1.11.0",
       "category": "saas-packs",
-      "keywords": [
-        "coreweave",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["coreweave", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8522,170 +8598,12 @@
       }
     },
     {
-      "name": "cursor-pack",
-      "source": "./plugins/saas-packs/cursor-pack",
-      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "cursor",
-        "ai-editor",
-        "code-editor",
-        "composer",
-        "ai-coding",
-        "vscode-fork",
-        "copilot-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "customerio-pack",
-      "source": "./plugins/saas-packs/customerio-pack",
-      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "customerio",
-        "customer-io",
-        "marketing",
-        "email",
-        "automation",
-        "campaigns",
-        "sms",
-        "push-notifications"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 68,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "databricks-pack",
-      "source": "./plugins/saas-packs/databricks-pack",
-      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
-      "version": "2.27.0",
-      "category": "saas-packs",
-      "keywords": [
-        "databricks",
-        "delta-lake",
-        "mlflow",
-        "spark",
-        "notebooks",
-        "clusters",
-        "data-engineering",
-        "lakehouse"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "deepgram-pack",
-      "source": "./plugins/saas-packs/deepgram-pack",
-      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "deepgram",
-        "speech-to-text",
-        "transcription",
-        "voice",
-        "audio",
-        "asr",
-        "real-time",
-        "voice-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 65,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "documenso-pack",
-      "source": "./plugins/saas-packs/documenso-pack",
-      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "documenso",
-        "document-signing",
-        "e-signature",
-        "templates",
-        "workflows",
-        "contracts",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 66,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "elevenlabs-pack",
       "source": "./plugins/saas-packs/elevenlabs-pack",
       "description": "Claude Code skill pack for ElevenLabs (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "elevenlabs",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["elevenlabs", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8702,77 +8620,12 @@
       }
     },
     {
-      "name": "evernote-pack",
-      "source": "./plugins/saas-packs/evernote-pack",
-      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "evernote",
-        "notes",
-        "notebooks",
-        "tags",
-        "search",
-        "productivity",
-        "organization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "exa-pack",
-      "source": "./plugins/saas-packs/exa-pack",
-      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "exa",
-        "neural-search",
-        "semantic-search",
-        "web-search",
-        "ai-search",
-        "retrieval",
-        "embeddings"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "fathom-pack",
       "source": "./plugins/saas-packs/fathom-pack",
       "description": "Claude Code skill pack for Fathom (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "fathom",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["fathom", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8794,12 +8647,7 @@
       "description": "Claude Code skill pack for Figma (30 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "figma",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["figma", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8821,12 +8669,7 @@
       "description": "Claude Code skill pack for Finta (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "finta",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["finta", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8843,75 +8686,12 @@
       }
     },
     {
-      "name": "firecrawl-pack",
-      "source": "./plugins/saas-packs/firecrawl-pack",
-      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "firecrawl",
-        "web-scraping",
-        "crawling",
-        "markdown",
-        "llm-ready",
-        "data-extraction",
-        "scraper"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "fireflies-pack",
-      "source": "./plugins/saas-packs/fireflies-pack",
-      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "fireflies",
-        "meeting-transcription",
-        "ai-notes",
-        "conversation-intelligence",
-        "summaries"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "flexport-pack",
       "source": "./plugins/saas-packs/flexport-pack",
       "description": "Claude Code skill pack for Flexport (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "flexport",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["flexport", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8933,13 +8713,7 @@
       "description": "Claude Code skill pack for Fly.io (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "flyio",
-        "fly.io",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["flyio", "fly.io", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8961,12 +8735,7 @@
       "description": "Claude Code skill pack for Fondo (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "fondo",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["fondo", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8988,12 +8757,7 @@
       "description": "Claude Code skill pack for Framer (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "framer",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["framer", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9010,78 +8774,12 @@
       }
     },
     {
-      "name": "ga4-pack",
-      "source": "./plugins/saas-packs/ga4-pack",
-      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
-      "version": "1.2.0",
-      "category": "saas-packs",
-      "keywords": [
-        "google-analytics",
-        "ga4",
-        "analytics",
-        "data-api",
-        "bigquery",
-        "reporting",
-        "dau-mau",
-        "cohort-retention"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 5
-      },
-      "verification": {
-        "score": 70,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-05-20T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gamma-pack",
-      "source": "./plugins/saas-packs/gamma-pack",
-      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "gamma",
-        "presentations",
-        "documents",
-        "ai-generation",
-        "templates",
-        "slides",
-        "visual-content"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 71,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "glean-pack",
       "source": "./plugins/saas-packs/glean-pack",
       "description": "Claude Code skill pack for Glean (24 skills)",
       "version": "1.8.0",
       "category": "saas-packs",
-      "keywords": [
-        "glean",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["glean", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9103,12 +8801,7 @@
       "description": "Claude Code skill pack for Grammarly (24 skills)",
       "version": "1.8.0",
       "category": "saas-packs",
-      "keywords": [
-        "grammarly",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["grammarly", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9125,107 +8818,12 @@
       }
     },
     {
-      "name": "granola-pack",
-      "source": "./plugins/saas-packs/granola-pack",
-      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "granola",
-        "meeting-notes",
-        "transcription",
-        "summaries",
-        "meetings",
-        "ai-notes",
-        "meeting-intelligence"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 72,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "groq-pack",
-      "source": "./plugins/saas-packs/groq-pack",
-      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "groq",
-        "lpu",
-        "fast-inference",
-        "llm",
-        "groq-cloud",
-        "low-latency",
-        "ai-acceleration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "guidewire-pack",
-      "source": "./plugins/saas-packs/guidewire-pack",
-      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
-      "version": "1.25.0",
-      "category": "saas-packs",
-      "keywords": [
-        "guidewire",
-        "insurance",
-        "policycenter",
-        "claimcenter",
-        "billingcenter",
-        "insurancesuite",
-        "enterprise"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 62,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "hex-pack",
       "source": "./plugins/saas-packs/hex-pack",
       "description": "Claude Code skill pack for Hex (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "hex",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["hex", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9247,12 +8845,7 @@
       "description": "Claude Code skill pack for Hootsuite (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "hootsuite",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["hootsuite", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9274,12 +8867,7 @@
       "description": "Claude Code skill pack for HubSpot (10 production-engineer skills)",
       "version": "2.9.0",
       "category": "saas-packs",
-      "keywords": [
-        "hubspot",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["hubspot", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9290,76 +8878,12 @@
       }
     },
     {
-      "name": "ideogram-pack",
-      "source": "./plugins/saas-packs/ideogram-pack",
-      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
-      "version": "1.10.0",
-      "category": "saas-packs",
-      "keywords": [
-        "ideogram",
-        "image-generation",
-        "text-to-image",
-        "ai-art",
-        "typography",
-        "creative",
-        "design"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "instantly-pack",
-      "source": "./plugins/saas-packs/instantly-pack",
-      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "instantly",
-        "cold-email",
-        "outreach",
-        "email-automation",
-        "lead-generation",
-        "sales"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "intercom-pack",
       "source": "./plugins/saas-packs/intercom-pack",
       "description": "Claude Code skill pack for Intercom (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "intercom",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["intercom", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9373,36 +8897,6 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "juicebox-pack",
-      "source": "./plugins/saas-packs/juicebox-pack",
-      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
-      "version": "1.16.0",
-      "category": "saas-packs",
-      "keywords": [
-        "juicebox",
-        "people-data",
-        "enrichment",
-        "contacts",
-        "search",
-        "data-api",
-        "lead-enrichment"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 71,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -9411,12 +8905,7 @@
       "description": "Claude Code skill pack for Klaviyo (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "klaviyo",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["klaviyo", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9430,152 +8919,6 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "klingai-pack",
-      "source": "./plugins/saas-packs/klingai-pack",
-      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "klingai",
-        "kling",
-        "video-generation",
-        "text-to-video",
-        "ai-video",
-        "generative-ai",
-        "creative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "langchain-py-pack",
-      "source": "./plugins/saas-packs/langchain-py-pack",
-      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
-      "version": "2.5.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langchain",
-        "langgraph",
-        "python",
-        "llm",
-        "agents",
-        "rag",
-        "checkpointing",
-        "streaming",
-        "middleware",
-        "langsmith"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 2
-      }
-    },
-    {
-      "name": "langfuse-pack",
-      "source": "./plugins/saas-packs/langfuse-pack",
-      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langfuse",
-        "observability",
-        "tracing",
-        "prompts",
-        "evaluation",
-        "llm-ops",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 67,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "lindy-pack",
-      "source": "./plugins/saas-packs/lindy-pack",
-      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
-      "version": "1.15.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lindy",
-        "ai-assistant",
-        "automation",
-        "workflows",
-        "tasks",
-        "intelligent-automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 75,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "linear-pack",
-      "source": "./plugins/saas-packs/linear-pack",
-      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "linear",
-        "issues",
-        "project-management",
-        "tracking",
-        "workflows",
-        "agile",
-        "team-collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 67,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -9584,12 +8927,7 @@
       "description": "Claude Code skill pack for Linktree (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "linktree",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["linktree", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9603,36 +8941,6 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "lokalise-pack",
-      "source": "./plugins/saas-packs/lokalise-pack",
-      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lokalise",
-        "translation",
-        "localization",
-        "i18n",
-        "l10n",
-        "tms",
-        "internationalization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -9641,12 +8949,7 @@
       "description": "Claude Code skill pack for Lucidchart (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "lucidchart",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["lucidchart", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9663,47 +8966,12 @@
       }
     },
     {
-      "name": "maintainx-pack",
-      "source": "./plugins/saas-packs/maintainx-pack",
-      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "maintainx",
-        "cmms",
-        "work-orders",
-        "maintenance",
-        "assets",
-        "facilities",
-        "operations"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "mindtickle-pack",
       "source": "./plugins/saas-packs/mindtickle-pack",
       "description": "Claude Code skill pack for Mindtickle (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "mindtickle",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["mindtickle", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9725,12 +8993,7 @@
       "description": "Claude Code skill pack for Miro (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "miro",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["miro", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9747,47 +9010,12 @@
       }
     },
     {
-      "name": "mistral-pack",
-      "source": "./plugins/saas-packs/mistral-pack",
-      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "mistral",
-        "llm",
-        "inference",
-        "embeddings",
-        "fine-tuning",
-        "ai",
-        "machine-learning"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 68,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "navan-pack",
       "source": "./plugins/saas-packs/navan-pack",
       "description": "Claude Code skill pack for Navan (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "navan",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["navan", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9809,12 +9037,7 @@
       "description": "Claude Code skill pack for Notion (30 skills)",
       "version": "1.38.0",
       "category": "saas-packs",
-      "keywords": [
-        "notion",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["notion", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9831,47 +9054,12 @@
       }
     },
     {
-      "name": "obsidian-pack",
-      "source": "./plugins/saas-packs/obsidian-pack",
-      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "obsidian",
-        "notes",
-        "vault",
-        "plugins",
-        "markdown",
-        "knowledge-management",
-        "pkm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "onenote-pack",
       "source": "./plugins/saas-packs/onenote-pack",
       "description": "Claude Code skill pack for OneNote (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "onenote",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["onenote", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9888,77 +9076,12 @@
       }
     },
     {
-      "name": "openevidence-pack",
-      "source": "./plugins/saas-packs/openevidence-pack",
-      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openevidence",
-        "medical-ai",
-        "clinical",
-        "healthcare",
-        "evidence-based",
-        "decision-support",
-        "medicine"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 66,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "openrouter-pack",
-      "source": "./plugins/saas-packs/openrouter-pack",
-      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-      "version": "1.20.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openrouter",
-        "llm-routing",
-        "model-selection",
-        "ai-gateway",
-        "multi-model",
-        "cost-optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "oraclecloud-pack",
       "source": "./plugins/saas-packs/oraclecloud-pack",
       "description": "Claude Code skill pack for Oracle Cloud (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "oraclecloud",
-        "oracle cloud",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["oraclecloud", "oracle cloud", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9980,12 +9103,7 @@
       "description": "Claude Code skill pack for Palantir (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "palantir",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["palantir", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10002,47 +9120,12 @@
       }
     },
     {
-      "name": "perplexity-pack",
-      "source": "./plugins/saas-packs/perplexity-pack",
-      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "perplexity",
-        "ai-search",
-        "research",
-        "citations",
-        "real-time",
-        "knowledge",
-        "answers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "persona-pack",
       "source": "./plugins/saas-packs/persona-pack",
       "description": "Claude Code skill pack for Persona (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "persona",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["persona", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10091,46 +9174,12 @@
       }
     },
     {
-      "name": "posthog-pack",
-      "source": "./plugins/saas-packs/posthog-pack",
-      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "posthog",
-        "product-analytics",
-        "feature-flags",
-        "session-replay",
-        "ab-testing",
-        "experimentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "procore-pack",
       "source": "./plugins/saas-packs/procore-pack",
       "description": "Claude Code skill pack for Procore (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "procore",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["procore", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10152,12 +9201,7 @@
       "description": "Claude Code skill pack for QuickNode (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "quicknode",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["quicknode", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10179,12 +9223,7 @@
       "description": "Claude Code skill pack for Ramp (24 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "ramp",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["ramp", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10206,12 +9245,7 @@
       "description": "Claude Code skill pack for RemoFirst (12 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "remofirst",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["remofirst", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10228,77 +9262,12 @@
       }
     },
     {
-      "name": "replit-pack",
-      "source": "./plugins/saas-packs/replit-pack",
-      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "replit",
-        "cloud-ide",
-        "deployments",
-        "collaborative",
-        "ai-coding",
-        "browser-ide",
-        "hosting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "retellai-pack",
-      "source": "./plugins/saas-packs/retellai-pack",
-      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
-      "version": "1.9.0",
-      "category": "saas-packs",
-      "keywords": [
-        "retellai",
-        "retell",
-        "voice-ai",
-        "phone-agents",
-        "conversational-ai",
-        "call-center",
-        "ivr"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "runway-pack",
       "source": "./plugins/saas-packs/runway-pack",
       "description": "Claude Code skill pack for Runway (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "runway",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["runway", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10320,12 +9289,7 @@
       "description": "Claude Code skill pack for Salesforce (30 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": [
-        "salesforce",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["salesforce", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10347,12 +9311,7 @@
       "description": "Claude Code skill pack for Salesloft (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "salesloft",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["salesloft", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10369,47 +9328,12 @@
       }
     },
     {
-      "name": "sentry-pack",
-      "source": "./plugins/saas-packs/sentry-pack",
-      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
-      "version": "1.51.0",
-      "category": "saas-packs",
-      "keywords": [
-        "sentry",
-        "error-monitoring",
-        "performance",
-        "observability",
-        "debugging",
-        "crash-reporting",
-        "apm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "serpapi-pack",
       "source": "./plugins/saas-packs/serpapi-pack",
       "description": "Claude Code skill pack for SerpApi (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": [
-        "serpapi",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["serpapi", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10460,12 +9384,7 @@
       "description": "Claude Code skill pack for Snowflake (30 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "snowflake",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["snowflake", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10482,47 +9401,12 @@
       }
     },
     {
-      "name": "speak-pack",
-      "source": "./plugins/saas-packs/speak-pack",
-      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "speak",
-        "language-learning",
-        "speech",
-        "ai-tutor",
-        "education",
-        "conversation",
-        "edtech"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 68,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "stackblitz-pack",
       "source": "./plugins/saas-packs/stackblitz-pack",
       "description": "Claude Code skill pack for StackBlitz (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "stackblitz",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["stackblitz", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10539,52 +9423,12 @@
       }
     },
     {
-      "name": "supabase-pack",
-      "source": "./plugins/saas-packs/supabase-pack",
-      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.53.0",
-      "category": "saas-packs",
-      "keywords": [
-        "supabase",
-        "postgres",
-        "database",
-        "authentication",
-        "realtime",
-        "storage",
-        "edge-functions",
-        "rls",
-        "row-level-security",
-        "baas",
-        "backend-as-a-service",
-        "firebase-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "techsmith-pack",
       "source": "./plugins/saas-packs/techsmith-pack",
       "description": "Claude Code skill pack for TechSmith (18 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": [
-        "techsmith",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["techsmith", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10606,13 +9450,7 @@
       "description": "Claude Code skill pack for Together AI (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": [
-        "together",
-        "together ai",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["together", "together ai", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10629,77 +9467,12 @@
       }
     },
     {
-      "name": "twinmind-pack",
-      "source": "./plugins/saas-packs/twinmind-pack",
-      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "twinmind",
-        "meetings",
-        "transcription",
-        "summaries",
-        "ai-assistant",
-        "productivity",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 66,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "vastai-pack",
-      "source": "./plugins/saas-packs/vastai-pack",
-      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vastai",
-        "vast-ai",
-        "gpu-marketplace",
-        "cloud-gpu",
-        "ml-infrastructure",
-        "compute",
-        "training"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "veeva-pack",
       "source": "./plugins/saas-packs/veeva-pack",
       "description": "Claude Code skill pack for Veeva (24 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": [
-        "veeva",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["veeva", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10713,39 +9486,6 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "vercel-pack",
-      "source": "./plugins/saas-packs/vercel-pack",
-      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vercel",
-        "deployment",
-        "edge-functions",
-        "serverless",
-        "preview",
-        "ci-cd",
-        "hosting",
-        "next-js",
-        "jamstack",
-        "frontend-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -10754,12 +9494,7 @@
       "description": "Claude Code skill pack for Webflow (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": [
-        "webflow",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["webflow", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10776,47 +9511,12 @@
       }
     },
     {
-      "name": "windsurf-pack",
-      "source": "./plugins/saas-packs/windsurf-pack",
-      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "windsurf",
-        "ai-editor",
-        "cascade",
-        "codeium",
-        "ai-coding",
-        "code-completion",
-        "refactoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "wispr-pack",
       "source": "./plugins/saas-packs/wispr-pack",
       "description": "Claude Code skill pack for Wispr (18 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": [
-        "wispr",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["wispr", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10838,12 +9538,7 @@
       "description": "Claude Code skill pack for Workhuman (18 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": [
-        "workhuman",
-        "saas",
-        "sdk",
-        "integration"
-      ],
+      "keywords": ["workhuman", "saas", "sdk", "integration"],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -10860,25 +9555,1094 @@
       }
     },
     {
-      "name": "access-control-auditor",
-      "source": "./plugins/security/access-control-auditor",
-      "description": "Audit access control implementations",
-      "version": "1.24.0",
-      "category": "security",
+      "name": "pm-ai-partner",
+      "source": "./plugins/productivity/pm-ai-partner",
+      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
+      "version": "1.8.0",
+      "category": "productivity",
+      "keywords": ["product-management", "pm", "ai-partner", "skills", "commands", "hooks"],
+      "author": {
+        "name": "Ahmed Khaled",
+        "email": "ahmd.khaled.a.mohamed@gmail.com"
+      },
+      "components": {
+        "skills": 12,
+        "commands": 6,
+        "hooks": 3,
+        "total": 21
+      }
+    },
+    {
+      "name": "validate-plugin",
+      "source": "./plugins/skill-enhancers/validate-plugin",
+      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
+      "version": "1.8.0",
+      "category": "skill-enhancers",
+      "keywords": ["validation", "plugin-development", "quality-assurance", "linting"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "zero-tech-debt",
+      "source": "./plugins/skill-enhancers/zero-tech-debt",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only \u2014 surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "version": "1.1.0",
+      "category": "skill-enhancers",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
+        "refactoring",
+        "tech-debt",
+        "architecture",
+        "cleanup",
+        "modernization",
+        "code-quality"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "executive-assistant-skills",
+      "source": "./plugins/business-tools/executive-assistant-skills",
+      "version": "1.8.0",
+      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
+      "author": {
+        "name": "Martin Gontovnikas",
+        "email": "gonto@hypergrowthpartners.com",
+        "url": "https://github.com/mgonto"
+      },
+      "category": "business-tools",
+      "keywords": [
+        "executive-assistant",
+        "meeting-prep",
+        "email",
+        "productivity",
+        "automation",
+        "todoist"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/mgonto/executive-assistant-skills",
+      "featured": true,
+      "components": {
+        "skills": 5
+      }
+    },
+    {
+      "name": "box-cloud-filesystem",
+      "source": "./plugins/productivity/box-cloud-filesystem",
+      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "box",
+        "cloud-storage",
+        "filesystem",
+        "file-sync",
+        "box-cli",
+        "upload",
+        "download",
+        "document-management",
+        "collaboration",
+        "ai-agent-storage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT",
+      "featured": true,
+      "pricing": "free",
+      "external_sync": true,
+      "components": {
+        "skills": 1,
+        "hooks": 2
       },
       "verification": {
-        "score": 96,
+        "score": 0,
+        "grade": "N/A",
+        "badge": "none",
+        "lastValidated": "2026-03-17T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "pr-to-spec",
+      "source": "./plugins/mcp/pr-to-spec",
+      "description": "The flight envelope for agentic coding \u2014 convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+      "version": "0.8.0",
+      "category": "mcp",
+      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "license": "MIT",
+      "featured": true,
+      "external_sync": true,
+      "mcpTools": 6,
+      "keywords": ["mcp", "pr-analysis", "intent-drift", "code-review", "agent-protocol"]
+    },
+    {
+      "name": "slack-channel",
+      "source": "./plugins/mcp/slack-channel",
+      "description": "Two-way Slack channel for Claude Code \u2014 chat from Slack DMs and channels via Socket Mode",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": ["slack", "channel", "mcp", "socket-mode", "chatops", "claude-code"],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT",
+      "featured": true,
+      "pricing": "free",
+      "external_sync": true,
+      "mcpTools": 5,
+      "components": {
+        "skills": 2
+      }
+    },
+    {
+      "name": "x-bug-triage-plugin",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage: X complaints \u2192 clusters \u2192 repo evidence \u2192 owner routing \u2192 Slack review \u2192 filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "keywords": ["bug-triage", "x-twitter", "slack", "devops", "mcp"],
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT",
+      "featured": false,
+      "pricing": "free",
+      "external_sync": true,
+      "mcpTools": 6,
+      "components": {
+        "skills": 5,
+        "agents": 4
+      }
+    },
+    {
+      "name": "framecraft",
+      "source": "./plugins/community/framecraft",
+      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
+      "version": "1.3.0",
+      "category": "community",
+      "keywords": ["demo-video", "video-generation", "playwright", "ffmpeg", "edge-tts", "mcp"],
+      "author": {
+        "name": "vaddisrinivas",
+        "url": "https://github.com/vaddisrinivas"
+      },
+      "components": {
+        "skills": 1
+      },
+      "featured": false
+    },
+    {
+      "name": "tweetclaw",
+      "source": "./plugins/devops/tweetclaw",
+      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
+      "version": "1.5.3",
+      "category": "devops",
+      "keywords": [
+        "twitter",
+        "x",
+        "automation",
+        "social-media",
+        "tweets",
+        "monitoring",
+        "giveaway",
+        "scraping"
+      ],
+      "author": {
+        "name": "Burak Bayir",
+        "email": "burak@xquik.com",
+        "url": "https://xquik.com"
+      },
+      "repository": "https://github.com/Xquik-dev/tweetclaw",
+      "homepage": "https://xquik.com",
+      "license": "MIT",
+      "pricing": "paid",
+      "components": {
+        "skills": 1,
+        "commands": 2
+      }
+    },
+    {
+      "name": "shipwright",
+      "source": "./plugins/ai-agency/shipwright",
+      "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+      "version": "1.3.0",
+      "category": "ai-agency",
+      "author": {
+        "name": "Nate Nelson",
+        "url": "https://github.com/Wynelson94"
+      },
+      "keywords": [
+        "app-builder",
+        "code-generator",
+        "autonomous-agent",
+        "pipeline",
+        "nextjs",
+        "supabase",
+        "sveltekit",
+        "astro",
+        "ai-agency"
+      ],
+      "repository": "https://github.com/Wynelson94/shipwright",
+      "homepage": "https://github.com/Wynelson94/shipwright",
+      "license": "MIT",
+      "featured": false,
+      "pricing": "free",
+      "components": {
+        "skills": 1,
+        "commands": 4
+      }
+    },
+    {
+      "name": "hyperfocus",
+      "source": "./plugins/productivity/hyperfocus",
+      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
+      "version": "0.2.0",
+      "category": "productivity",
+      "author": {
+        "name": "Nestor Magalhaes",
+        "email": "nestor.magalhaes@appex.world"
+      },
+      "keywords": [
+        "accessibility",
+        "adhd",
+        "neurodivergent",
+        "formatting",
+        "readability",
+        "productivity",
+        "cognitive-accessibility"
+      ],
+      "repository": "https://github.com/nextor2k/hyperfocus",
+      "homepage": "https://github.com/nextor2k/hyperfocus",
+      "license": "MIT",
+      "featured": false,
+      "pricing": "free",
+      "components": {
+        "skills": 1,
+        "agents": 0
+      }
+    },
+    {
+      "name": "plane",
+      "source": "./plugins/productivity/plane",
+      "description": "Plane is a team behavior observatory \u2014 synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+      "tagline": "Team behavior observatory for Plane workspaces",
+      "version": "0.3.0",
+      "category": "productivity",
+      "keywords": [
+        "plane",
+        "project-management",
+        "team-behavior",
+        "observability",
+        "productivity",
+        "agent-skills",
+        "forge-generated"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 2
+      },
+      "generated": true,
+      "author_type": "forge"
+    },
+    {
+      "name": "local-tts",
+      "source": "./plugins/ai-ml/local-tts",
+      "description": "Offline text-to-speech via VoxCPM2 \u2014 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+      "version": "1.3.0",
+      "category": "ai-ml",
+      "keywords": [
+        "tts",
+        "text-to-speech",
+        "voice",
+        "voice-cloning",
+        "voice-design",
+        "offline",
+        "voxcpm",
+        "apple-silicon",
+        "audio",
+        "narration"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "Apache-2.0",
+      "repository": "https://github.com/vdk888/local-tts"
+    },
+    {
+      "name": "boycott-filter",
+      "source": "./plugins/community/boycott-filter",
+      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
+      "version": "1.2.0",
+      "category": "community",
+      "keywords": [
+        "boycott",
+        "consumer",
+        "shopping",
+        "brands",
+        "chrome-extension",
+        "conversational",
+        "privacy",
+        "ethical-consumption"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "web-analytics",
+      "source": "./plugins/analytics/web-analytics",
+      "description": "Push-based web analytics intelligence team \u2014 self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
+      "version": "1.4.0",
+      "category": "analytics",
+      "keywords": [
+        "analytics",
+        "umami",
+        "ga4",
+        "traffic",
+        "mcp",
+        "self-hosted",
+        "multi-agent",
+        "push-based"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 9
+      },
+      "verification": {
+        "score": 85,
         "grade": "A",
         "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "aomi",
+      "source": "./plugins/crypto/aomi",
+      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
+      "version": "0.10.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "defi",
+        "web3",
+        "evm",
+        "ethereum",
+        "wallet",
+        "account-abstraction",
+        "trading",
+        "agent",
+        "mcp"
+      ],
+      "author": {
+        "name": "aomi-labs",
+        "url": "https://aomi.dev",
+        "email": "info@aomi.dev"
+      },
+      "featured": false
+    },    {
+      "name": "cli-power-skills",
+      "source": "./plugins/productivity/cli-power-skills",
+      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "cli-tools",
+        "agentic-skills",
+        "data-processing",
+        "security",
+        "web-crawling",
+        "python",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Yuriy Kotik",
+        "url": "https://github.com/ykotik"
+      },
+      "repository": "https://github.com/ykotik/cli-power-skills",
+      "license": "MIT"
+    },    {
+      "name": "claude-workflow-skills",
+      "source": "./plugins/productivity/claude-workflow-skills",
+      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
+      "version": "1.7.1",
+      "category": "productivity",
+      "keywords": [
+        "workflow",
+        "promote",
+        "release",
+        "audit",
+        "standards",
+        "improve",
+        "triage",
+        "git",
+        "review",
+        "pull-request"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
+      "repository": "https://github.com/ali5ter/claude-workflow-skills",
+      "license": "MIT"
+    },    {
+      "name": "cli-ux-tester",
+      "source": "./plugins/testing/cli-ux-tester",
+      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
+      "version": "3.1.0",
+      "category": "testing",
+      "keywords": [
+        "CLI",
+        "UX",
+        "testing",
+        "developer-experience",
+        "terminal",
+        "usability"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "license": "MIT"
+    },    {
+      "name": "skyvern",
+      "source": "./plugins/productivity/skyvern",
+      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
+      "version": "0.1.0",
+      "category": "productivity",
+      "author": {
+        "name": "Skyvern-AI",
+        "url": "https://github.com/Skyvern-AI"
+      },
+      "license": "AGPL-3.0"
+    },    {
+      "name": "tonone",
+      "source": "./plugins/ai-agency/tonone",
+      "description": "23-agent engineering + product team with 125 skills for Claude Code",
+      "version": "1.8.0",
+      "category": "ai-agency",
+      "keywords": [
+        "agents",
+        "engineering-team",
+        "infrastructure",
+        "devops",
+        "backend",
+        "security",
+        "observability",
+        "frontend",
+        "ml",
+        "mobile",
+        "embedded",
+        "analytics",
+        "testing",
+        "platform",
+        "sales",
+        "revenue",
+        "customer-success",
+        "content-marketing",
+        "pr",
+        "community",
+        "finance",
+        "people",
+        "operations",
+        "support"
+      ],
+      "author": {
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
+      },
+      "repository": "https://github.com/tonone-ai/tonone",
+      "license": "MIT"
+    },    {
+      "name": "x-bug-triage",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "triage",
+        "x-api",
+        "bug-tracking",
+        "clustering"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "license": "MIT"
+    },    {
+      "name": "hyperflow",
+      "source": "./plugins/ai-agency/hyperflow",
+      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
+      "version": "4.26.1",
+      "category": "ai-agency",
+      "keywords": [
+        "claude-code-plugin",
+        "multi-agent",
+        "dynamic-workflows",
+        "workflow-chain",
+        "triageflow",
+        "personas",
+        "flow-profiles",
+        "code-review",
+        "project-memory",
+        "multi-tool"
+      ],
+      "author": {
+        "name": "Mohammed Abdelhady",
+        "url": "https://github.com/Mohammed-Abdelhady"
+      },
+      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "license": "MIT"
+    },    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },    {
+      "name": "ejentum-anti-deception",
+      "source": "./plugins/community/ejentum-anti-deception",
+      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },    {
+      "name": "ejentum-code",
+      "source": "./plugins/community/ejentum-code",
+      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },    {
+      "name": "ejentum-memory",
+      "source": "./plugins/community/ejentum-memory",
+      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },    {
+      "name": "ejentum-reasoning",
+      "source": "./plugins/community/ejentum-reasoning",
+      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },    {
+      "name": "over-50s-health",
+      "source": "./plugins/productivity/over-50s-health",
+      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
+      "version": "3.3.0",
+      "category": "productivity",
+      "keywords": [
+        "health",
+        "fitness",
+        "nutrition",
+        "longevity",
+        "50+"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
+      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
+      "license": "MIT"
+    },    {
+      "name": "obsidian-project-documentation",
+      "source": "./plugins/productivity/obsidian-project-documentation",
+      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
+      "version": "3.2.5",
+      "category": "productivity",
+      "keywords": [
+        "obsidian",
+        "documentation",
+        "notes",
+        "projects"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
+      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
+      "license": "MIT"
+    },    {
+      "name": "pair-programmer",
+      "source": "./plugins/productivity/pair-programmer",
+      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "pair-programming",
+        "coding",
+        "skill-development",
+        "graduated-assistance"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/pair-programmer",
+      "repository": "https://github.com/ali5ter/pair-programmer",
+      "license": "MIT"
+    },    {
+      "name": "governed-second-brain",
+      "source": "./plugins/mcp/governed-second-brain",
+      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
+      "version": "1.1.2",
+      "category": "mcp",
+      "keywords": [
+        "memory",
+        "knowledge",
+        "governance",
+        "qmd",
+        "brain",
+        "citations",
+        "local-first",
+        "second-brain"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "license": "Apache-2.0"
+    },    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "databricks-workspace-mcp",
+      "source": "./plugins/mcp/databricks-workspace-mcp",
+      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "model-context-protocol",
+        "databricks",
+        "lakehouse",
+        "unity-catalog",
+        "clusters",
+        "dlt",
+        "finops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://tonsofskills.com/learn/databricks/",
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "license": "MIT",
+      "mcpTools": 8
+    },
+    {
+      "name": "beads-dolt",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "beads",
+        "bd",
+        "dolt",
+        "dolthub",
+        "task-tracking",
+        "mcp",
+        "version-control",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "publishing-skills",
+      "source": "./plugins/productivity/publishing-skills",
+      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "ghost",
+        "blogging",
+        "seo",
+        "content-creation",
+        "publishing",
+        "claude-code",
+        "ai-writing"
+      ],
+      "author": {
+        "name": "AutomateLab",
+        "url": "https://github.com/AutomateLab-tech",
+        "email": "hello@automatelab.tech"
+      },
+      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
+      "license": "MIT-0"
+    },
+    {
+      "name": "dolt-mcp-vcs",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "dolt-mcp-vcs",
+        "dolt",
+        "dolthub",
+        "dolt-mcp",
+        "version-control",
+        "vcs",
+        "mcp",
+        "sql",
+        "beads",
+        "bd"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./plugins/community/hermes-tweet",
+      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
+      "version": "0.1.6",
+      "category": "community",
+      "keywords": [
+        "hermes-agent",
+        "hermes-plugin",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
+      ],
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
+      "repository": "https://github.com/Xquik-dev/hermes-tweet",
+      "license": "MIT"
+    },
+    {
+      "name": "x-twitter-scraper",
+      "source": "./plugins/api-development/x-twitter-scraper",
+      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
+      "version": "0.1.0",
+      "category": "api-development",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
+      "license": "MIT"
+    },
+    {
+      "name": "servicegraph",
+      "source": "./plugins/mcp/servicegraph",
+      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
+      "version": "0.2.0",
+      "category": "mcp",
+      "keywords": [
+        "servicegraph",
+        "service-providers",
+        "agencies",
+        "law-firms",
+        "consulting",
+        "accounting",
+        "marketing",
+        "lead-generation",
+        "professional-services",
+        "us-firms",
+        "product-directories",
+        "saas-directories",
+        "mcp-directories",
+        "ai-directories",
+        "product-launch",
+        "backlinks"
+      ],
+      "author": {
+        "name": "Artur Briugeman",
+        "url": "https://servicegraph.co",
+        "email": "artur@nostr.band"
+      },
+      "homepage": "https://servicegraph.co",
+      "repository": "https://github.com/nostrband/servicegraph",
+      "license": "MIT"
+    },
+    {
+      "name": "schedule-after-usage-reset",
+      "source": "./plugins/productivity/schedule-after-usage-reset",
+      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "schedule",
+        "usage-reset",
+        "rate-limit",
+        "claude-code",
+        "automation"
+      ],
+      "author": {
+        "name": "patricksong1993",
+        "url": "https://github.com/patricksong1993"
+      },
+      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "mnemos",
+      "source": "./plugins/community/mnemos",
+      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
+      "version": "0.9.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "mcp",
+        "claude-code",
+        "persistent-memory",
+        "agent-memory",
+        "knowledge-graph",
+        "context",
+        "skill",
+        "observations",
+        "provenance",
+        "learning-loop",
+        "golang"
+      ],
+      "author": {
+        "name": "André Figueira",
+        "url": "https://polyxmedia.com",
+        "email": "andre@polyxmedia.com"
+      },
+      "homepage": "https://github.com/polyxmedia/mnemos",
+      "repository": "https://github.com/polyxmedia/mnemos",
+      "license": "MIT"
+    },
+    {
+      "name": "portaljs",
+      "source": "./plugins/community/portaljs",
+      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
+      "version": "0.1.0",
+      "category": "community",
+      "keywords": [
+        "portaljs",
+        "data-portal",
+        "ckan",
+        "nextjs",
+        "data-catalog"
+      ],
+      "author": {
+        "name": "Datopian",
+        "url": "https://www.datopian.com"
+      },
+      "homepage": "https://github.com/datopian/portaljs",
+      "repository": "https://github.com/datopian/portaljs",
+      "license": "MIT"
+    },
+    {
+      "name": "llm-box",
+      "source": "./plugins/community/llm-box",
+      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
+      "version": "0.3.0",
+      "category": "community",
+      "keywords": [
+        "workflow",
+        "automation",
+        "terminal",
+        "cli",
+        "yaml",
+        "llm",
+        "mcp"
+      ],
+      "author": {
+        "name": "alib8b8",
+        "url": "https://github.com/alib8b8"
+      },
+      "homepage": "https://github.com/alib8b8/llm-box",
+      "repository": "https://github.com/alib8b8/llm-box",
+      "license": "MIT"
+    },
+    {
+      "name": "j-rig",
+      "source": "./plugins/productivity/j-rig",
+      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "skill-refiner",
+        "eval-guided",
+        "skill-md",
+        "meta-tooling",
+        "hooks"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "intent-labs-pack",
+      "source": "./plugins/productivity/intent-labs-pack",
+      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "audit-tests",
+        "validate-skillmd",
+        "testing",
+        "skill-validation",
+        "intent-eval",
+        "dogfood"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 2,
+        "commands": 0,
+        "agents": 0,
+        "total": 2
       }
     },
     {
@@ -10906,1479 +10670,119 @@
       "license": "MIT"
     },
     {
-      "name": "authentication-validator",
-      "source": "./plugins/security/authentication-validator",
-      "description": "Validate authentication implementations",
-      "version": "1.26.0",
-      "category": "security",
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "compliance-report-generator",
-      "source": "./plugins/security/compliance-report-generator",
-      "description": "Generate compliance reports",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cors-policy-validator",
-      "source": "./plugins/security/cors-policy-validator",
-      "description": "Validate CORS policies",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "csrf-protection-validator",
-      "source": "./plugins/security/csrf-protection-validator",
-      "description": "Validate CSRF protection",
-      "version": "1.26.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-privacy-scanner",
-      "source": "./plugins/security/data-privacy-scanner",
-      "description": "Scan for data privacy issues",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "dependency-checker",
-      "source": "./plugins/security/dependency-checker",
-      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "dependencies",
-        "npm",
-        "pip",
-        "composer",
-        "vulnerabilities"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "encryption-tool",
-      "source": "./plugins/security/encryption-tool",
-      "description": "Encrypt and decrypt data with various algorithms",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gdpr-compliance-scanner",
-      "source": "./plugins/security/gdpr-compliance-scanner",
-      "description": "Scan for GDPR compliance issues",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "hipaa-compliance-checker",
-      "source": "./plugins/security/hipaa-compliance-checker",
-      "description": "Check HIPAA compliance",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "input-validation-scanner",
-      "source": "./plugins/security/input-validation-scanner",
-      "description": "Scan input validation practices",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "owasp-compliance-checker",
-      "source": "./plugins/security/owasp-compliance-checker",
-      "description": "Check OWASP Top 10 compliance",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "pci-dss-validator",
-      "source": "./plugins/security/pci-dss-validator",
-      "description": "Validate PCI DSS compliance",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "penetration-tester",
-      "source": "./plugins/security/penetration-tester",
-      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
-      "version": "3.30.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "penetration-testing",
-        "pentesting",
-        "owasp",
-        "owasp-top-10",
-        "vulnerability-scanning",
-        "dependency-audit",
-        "license-compliance",
-        "engagement-governance",
-        "chain-of-custody"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 84,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "secret-scanner",
-      "source": "./plugins/security/secret-scanner",
-      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "secrets",
-        "api-keys",
-        "credentials",
-        "passwords"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-audit-reporter",
-      "source": "./plugins/security/security-audit-reporter",
-      "description": "Generate comprehensive security audit reports",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-headers-analyzer",
-      "source": "./plugins/security/security-headers-analyzer",
-      "description": "Analyze HTTP security headers",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-incident-responder",
-      "source": "./plugins/security/security-incident-responder",
-      "description": "Assist with security incident response",
-      "version": "1.32.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-misconfiguration-finder",
-      "source": "./plugins/security/security-misconfiguration-finder",
-      "description": "Find security misconfigurations",
-      "version": "1.29.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "session-security-checker",
-      "source": "./plugins/security/session-security-checker",
-      "description": "Check session security implementation",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "severity1-marketplace",
-      "source": "./plugins/security/severity1-marketplace",
-      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
-      "version": "1.6.0",
-      "category": "security",
-      "keywords": [
-        "severity",
-        "classification",
-        "prompt-improvement",
-        "marketplace",
-        "security",
-        "quality",
-        "triage",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "severity1",
-        "email": "severity1@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 2,
-        "agents": 1
-      }
-    },
-    {
-      "name": "soc2-audit-helper",
-      "source": "./plugins/security/soc2-audit-helper",
-      "description": "Assist with SOC2 audit preparation",
-      "version": "1.30.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sql-injection-detector",
-      "source": "./plugins/security/sql-injection-detector",
-      "description": "Detect SQL injection vulnerabilities",
-      "version": "1.31.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ssl-certificate-manager",
-      "source": "./plugins/security/ssl-certificate-manager",
-      "description": "Manage and monitor SSL/TLS certificates",
-      "version": "1.21.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "vulnerability-scanner",
-      "source": "./plugins/security/vulnerability-scanner",
-      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "vulnerability",
-        "scanning",
-        "cve",
-        "sast"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "xss-vulnerability-scanner",
-      "source": "./plugins/security/xss-vulnerability-scanner",
-      "description": "Scan for XSS vulnerabilities",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "axiom",
-      "source": "./plugins/skill-enhancers/axiom",
-      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
-      "version": "0.3.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "ios",
-        "debugging",
-        "swift",
-        "persistence",
-        "testing",
-        "performance",
-        "xcode",
-        "concurrency",
-        "database",
-        "swiftdata",
-        "grdb",
-        "liquid-glass",
-        "swiftui"
-      ],
-      "author": {
-        "name": "Charles Wiltgen",
-        "url": "https://github.com/CharlesWiltgen"
-      },
-      "components": {
-        "skills": 13,
-        "total": 13
-      }
-    },
-    {
-      "name": "calendar-to-workflow",
-      "source": "./plugins/skill-enhancers/calendar-to-workflow",
-      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "calendar",
-        "automation",
-        "meetings",
-        "productivity"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "file-to-code",
-      "source": "./plugins/skill-enhancers/file-to-code",
-      "description": "Converts file references into executable code implementations",
-      "version": "0.16.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "files",
-        "automation",
-        "code-generation"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "research-to-deploy",
-      "source": "./plugins/skill-enhancers/research-to-deploy",
-      "description": "Transforms research findings into deployed solutions automatically",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "research",
-        "automation",
-        "deployment"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "search-to-slack",
-      "source": "./plugins/skill-enhancers/search-to-slack",
-      "description": "Automatically posts search results to Slack channels",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "search",
-        "slack",
-        "automation",
-        "integration"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "skill-creator",
-      "source": "./plugins/skill-enhancers/skill-creator",
-      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.20.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "skill-creation",
-        "validation",
-        "meta-tooling",
-        "grading",
-        "anthropic-spec"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "featured": true,
-      "pluginCount": 1,
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "validate-plugin",
-      "source": "./plugins/skill-enhancers/validate-plugin",
-      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
-      "version": "1.8.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "validation",
-        "plugin-development",
-        "quality-assurance",
-        "linting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "web-to-github-issue",
-      "source": "./plugins/skill-enhancers/web-to-github-issue",
-      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
-      "version": "1.27.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "web-search",
         "github",
-        "automation",
-        "research",
-        "issue-tracking",
-        "skill-enhancer",
-        "productivity",
-        "workflow"
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
       ],
       "author": {
-        "name": "Claude Code Plugins Team",
-        "email": "[email protected]"
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
       },
-      "featured": true,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "zero-tech-debt",
-      "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
-      "version": "1.1.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "refactoring",
-        "tech-debt",
-        "architecture",
-        "cleanup",
-        "modernization",
-        "code-quality"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "accessibility-test-scanner",
-      "source": "./plugins/testing/accessibility-test-scanner",
-      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "accessibility",
-        "a11y",
-        "wcag",
-        "aria",
-        "screen-reader",
-        "compliance"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-fuzzer",
-      "source": "./plugins/testing/api-fuzzer",
-      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "fuzzing",
-        "api",
-        "security",
-        "edge-cases",
-        "input-validation"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-test-automation",
-      "source": "./plugins/testing/api-test-automation",
-      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "api",
-        "rest",
-        "graphql",
-        "automation",
-        "endpoints"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "browser-compatibility-tester",
-      "source": "./plugins/testing/browser-compatibility-tester",
-      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-      "version": "2.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "cross-browser",
-        "browserstack",
-        "selenium",
-        "playwright",
-        "compatibility"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "chaos-engineering-toolkit",
-      "source": "./plugins/testing/chaos-engineering-toolkit",
-      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "chaos-engineering",
-        "resilience",
-        "failure-injection",
-        "fault-tolerance",
-        "reliability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cli-ux-tester",
-      "source": "./plugins/testing/cli-ux-tester",
-      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
-      "version": "3.1.0",
-      "category": "testing",
-      "keywords": [
-        "CLI",
-        "UX",
-        "testing",
-        "developer-experience",
-        "terminal",
-        "usability"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
-      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
       "license": "MIT"
     },
     {
-      "name": "code-cleanup",
-      "source": "./plugins/testing/code-cleanup",
-      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
-      "version": "1.7.0",
-      "category": "testing",
+      "name": "skills-janitor",
+      "source": "./plugins/community/skills-janitor",
+      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
+      "version": "0.1.0",
+      "category": "community",
       "keywords": [
-        "code-quality",
+        "skills",
         "cleanup",
-        "refactoring",
-        "dead-code",
-        "deduplication",
-        "type-safety",
-        "security",
-        "performance",
-        "async",
-        "tech-debt",
-        "code-review"
+        "context-window",
+        "token-budget",
+        "maintenance",
+        "tui"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "name": "Krzysztof Hendzel",
+        "url": "https://github.com/khendzel",
+        "email": "krzysztoff.hendzel@gmail.com"
       },
-      "components": {
-        "skills": 1,
-        "agents": 11
-      }
+      "repository": "https://github.com/khendzel/skills-janitor",
+      "license": "MIT"
     },
     {
-      "name": "contract-test-validator",
-      "source": "./plugins/testing/contract-test-validator",
-      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "contract-testing",
-        "pact",
-        "openapi",
-        "api",
-        "microservices",
-        "consumer-driven"
-      ],
+      "name": "walkie-talkie",
+      "source": "./plugins/community/walkie-talkie",
+      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
+      "version": "0.1.0",
+      "category": "community",
       "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
+        "name": "Walkie-Talkie Maintainers",
+        "url": "https://github.com/walkie-talkie-skill"
       },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
+      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
+      "license": "MIT"
     },
     {
-      "name": "database-test-manager",
-      "source": "./plugins/testing/database-test-manager",
-      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
-      "version": "1.26.0",
-      "category": "testing",
+      "name": "brand-forge",
+      "source": "./plugins/design/brand-forge",
+      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
+      "version": "0.5.1",
+      "category": "design",
       "keywords": [
-        "testing",
-        "database",
-        "sql",
-        "test-data",
-        "fixtures",
-        "migrations",
-        "transactions"
+        "branding",
+        "logo",
+        "brand-identity",
+        "design",
+        "svg",
+        "templates",
+        "image-generation"
       ],
       "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
       },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
+      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
     },
     {
-      "name": "e2e-test-framework",
-      "source": "./plugins/testing/e2e-test-framework",
-      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
-      "version": "1.21.0",
-      "category": "testing",
+      "name": "content-multiplier",
+      "source": "./plugins/productivity/content-multiplier",
+      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
+      "version": "0.2.1",
+      "category": "productivity",
       "keywords": [
-        "testing",
-        "e2e",
-        "playwright",
-        "cypress",
-        "selenium",
-        "browser-testing"
+        "marketing",
+        "content",
+        "repurposing",
+        "brand-voice",
+        "localization",
+        "social-media"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
       },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
+      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
     },
     {
-      "name": "integration-test-runner",
-      "source": "./plugins/testing/integration-test-runner",
-      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "integration-tests",
-        "test-runner",
-        "e2e",
-        "api-testing"
-      ],
+      "name": "quit-sponsor",
+      "source": "./plugins/community/quit-sponsor",
+      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
+      "version": "0.1.0",
+      "category": "community",
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "metr0x",
+        "url": "https://github.com/metrox-eth"
       },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "kobiton-automate",
-      "source": "./plugins/testing/kobiton-automate",
-      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
-      "version": "1.0.2",
-      "category": "testing",
-      "keywords": [
-        "mobile",
-        "testing",
-        "appium",
-        "automation",
-        "devices",
-        "ios",
-        "android",
-        "real-device",
-        "mcp",
-        "kobiton"
-      ],
-      "author": {
-        "name": "Kobiton Inc.",
-        "url": "https://github.com/kobiton"
-      },
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "kobiton/automate",
-        "source_path": "."
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-05-20T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "load-balancer-tester",
-      "source": "./plugins/testing/load-balancer-tester",
-      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "load-balancer",
-        "traffic-distribution",
-        "failover",
-        "high-availability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mobile-app-tester",
-      "source": "./plugins/testing/mobile-app-tester",
-      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mobile",
-        "appium",
-        "detox",
-        "xcuitest",
-        "espresso",
-        "ios",
-        "android"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mutation-test-runner",
-      "source": "./plugins/testing/mutation-test-runner",
-      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mutation-testing",
-        "test-quality",
-        "stryker",
-        "pitest"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-test-suite",
-      "source": "./plugins/testing/performance-test-suite",
-      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
-      "version": "1.30.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "performance",
-        "load-testing",
-        "benchmarking",
-        "stress-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "regression-test-tracker",
-      "source": "./plugins/testing/regression-test-tracker",
-      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
-      "version": "1.26.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "regression-testing",
-        "test-tracking",
-        "ci-cd",
-        "quality-assurance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-test-scanner",
-      "source": "./plugins/testing/security-test-scanner",
-      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
-      "version": "1.29.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "security",
-        "vulnerabilities",
-        "owasp",
-        "penetration-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "smoke-test-runner",
-      "source": "./plugins/testing/smoke-test-runner",
-      "description": "Quick smoke test suites to verify critical functionality after deployments",
-      "version": "1.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "smoke-tests",
-        "deployment",
-        "sanity-check",
-        "critical-path"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "snapshot-test-manager",
-      "source": "./plugins/testing/snapshot-test-manager",
-      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "snapshot",
-        "jest",
-        "vitest",
-        "diff-analysis",
-        "test-management"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-coverage-analyzer",
-      "source": "./plugins/testing/test-coverage-analyzer",
-      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "coverage",
-        "code-coverage",
-        "metrics",
-        "analysis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-data-generator",
-      "source": "./plugins/testing/test-data-generator",
-      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "test-data",
-        "fake-data",
-        "fixtures",
-        "factory"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-doubles-generator",
-      "source": "./plugins/testing/test-doubles-generator",
-      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mocks",
-        "stubs",
-        "spies",
-        "fakes",
-        "test-doubles",
-        "jest",
-        "sinon"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-environment-manager",
-      "source": "./plugins/testing/test-environment-manager",
-      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "environment",
-        "docker",
-        "testcontainers",
-        "isolation",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-orchestrator",
-      "source": "./plugins/testing/test-orchestrator",
-      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "orchestration",
-        "workflow",
-        "parallel",
-        "test-selection",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-report-generator",
-      "source": "./plugins/testing/test-report-generator",
-      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "reporting",
-        "coverage",
-        "metrics",
-        "dashboard",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "unit-test-generator",
-      "source": "./plugins/testing/unit-test-generator",
-      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "unit-tests",
-        "test-generation",
-        "jest",
-        "pytest",
-        "mocha",
-        "junit"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "visual-regression-tester",
-      "source": "./plugins/testing/visual-regression-tester",
-      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "visual-regression",
-        "ui-testing",
-        "percy",
-        "chromatic",
-        "backstop",
-        "screenshot-testing"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
+      "repository": "https://github.com/metrox-eth/quit-sponsor",
+      "license": "MIT"
     }
   ]
 }

--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -16,202 +16,6 @@
   },
   "plugins": [
     {
-      "name": "000-jeremy-content-consistency-validator",
-      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
-      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
-      "version": "3.29.0",
-      "category": "productivity",
-      "maintainer": "@jeremylongshore",
-      "keywords": [
-        "documentation",
-        "consistency",
-        "validation",
-        "drift-detection",
-        "source-of-truth",
-        "authority-registry",
-        "content-audit",
-        "quality-assurance",
-        "release-gate",
-        "standards"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "002-jeremy-yaml-master-agent",
-      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
-      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
-      "version": "2.21.0",
-      "category": "productivity",
-      "keywords": [
-        "yaml",
-        "validation",
-        "linting",
-        "schema",
-        "json",
-        "conversion",
-        "parsing",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 1
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "003-jeremy-vertex-ai-media-master",
-      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
-      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
-      "version": "2.25.0",
-      "category": "productivity",
-      "keywords": [
-        "vertex-ai",
-        "gemini",
-        "multimodal",
-        "video-processing",
-        "audio-generation",
-        "image-generation",
-        "marketing",
-        "campaigns",
-        "content-generation",
-        "imagen",
-        "media-production",
-        "google-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "004-jeremy-google-cloud-agent-sdk",
-      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
-      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
-      "version": "2.24.0",
-      "category": "productivity",
-      "keywords": [
-        "agent-development-kit",
-        "adk",
-        "agent-starter-pack",
-        "multi-agent",
-        "containerized-agents",
-        "cloud-run",
-        "gke",
-        "agent-engine",
-        "rag-agents",
-        "react-agents",
-        "google-cloud",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "access-control-auditor",
-      "source": "./plugins/security/access-control-auditor",
-      "description": "Audit access control implementations",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "accessibility-test-scanner",
-      "source": "./plugins/testing/accessibility-test-scanner",
-      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "accessibility",
-        "a11y",
-        "wcag",
-        "aria",
-        "screen-reader",
-        "compliance"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "agent-context-manager",
-      "source": "./plugins/productivity/agent-context-manager",
-      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
-      "version": "1.23.0",
-      "category": "productivity",
-      "keywords": ["agents", "context", "automation"],
-      "author": {
-        "name": "Jeremy Longshore"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "agency-os",
       "source": "./plugins/ai-agency/agency-os",
       "description": "Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel with dependency ordering and model routing.",
@@ -232,28 +36,209 @@
       }
     },
     {
-      "name": "ai-commit-gen",
-      "source": "./plugins/productivity/ai-commit-gen",
-      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
-      "version": "1.10.0",
-      "category": "productivity",
+      "name": "discovery-questionnaire",
+      "source": "./plugins/ai-agency/discovery-questionnaire",
+      "description": "Generate custom discovery questionnaires for AI agency prospects",
+      "version": "1.9.0",
+      "category": "ai-agency",
       "keywords": [
-        "git",
-        "commit",
-        "conventional-commits",
-        "ai",
-        "automation",
-        "productivity",
-        "devops"
+        "discovery",
+        "questionnaire",
+        "client",
+        "sales",
+        "agency",
+        "ai-agency"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "hyperflow",
+      "source": "./plugins/ai-agency/hyperflow",
+      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
+      "version": "4.26.1",
+      "category": "ai-agency",
+      "keywords": [
+        "claude-code-plugin",
+        "multi-agent",
+        "dynamic-workflows",
+        "workflow-chain",
+        "triageflow",
+        "personas",
+        "flow-profiles",
+        "code-review",
+        "project-memory",
+        "multi-tool"
+      ],
+      "author": {
+        "name": "Mohammed Abdelhady",
+        "url": "https://github.com/Mohammed-Abdelhady"
       },
-      "featured": true,
+      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "license": "MIT"
+    },
+    {
+      "name": "make-scenario-builder",
+      "source": "./plugins/ai-agency/make-scenario-builder",
+      "description": "Create Make.com (Integromat) scenarios with AI assistance",
+      "version": "1.15.0",
+      "category": "ai-agency",
+      "keywords": [
+        "make",
+        "integromat",
+        "automation",
+        "scenarios",
+        "workflow",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "n8n-workflow-designer",
+      "source": "./plugins/ai-agency/n8n-workflow-designer",
+      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
+      "version": "1.13.0",
+      "category": "ai-agency",
+      "keywords": [
+        "n8n",
+        "workflow",
+        "automation",
+        "self-hosted",
+        "open-source",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "url": "https://github.com/jeremylongshore/claude-code-plugins"
+      },
+      "featured": true
+    },
+    {
+      "name": "roi-calculator",
+      "source": "./plugins/ai-agency/roi-calculator",
+      "description": "Calculate and present ROI for AI automation projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "roi",
+        "return on investment",
+        "calculator",
+        "sales",
+        "value",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "shipwright",
+      "source": "./plugins/ai-agency/shipwright",
+      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+      "version": "1.3.0",
+      "category": "ai-agency",
+      "author": {
+        "name": "Nate Nelson",
+        "url": "https://github.com/Wynelson94"
+      },
+      "keywords": [
+        "app-builder",
+        "code-generator",
+        "autonomous-agent",
+        "pipeline",
+        "nextjs",
+        "supabase",
+        "sveltekit",
+        "astro",
+        "ai-agency"
+      ],
+      "repository": "https://github.com/Wynelson94/shipwright",
+      "homepage": "https://github.com/Wynelson94/shipwright",
+      "license": "MIT",
+      "featured": false,
+      "pricing": "free",
       "components": {
-        "commands": 1,
-        "total": 1
+        "skills": 1,
+        "commands": 4
+      }
+    },
+    {
+      "name": "sow-generator",
+      "source": "./plugins/ai-agency/sow-generator",
+      "description": "Generate professional Statements of Work for AI projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "sow",
+        "statement of work",
+        "contract",
+        "proposal",
+        "agency",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "tonone",
+      "source": "./plugins/ai-agency/tonone",
+      "description": "23-agent engineering + product team with 125 skills for Claude Code",
+      "version": "1.8.0",
+      "category": "ai-agency",
+      "keywords": [
+        "agents",
+        "engineering-team",
+        "infrastructure",
+        "devops",
+        "backend",
+        "security",
+        "observability",
+        "frontend",
+        "ml",
+        "mobile",
+        "embedded",
+        "analytics",
+        "testing",
+        "platform",
+        "sales",
+        "revenue",
+        "customer-success",
+        "content-marketing",
+        "pr",
+        "community",
+        "finance",
+        "people",
+        "operations",
+        "support"
+      ],
+      "author": {
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
+      },
+      "repository": "https://github.com/tonone-ai/tonone",
+      "license": "MIT"
+    },
+    {
+      "name": "zapier-zap-builder",
+      "source": "./plugins/ai-agency/zapier-zap-builder",
+      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
+      "version": "1.10.0",
+      "category": "ai-agency",
+      "keywords": [
+        "zapier",
+        "zap",
+        "automation",
+        "integration",
+        "workflow",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
       }
     },
     {
@@ -262,7 +247,13 @@
       "description": "AI ethics and fairness validation",
       "version": "1.24.0",
       "category": "ai-ml",
-      "keywords": ["ethics", "fairness", "bias", "responsible-ai", "ml"],
+      "keywords": [
+        "ethics",
+        "fairness",
+        "bias",
+        "responsible-ai",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -271,54 +262,6 @@
         "score": 85,
         "grade": "B",
         "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ai-experiment-logger",
-      "source": "./plugins/mcp/ai-experiment-logger",
-      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
-      "version": "1.12.0",
-      "category": "mcp",
-      "keywords": ["ai", "experiments", "logging", "mcp"],
-      "author": {
-        "name": "Claude Code Plugins"
-      },
-      "zcf_metadata": {
-        "preset_id": "ai-experiment-logger",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "ai-ml"
-      }
-    },
-    {
-      "name": "ai-ml-engineering-pack",
-      "source": "./plugins/packages/ai-ml-engineering-pack",
-      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "ai",
-        "ml",
-        "llm",
-        "prompt-engineering",
-        "rag",
-        "vector-database",
-        "ai-safety",
-        "openai",
-        "anthropic",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pluginCount": 12,
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
@@ -361,541 +304,24 @@
       }
     },
     {
-      "name": "alerting-rule-creator",
-      "source": "./plugins/performance/alerting-rule-creator",
-      "description": "Create intelligent alerting rules for performance monitoring",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["alerting", "monitoring", "sre", "observability"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "anomaly-detection-system",
       "source": "./plugins/ai-ml/anomaly-detection-system",
       "description": "Detect anomalies and outliers in data",
       "version": "1.26.0",
       "category": "ai-ml",
-      "keywords": ["anomaly", "outliers", "detection", "isolation", "ml"],
+      "keywords": [
+        "anomaly",
+        "outliers",
+        "detection",
+        "isolation",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ansible-playbook-creator",
-      "source": "./plugins/devops/ansible-playbook-creator",
-      "description": "Create Ansible playbooks for configuration management",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": ["ansible", "automation", "configuration", "playbooks", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-authentication-builder",
-      "source": "./plugins/api-development/api-authentication-builder",
-      "description": "Build authentication systems with JWT, OAuth2, and API keys",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": ["authentication", "jwt", "oauth", "security"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-batch-processor",
-      "source": "./plugins/api-development/api-batch-processor",
-      "description": "Implement batch API operations with bulk processing and job queues",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["batch", "bulk", "queue", "job-processing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-cache-manager",
-      "source": "./plugins/api-development/api-cache-manager",
-      "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["caching", "redis", "cdn", "performance"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-contract-generator",
-      "source": "./plugins/api-development/api-contract-generator",
-      "description": "Generate API contracts for consumer-driven contract testing",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["contract", "pact", "testing", "microservices"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-documentation-generator",
-      "source": "./plugins/api-development/api-documentation-generator",
-      "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
-      "version": "1.27.0",
-      "category": "api-development",
-      "keywords": ["api", "documentation", "openapi", "swagger", "docs"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-error-handler",
-      "source": "./plugins/api-development/api-error-handler",
-      "description": "Implement standardized error handling with proper HTTP status codes",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["error-handling", "api", "http-status", "exceptions"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-event-emitter",
-      "source": "./plugins/api-development/api-event-emitter",
-      "description": "Implement event-driven APIs with message queues and event streaming",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["events", "messaging", "kafka", "rabbitmq", "event-driven"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-fuzzer",
-      "source": "./plugins/testing/api-fuzzer",
-      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": ["testing", "fuzzing", "api", "security", "edge-cases", "input-validation"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-gateway-builder",
-      "source": "./plugins/api-development/api-gateway-builder",
-      "description": "Build API gateway with routing, authentication, and rate limiting",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["api-gateway", "routing", "proxy", "microservices"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-load-tester",
-      "source": "./plugins/api-development/api-load-tester",
-      "description": "Load test APIs with k6, Gatling, or Artillery",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["load-testing", "performance", "k6", "stress-testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-migration-tool",
-      "source": "./plugins/api-development/api-migration-tool",
-      "description": "Migrate APIs between versions with backward compatibility",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["migration", "versioning", "api", "backward-compatibility"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-mock-server",
-      "source": "./plugins/api-development/api-mock-server",
-      "description": "Create mock API servers from OpenAPI specs for testing",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["mock", "testing", "openapi", "stub"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-monitoring-dashboard",
-      "source": "./plugins/api-development/api-monitoring-dashboard",
-      "description": "Create monitoring dashboards for API health, metrics, and alerts",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["monitoring", "metrics", "observability", "dashboard"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-rate-limiter",
-      "source": "./plugins/api-development/api-rate-limiter",
-      "description": "Implement rate limiting with token bucket, sliding window, and Redis",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["rate-limiting", "throttling", "api", "redis"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-request-logger",
-      "source": "./plugins/api-development/api-request-logger",
-      "description": "Log API requests with structured logging and correlation IDs",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["logging", "observability", "audit", "correlation"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-response-validator",
-      "source": "./plugins/api-development/api-response-validator",
-      "description": "Validate API responses against schemas and contracts",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["validation", "schema", "testing", "api"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-schema-validator",
-      "source": "./plugins/api-development/api-schema-validator",
-      "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["schema", "validation", "json-schema", "joi", "zod"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-sdk-generator",
-      "source": "./plugins/api-development/api-sdk-generator",
-      "description": "Generate client SDKs from OpenAPI specs for multiple languages",
-      "version": "1.22.0",
-      "category": "api-development",
-      "keywords": ["sdk", "client", "openapi", "codegen"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-security-scanner",
-      "source": "./plugins/api-development/api-security-scanner",
-      "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["security", "api", "owasp", "vulnerability"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-test-automation",
-      "source": "./plugins/testing/api-test-automation",
-      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": ["testing", "api", "rest", "graphql", "automation", "endpoints"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-throttling-manager",
-      "source": "./plugins/api-development/api-throttling-manager",
-      "description": "Manage API throttling with dynamic rate limits and quota management",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["throttling", "rate-limiting", "quota", "traffic-management"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "api-versioning-manager",
-      "source": "./plugins/api-development/api-versioning-manager",
-      "description": "Manage API versions with migration strategies and backward compatibility",
-      "version": "1.26.0",
-      "category": "api-development",
-      "keywords": ["api", "versioning", "migration", "backward-compatibility"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "apm-dashboard-creator",
-      "source": "./plugins/performance/apm-dashboard-creator",
-      "description": "Create Application Performance Monitoring dashboards",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["apm", "monitoring", "dashboard", "grafana", "datadog"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "application-profiler",
-      "source": "./plugins/performance/application-profiler",
-      "description": "Profile application performance with CPU, memory, and execution time analysis",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["performance", "profiling", "monitoring", "optimization"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "arbitrage-opportunity-finder",
-      "source": "./plugins/crypto/arbitrage-opportunity-finder",
-      "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": ["arbitrage", "trading", "defi", "mev", "profit"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "authentication-validator",
-      "source": "./plugins/security/authentication-validator",
-      "description": "Validate authentication implementations",
-      "version": "1.26.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "auto-scaling-configurator",
-      "source": "./plugins/devops/auto-scaling-configurator",
-      "description": "Configure auto-scaling policies for applications and infrastructure",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": ["autoscaling", "scaling", "hpa", "kubernetes", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -907,183 +333,19 @@
       "description": "Build AutoML pipelines",
       "version": "1.25.0",
       "category": "ai-ml",
-      "keywords": ["automl", "automated", "pipeline", "h2o", "ml"],
+      "keywords": [
+        "automl",
+        "automated",
+        "pipeline",
+        "h2o",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "backup-strategy-implementor",
-      "source": "./plugins/devops/backup-strategy-implementor",
-      "description": "Implement backup strategies for databases and applications",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": ["backup", "disaster-recovery", "restoration", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "blockchain-explorer-cli",
-      "source": "./plugins/crypto/blockchain-explorer-cli",
-      "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": ["blockchain", "explorer", "etherscan", "transactions", "addresses", "contracts"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "bottleneck-detector",
-      "source": "./plugins/performance/bottleneck-detector",
-      "description": "Detect and resolve performance bottlenecks",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["bottleneck", "performance", "optimization", "profiling"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "browser-compatibility-tester",
-      "source": "./plugins/testing/browser-compatibility-tester",
-      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-      "version": "2.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "cross-browser",
-        "browserstack",
-        "selenium",
-        "playwright",
-        "compatibility"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cache-performance-optimizer",
-      "source": "./plugins/performance/cache-performance-optimizer",
-      "description": "Optimize caching strategies for improved performance",
-      "version": "1.19.0",
-      "category": "performance",
-      "keywords": ["cache", "performance", "optimization", "redis"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "calendar-to-workflow",
-      "source": "./plugins/skill-enhancers/calendar-to-workflow",
-      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": ["calendar", "automation", "meetings", "productivity"],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "capacity-planning-analyzer",
-      "source": "./plugins/performance/capacity-planning-analyzer",
-      "description": "Analyze and plan for capacity requirements",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["capacity-planning", "scaling", "forecasting", "infrastructure"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "chaos-engineering-toolkit",
-      "source": "./plugins/testing/chaos-engineering-toolkit",
-      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "chaos-engineering",
-        "resilience",
-        "failure-injection",
-        "fault-tolerance",
-        "reliability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ci-cd-pipeline-builder",
-      "source": "./plugins/devops/ci-cd-pipeline-builder",
-      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": ["ci-cd", "github-actions", "gitlab-ci", "jenkins", "devops", "automation"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 91,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -1095,7 +357,13 @@
       "description": "Build classification models",
       "version": "1.22.0",
       "category": "ai-ml",
-      "keywords": ["classification", "supervised", "predictor", "labels", "ml"],
+      "keywords": [
+        "classification",
+        "supervised",
+        "predictor",
+        "labels",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1108,72 +376,24 @@
       }
     },
     {
-      "name": "cloud-cost-optimizer",
-      "source": "./plugins/devops/cloud-cost-optimizer",
-      "description": "Optimize cloud costs and generate cost reports",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": ["cost", "optimization", "finops", "cloud", "aws", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "clustering-algorithm-runner",
       "source": "./plugins/ai-ml/clustering-algorithm-runner",
       "description": "Run clustering algorithms on datasets",
       "version": "1.23.0",
       "category": "ai-ml",
-      "keywords": ["clustering", "kmeans", "dbscan", "hierarchical", "ml"],
+      "keywords": [
+        "clustering",
+        "kmeans",
+        "dbscan",
+        "hierarchical",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "compliance-checker",
-      "source": "./plugins/devops/compliance-checker",
-      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": ["compliance", "security", "audit", "soc2", "hipaa", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "compliance-report-generator",
-      "source": "./plugins/security/compliance-report-generator",
-      "description": "Generate compliance reports",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -1185,7 +405,13 @@
       "description": "Computer vision image processing and analysis",
       "version": "1.21.0",
       "category": "ai-ml",
-      "keywords": ["cv", "vision", "images", "detection", "ml"],
+      "keywords": [
+        "cv",
+        "vision",
+        "images",
+        "detection",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1198,377 +424,24 @@
       }
     },
     {
-      "name": "container-registry-manager",
-      "source": "./plugins/devops/container-registry-manager",
-      "description": "Manage container registries (ECR, GCR, Harbor)",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": ["registry", "containers", "docker", "ecr", "gcr", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "container-security-scanner",
-      "source": "./plugins/devops/container-security-scanner",
-      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": ["security", "containers", "scanning", "vulnerabilities", "trivy", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "contract-test-validator",
-      "source": "./plugins/testing/contract-test-validator",
-      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "contract-testing",
-        "pact",
-        "openapi",
-        "api",
-        "microservices",
-        "consumer-driven"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "conversational-api-debugger",
-      "source": "./plugins/mcp/conversational-api-debugger",
-      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": ["mcp", "api", "debugging", "openapi", "har", "rest", "curl", "http"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 4,
-      "zcf_metadata": {
-        "preset_id": "conversational-api-debugger",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "api"
-      }
-    },
-    {
-      "name": "cors-policy-validator",
-      "source": "./plugins/security/cors-policy-validator",
-      "description": "Validate CORS policies",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cpu-usage-monitor",
-      "source": "./plugins/performance/cpu-usage-monitor",
-      "description": "Monitor and analyze CPU usage patterns in applications",
-      "version": "1.23.0",
-      "category": "performance",
-      "keywords": ["cpu", "monitoring", "performance", "optimization"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "creator-studio-pack",
-      "source": "./plugins/packages/creator-studio-pack",
-      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
-      "version": "1.16.0",
-      "category": "packages",
-      "keywords": [
-        "video",
-        "content-creation",
-        "youtube",
-        "filmmaking",
-        "creator",
-        "documentation",
-        "screencast",
-        "tutorial",
-        "video-editing",
-        "content-strategy",
-        "distribution",
-        "thumbnails",
-        "subtitles",
-        "repurposing",
-        "batch-recording",
-        "analytics",
-        "package",
-        "premium"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pricing": {
-        "model": "one-time",
-        "price": 149,
-        "currency": "USD"
-      },
-      "components": {
-        "agents": 10,
-        "commands": 10,
-        "total": 20
-      }
-    },
-    {
-      "name": "cross-chain-bridge-monitor",
-      "source": "./plugins/crypto/cross-chain-bridge-monitor",
-      "description": "Monitor cross-chain bridge activity, track transfers, analyze security, and detect bridge exploits",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "cross-chain",
-        "bridge",
-        "security",
-        "monitoring",
-        "layer2",
-        "multichain",
-        "defi"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-derivatives-tracker",
-      "source": "./plugins/crypto/crypto-derivatives-tracker",
-      "description": "Track crypto futures, options, perpetual swaps with funding rates, open interest, and derivatives market analysis",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "derivatives",
-        "futures",
-        "options",
-        "perpetuals",
-        "funding-rate",
-        "open-interest",
-        "trading"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-news-aggregator",
-      "source": "./plugins/crypto/crypto-news-aggregator",
-      "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": ["news", "aggregator", "sentiment", "crypto", "media"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-portfolio-tracker",
-      "source": "./plugins/crypto/crypto-portfolio-tracker",
-      "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": ["crypto", "portfolio", "trading", "investment", "bitcoin", "ethereum", "defi"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-signal-generator",
-      "source": "./plugins/crypto/crypto-signal-generator",
-      "description": "Generate trading signals from technical indicators and market analysis",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": ["trading", "signals", "technical-analysis", "indicators", "crypto"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "crypto-tax-calculator",
-      "source": "./plugins/crypto/crypto-tax-calculator",
-      "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": ["crypto", "tax", "calculator", "fifo", "lifo", "capital gains"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "csrf-protection-validator",
-      "source": "./plugins/security/csrf-protection-validator",
-      "description": "Validate CSRF protection",
-      "version": "1.26.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "data-preprocessing-pipeline",
       "source": "./plugins/ai-ml/data-preprocessing-pipeline",
       "description": "Automated data preprocessing and cleaning pipelines",
       "version": "1.23.0",
       "category": "ai-ml",
-      "keywords": ["preprocessing", "cleaning", "etl", "pipeline", "data"],
+      "keywords": [
+        "preprocessing",
+        "cleaning",
+        "etl",
+        "pipeline",
+        "data"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-privacy-scanner",
-      "source": "./plugins/security/data-privacy-scanner",
-      "description": "Scan for data privacy issues",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-seeder-generator",
-      "source": "./plugins/database/data-seeder-generator",
-      "description": "Generate realistic test data and database seed scripts for development and testing environments",
-      "version": "1.22.0",
-      "category": "database",
-      "keywords": ["seeding", "test-data", "fixtures", "database", "testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "data-validation-engine",
-      "source": "./plugins/database/data-validation-engine",
-      "description": "Database plugin for data-validation-engine",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": ["database", "backend", "validation"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -1580,375 +453,19 @@
       "description": "Create data visualizations and plots",
       "version": "1.21.0",
       "category": "ai-ml",
-      "keywords": ["visualization", "plots", "charts", "graphs", "analytics"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-archival-system",
-      "source": "./plugins/database/database-archival-system",
-      "description": "Database plugin for database-archival-system",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "backend", "archival"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-audit-logger",
-      "source": "./plugins/database/database-audit-logger",
-      "description": "Database plugin for database-audit-logger",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": ["database", "backend", "audit"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-backup-automator",
-      "source": "./plugins/database/database-backup-automator",
-      "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
-      "version": "1.26.0",
-      "category": "database",
-      "keywords": ["database", "backup", "automation", "disaster-recovery", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 74,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-cache-layer",
-      "source": "./plugins/database/database-cache-layer",
-      "description": "Database plugin for database-cache-layer",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": ["database", "backend", "cache"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-connection-pooler",
-      "source": "./plugins/database/database-connection-pooler",
-      "description": "Implement and optimize database connection pooling for improved performance and resource management",
-      "version": "1.23.0",
-      "category": "database",
-      "keywords": ["connection-pool", "database", "performance", "backend", "optimization"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-deadlock-detector",
-      "source": "./plugins/database/database-deadlock-detector",
-      "description": "Database plugin for database-deadlock-detector",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "backend", "deadlock"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-diff-tool",
-      "source": "./plugins/database/database-diff-tool",
-      "description": "Database plugin for database-diff-tool",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "backend", "diff"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-documentation-gen",
-      "source": "./plugins/database/database-documentation-gen",
-      "description": "Database plugin for database-documentation-gen",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": ["database", "backend", "documentation"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-health-monitor",
-      "source": "./plugins/database/database-health-monitor",
-      "description": "Database plugin for database-health-monitor",
-      "version": "1.25.0",
-      "category": "database",
-      "keywords": ["database", "backend", "health"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-index-advisor",
-      "source": "./plugins/database/database-index-advisor",
-      "description": "Analyze query patterns and recommend optimal database indexes with impact analysis",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "indexes", "optimization", "performance"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-migration-manager",
-      "source": "./plugins/database/database-migration-manager",
-      "description": "Manage database migrations with version control, rollback capabilities, and automated schema evolution tracking",
-      "version": "1.23.0",
-      "category": "database",
-      "keywords": ["database", "migration", "schema", "version-control", "backend"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-partition-manager",
-      "source": "./plugins/database/database-partition-manager",
-      "description": "Database plugin for database-partition-manager",
-      "version": "1.25.0",
-      "category": "database",
-      "keywords": ["database", "backend", "partition"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-query-profiler",
-      "source": "./plugins/performance/database-query-profiler",
-      "description": "Profile and optimize database queries for performance",
-      "version": "1.9.0",
-      "category": "performance",
-      "keywords": ["database", "query", "profiling", "optimization", "sql"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "database-recovery-manager",
-      "source": "./plugins/database/database-recovery-manager",
-      "description": "Database plugin for database-recovery-manager",
-      "version": "1.26.0",
-      "category": "database",
-      "keywords": ["database", "backend", "recovery"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-replication-manager",
-      "source": "./plugins/database/database-replication-manager",
-      "description": "Manage database replication, failover, and high availability configurations",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": ["replication", "high-availability", "failover", "database", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-schema-designer",
-      "source": "./plugins/database/database-schema-designer",
-      "description": "Design and visualize database schemas with normalization guidance, relationship mapping, and ERD generation",
-      "version": "1.24.0",
-      "category": "database",
-      "keywords": ["database", "schema", "design", "erd", "normalization"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-security-scanner",
-      "source": "./plugins/database/database-security-scanner",
-      "description": "Database plugin for database-security-scanner",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "backend", "security"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-sharding-manager",
-      "source": "./plugins/database/database-sharding-manager",
-      "description": "Database plugin for database-sharding-manager",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "backend", "sharding"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-test-manager",
-      "source": "./plugins/testing/database-test-manager",
-      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
-      "version": "1.26.0",
-      "category": "testing",
       "keywords": [
-        "testing",
-        "database",
-        "sql",
-        "test-data",
-        "fixtures",
-        "migrations",
-        "transactions"
+        "visualization",
+        "plots",
+        "charts",
+        "graphs",
+        "analytics"
       ],
       "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "database-transaction-monitor",
-      "source": "./plugins/database/database-transaction-monitor",
-      "description": "Database plugin for database-transaction-monitor",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["database", "backend", "transaction"],
-      "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
-        "score": 92,
+        "score": 93,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -1960,7 +477,13 @@
       "description": "Split datasets for training, validation, and testing",
       "version": "1.22.0",
       "category": "ai-ml",
-      "keywords": ["split", "train-test", "validation", "stratify", "ml"],
+      "keywords": [
+        "split",
+        "train-test",
+        "validation",
+        "stratify",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1978,7 +501,13 @@
       "description": "Deep learning optimization techniques",
       "version": "1.23.0",
       "category": "ai-ml",
-      "keywords": ["optimization", "adam", "sgd", "learning-rate", "deep-learning"],
+      "keywords": [
+        "optimization",
+        "adam",
+        "sgd",
+        "learning-rate",
+        "deep-learning"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -1991,434 +520,18 @@
       }
     },
     {
-      "name": "defi-yield-optimizer",
-      "source": "./plugins/crypto/defi-yield-optimizer",
-      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": ["defi", "yield", "farming", "liquidity", "apy", "optimization", "crypto"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 80,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "dependency-checker",
-      "source": "./plugins/security/dependency-checker",
-      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": ["security", "dependencies", "npm", "pip", "composer", "vulnerabilities"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "deployment-pipeline-orchestrator",
-      "source": "./plugins/devops/deployment-pipeline-orchestrator",
-      "description": "Orchestrate complex multi-stage deployment pipelines",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": ["pipeline", "orchestration", "deployment", "cicd", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "deployment-rollback-manager",
-      "source": "./plugins/devops/deployment-rollback-manager",
-      "description": "Manage and execute deployment rollbacks with safety checks",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": ["rollback", "deployment", "kubernetes", "recovery", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "design-to-code",
-      "source": "./plugins/mcp/design-to-code",
-      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "design",
-        "figma",
-        "react",
-        "svelte",
-        "vue",
-        "accessibility",
-        "component-generation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 3,
-      "zcf_metadata": {
-        "preset_id": "design-to-code",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "design"
-      }
-    },
-    {
-      "name": "devops-automation-pack",
-      "source": "./plugins/packages/devops-automation-pack",
-      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "devops",
-        "ci-cd",
-        "docker",
-        "kubernetes",
-        "terraform",
-        "deployment",
-        "infrastructure",
-        "automation",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "dex-aggregator-router",
-      "source": "./plugins/crypto/dex-aggregator-router",
-      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": ["dex", "swap", "trading", "defi", "aggregator", "routing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "disaster-recovery-planner",
-      "source": "./plugins/devops/disaster-recovery-planner",
-      "description": "Plan and implement disaster recovery procedures",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": ["disaster-recovery", "dr", "business-continuity", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "discovery-questionnaire",
-      "source": "./plugins/ai-agency/discovery-questionnaire",
-      "description": "Generate custom discovery questionnaires for AI agency prospects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": ["discovery", "questionnaire", "client", "sales", "agency", "ai-agency"],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "distributed-tracing-setup",
-      "source": "./plugins/performance/distributed-tracing-setup",
-      "description": "Set up distributed tracing for microservices",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["tracing", "observability", "microservices", "opentelemetry"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "docker-compose-generator",
-      "source": "./plugins/devops/docker-compose-generator",
-      "description": "Generate Docker Compose configurations for multi-container applications with best practices",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": ["docker", "docker-compose", "containers", "orchestration", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "domain-memory-agent",
-      "source": "./plugins/mcp/domain-memory-agent",
-      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
-      "version": "1.17.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "knowledge-base",
-        "semantic-search",
-        "tfidf",
-        "summarization",
-        "rag",
-        "documentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 6,
-      "zcf_metadata": {
-        "preset_id": "domain-memory-agent",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "knowledge"
-      }
-    },
-    {
-      "name": "lumera-agent-memory",
-      "source": "./plugins/mcp/lumera-agent-memory",
-      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
-      "version": "1.7.0",
-      "category": "mcp",
-      "keywords": ["mcp", "memory", "cascade", "storage", "encryption", "search", "fts", "agent"],
-      "author": {
-        "name": "Intent Solutions IO",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "mcpTools": ["store_memory", "recall_memory", "search_memory", "delete_memory"]
-    },
-    {
-      "name": "e2e-test-framework",
-      "source": "./plugins/testing/e2e-test-framework",
-      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": ["testing", "e2e", "playwright", "cypress", "selenium", "browser-testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "encryption-tool",
-      "source": "./plugins/security/encryption-tool",
-      "description": "Encrypt and decrypt data with various algorithms",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "engineer-design-diagram",
-      "source": "./plugins/devops/engineer-design-diagram",
-      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI \u2014 package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
-      "version": "0.5.0",
-      "category": "devops",
-      "keywords": [
-        "architecture",
-        "diagram",
-        "visualization",
-        "svg",
-        "html",
-        "pr-review",
-        "drift-detection",
-        "sequence-diagram",
-        "engineering-design",
-        "documentation",
-        "onboarding"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "components": {
-        "skills": 1
-      }
-    },
-    {
-      "name": "environment-config-manager",
-      "source": "./plugins/devops/environment-config-manager",
-      "description": "Manage environment configurations and secrets across deployments",
-      "version": "1.23.0",
-      "category": "devops",
-      "keywords": ["config", "environment", "secrets", "configuration", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "error-rate-monitor",
-      "source": "./plugins/performance/error-rate-monitor",
-      "description": "Monitor and analyze application error rates",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["errors", "monitoring", "reliability", "sre"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "excel-analyst-pro",
-      "source": "./plugins/business-tools/excel-analyst-pro",
-      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
-      "version": "1.21.0",
-      "category": "business-tools",
-      "keywords": [
-        "excel",
-        "financial-modeling",
-        "dcf",
-        "lbo",
-        "valuation",
-        "variance-analysis",
-        "pivot-tables",
-        "investment-banking",
-        "private-equity",
-        "financial-analysis",
-        "skills",
-        "mcp"
-      ],
-      "author": {
-        "name": "ClaudeCodePlugins",
-        "email": "plugins@tonsofskills.com"
-      },
-      "featured": true,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "components": {
-        "skills": 4,
-        "commands": 3
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "brand-strategy-framework",
-      "source": "./plugins/business-tools/brand-strategy-framework",
-      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
-      "version": "1.7.0",
-      "category": "business-tools",
-      "keywords": [
-        "brand-strategy",
-        "marketing",
-        "branding",
-        "positioning",
-        "messaging",
-        "brand-guidelines",
-        "audience-architecture",
-        "brand-identity"
-      ],
-      "author": {
-        "name": "Rowan Brooks",
-        "email": "rowanbrooks100@github.com"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "experiment-tracking-setup",
       "source": "./plugins/ai-ml/experiment-tracking-setup",
       "description": "Set up ML experiment tracking",
       "version": "1.19.0",
       "category": "ai-ml",
-      "keywords": ["experiments", "mlflow", "wandb", "tracking", "mlops"],
+      "keywords": [
+        "experiments",
+        "mlflow",
+        "wandb",
+        "tracking",
+        "mlops"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
@@ -2428,52 +541,6 @@
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "fairdb-operations-kit",
-      "source": "./plugins/devops/fairdb-operations-kit",
-      "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "fairdb",
-        "postgresql",
-        "database",
-        "saas",
-        "operations",
-        "devops",
-        "backup",
-        "monitoring",
-        "vps",
-        "contabo",
-        "wasabi",
-        "pgbackrest",
-        "automation",
-        "incident-response"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "featured": false,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "fairdb-ops-manager",
-      "source": "./plugins/community/fairdb-ops-manager",
-      "description": "Database operations management for FairDB PostgreSQL clusters",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": ["database", "postgresql", "operations"],
-      "author": {
-        "name": "Community"
       }
     },
     {
@@ -2482,278 +549,19 @@
       "description": "Feature creation, selection, and transformation tools",
       "version": "1.23.0",
       "category": "ai-ml",
-      "keywords": ["features", "engineering", "selection", "transformation", "ml"],
+      "keywords": [
+        "features",
+        "engineering",
+        "selection",
+        "transformation",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "file-to-code",
-      "source": "./plugins/skill-enhancers/file-to-code",
-      "description": "Converts file references into executable code implementations",
-      "version": "0.16.0",
-      "category": "skill-enhancers",
-      "keywords": ["files", "automation", "code-generation"],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "flash-loan-simulator",
-      "source": "./plugins/crypto/flash-loan-simulator",
-      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "flash-loans",
-        "defi",
-        "aave",
-        "arbitrage",
-        "liquidation",
-        "ethereum",
-        "simulation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 86,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "formatter",
-      "source": "./plugins/examples/formatter",
-      "description": "Code formatting plugin using hooks to auto-format on save",
-      "version": "2.26.0",
-      "category": "examples",
-      "keywords": ["formatting", "hooks", "automation"],
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "freshie-inventory-manager",
-      "source": "./plugins/database/freshie-inventory-manager",
-      "description": "Interactive command center for the freshie ecosystem inventory database \u2014 conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
-      "version": "1.5.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "inventory",
-        "freshie",
-        "compliance",
-        "sqlite",
-        "ecosystem",
-        "audit",
-        "subagents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 3
-      }
-    },
-    {
-      "name": "fullstack-starter-pack",
-      "source": "./plugins/packages/fullstack-starter-pack",
-      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
-      "version": "1.21.0",
-      "category": "packages",
-      "keywords": [
-        "fullstack",
-        "react",
-        "express",
-        "fastapi",
-        "postgresql",
-        "prisma",
-        "typescript",
-        "mvp",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pluginCount": 15
-    },
-    {
-      "name": "gas-fee-optimizer",
-      "source": "./plugins/crypto/gas-fee-optimizer",
-      "description": "Optimize transaction gas fees with timing and routing recommendations",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": ["gas", "fees", "ethereum", "optimization", "transaction", "l2"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 88,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gdpr-compliance-scanner",
-      "source": "./plugins/security/gdpr-compliance-scanner",
-      "description": "Scan for GDPR compliance issues",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "git-commit-smart",
-      "source": "./plugins/devops/git-commit-smart",
-      "description": "AI-powered conventional commit message generator with smart analysis",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": [
-        "git",
-        "commits",
-        "conventional-commits",
-        "automation",
-        "devops",
-        "productivity"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gitops-workflow-builder",
-      "source": "./plugins/devops/gitops-workflow-builder",
-      "description": "Build GitOps workflows with ArgoCD and Flux",
-      "version": "1.22.0",
-      "category": "devops",
-      "keywords": ["gitops", "argocd", "flux", "cd", "kubernetes", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "graphql-server-builder",
-      "source": "./plugins/api-development/graphql-server-builder",
-      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
-      "version": "1.22.0",
-      "category": "api-development",
-      "keywords": ["graphql", "api", "server", "apollo", "schema", "resolvers"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "grpc-service-generator",
-      "source": "./plugins/api-development/grpc-service-generator",
-      "description": "Generate gRPC services with Protocol Buffers and streaming support",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": ["grpc", "protobuf", "microservices", "streaming"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "hello-world",
-      "source": "./plugins/examples/hello-world",
-      "description": "Simple example plugin demonstrating basic slash commands",
-      "version": "1.12.0",
-      "category": "examples",
-      "keywords": ["example", "tutorial", "beginner"],
-      "author": {
-        "name": "Jeremy Longshore"
-      }
-    },
-    {
-      "name": "helm-chart-generator",
-      "source": "./plugins/devops/helm-chart-generator",
-      "description": "Generate Helm charts for Kubernetes applications",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": ["helm", "kubernetes", "packaging", "charts", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "hipaa-compliance-checker",
-      "source": "./plugins/security/hipaa-compliance-checker",
-      "description": "Check HIPAA compliance",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -2765,2295 +573,19 @@
       "description": "Optimize hyperparameters using grid/random/bayesian search",
       "version": "1.21.0",
       "category": "ai-ml",
-      "keywords": ["hyperparameters", "optimization", "tuning", "search", "ml"],
+      "keywords": [
+        "hyperparameters",
+        "optimization",
+        "tuning",
+        "search",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
       },
       "verification": {
         "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "infrastructure-as-code-generator",
-      "source": "./plugins/devops/infrastructure-as-code-generator",
-      "description": "Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": ["iac", "terraform", "cloudformation", "pulumi", "infrastructure", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "infrastructure-drift-detector",
-      "source": "./plugins/devops/infrastructure-drift-detector",
-      "description": "Detect infrastructure drift from desired state",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": ["drift", "terraform", "infrastructure", "monitoring", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "infrastructure-metrics-collector",
-      "source": "./plugins/performance/infrastructure-metrics-collector",
-      "description": "Collect comprehensive infrastructure performance metrics",
-      "version": "1.20.0",
-      "category": "performance",
-      "keywords": ["infrastructure", "metrics", "monitoring", "observability"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "input-validation-scanner",
-      "source": "./plugins/security/input-validation-scanner",
-      "description": "Scan input validation practices",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "integration-test-runner",
-      "source": "./plugins/testing/integration-test-runner",
-      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": ["testing", "integration-tests", "test-runner", "e2e", "api-testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "kobiton-automate",
-      "source": "./plugins/testing/kobiton-automate",
-      "description": "Real mobile devices on demand via Kobiton's remote MCP \u2014 no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
-      "version": "1.0.2",
-      "category": "testing",
-      "keywords": [
-        "mobile",
-        "testing",
-        "appium",
-        "automation",
-        "devices",
-        "ios",
-        "android",
-        "real-device",
-        "mcp",
-        "kobiton"
-      ],
-      "author": {
-        "name": "Kobiton Inc.",
-        "url": "https://github.com/kobiton"
-      },
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "kobiton/automate",
-        "source_path": "."
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-05-20T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "kubernetes-deployment-creator",
-      "source": "./plugins/devops/kubernetes-deployment-creator",
-      "description": "Create Kubernetes deployments, services, and configurations with best practices",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": ["kubernetes", "k8s", "deployment", "orchestration", "containers"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 63,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "liquidity-pool-analyzer",
-      "source": "./plugins/crypto/liquidity-pool-analyzer",
-      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
-      "version": "1.23.0",
-      "category": "crypto",
-      "keywords": ["liquidity", "pool", "defi", "impermanent", "loss", "apy"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "load-balancer-configurator",
-      "source": "./plugins/devops/load-balancer-configurator",
-      "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
-      "version": "1.28.0",
-      "category": "devops",
-      "keywords": ["load-balancer", "alb", "nginx", "haproxy", "networking", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "load-balancer-tester",
-      "source": "./plugins/testing/load-balancer-tester",
-      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "load-balancer",
-        "traffic-distribution",
-        "failover",
-        "high-availability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "load-test-runner",
-      "source": "./plugins/performance/load-test-runner",
-      "description": "Create and execute load tests for performance validation",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["load-testing", "performance", "stress-test", "k6"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "log-aggregation-setup",
-      "source": "./plugins/devops/log-aggregation-setup",
-      "description": "Set up log aggregation (ELK, Loki, Splunk)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": ["logging", "elk", "loki", "splunk", "observability", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "log-analysis-tool",
-      "source": "./plugins/performance/log-analysis-tool",
-      "description": "Analyze logs for performance insights and issues",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": ["logs", "analysis", "performance", "debugging"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "make-scenario-builder",
-      "source": "./plugins/ai-agency/make-scenario-builder",
-      "description": "Create Make.com (Integromat) scenarios with AI assistance",
-      "version": "1.15.0",
-      "category": "ai-agency",
-      "keywords": ["make", "integromat", "automation", "scenarios", "workflow", "ai-agency"],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "market-movers-scanner",
-      "source": "./plugins/crypto/market-movers-scanner",
-      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": ["market", "scanner", "movers", "gainers", "losers", "volume", "trading"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 82,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "market-price-tracker",
-      "source": "./plugins/crypto/market-price-tracker",
-      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": ["market", "price", "tracking", "trading", "crypto", "stocks", "forex"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "market-sentiment-analyzer",
-      "source": "./plugins/crypto/market-sentiment-analyzer",
-      "description": "Analyze market sentiment from social media, news, and on-chain data",
-      "version": "1.24.0",
-      "category": "crypto",
-      "keywords": ["sentiment", "analysis", "social", "news", "market", "crypto"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 83,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "memory-leak-detector",
-      "source": "./plugins/performance/memory-leak-detector",
-      "description": "Detect memory leaks and analyze memory usage patterns",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": ["memory", "leak", "detection", "performance"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mempool-analyzer",
-      "source": "./plugins/crypto/mempool-analyzer",
-      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
-      "version": "1.32.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "mempool",
-        "mev",
-        "ethereum",
-        "blockchain",
-        "gas",
-        "pending-transactions",
-        "arbitrage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 85,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "metrics-aggregator",
-      "source": "./plugins/performance/metrics-aggregator",
-      "description": "Aggregate and centralize performance metrics",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["metrics", "aggregation", "prometheus", "monitoring"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ml-model-trainer",
-      "source": "./plugins/ai-ml/ml-model-trainer",
-      "description": "Train and optimize machine learning models with automated workflows",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": ["ml", "machine-learning", "training", "models", "ai"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mobile-app-tester",
-      "source": "./plugins/testing/mobile-app-tester",
-      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mobile",
-        "appium",
-        "detox",
-        "xcuitest",
-        "espresso",
-        "ios",
-        "android"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "model-deployment-helper",
-      "source": "./plugins/ai-ml/model-deployment-helper",
-      "description": "Deploy ML models to production",
-      "version": "1.19.0",
-      "category": "ai-ml",
-      "keywords": ["deployment", "serving", "production", "api", "mlops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "model-evaluation-suite",
-      "source": "./plugins/ai-ml/model-evaluation-suite",
-      "description": "Comprehensive model evaluation with multiple metrics",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": ["evaluation", "metrics", "testing", "validation", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "model-explainability-tool",
-      "source": "./plugins/ai-ml/model-explainability-tool",
-      "description": "Model interpretability and explainability",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": ["explainability", "shap", "lime", "interpretability", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "model-versioning-tracker",
-      "source": "./plugins/ai-ml/model-versioning-tracker",
-      "description": "Track and manage model versions",
-      "version": "1.24.0",
-      "category": "ai-ml",
-      "keywords": ["versioning", "mlflow", "tracking", "registry", "mlops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "monitoring-stack-deployer",
-      "source": "./plugins/devops/monitoring-stack-deployer",
-      "description": "Deploy monitoring stacks (Prometheus, Grafana, Datadog)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": ["monitoring", "prometheus", "grafana", "observability", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mutation-test-runner",
-      "source": "./plugins/testing/mutation-test-runner",
-      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": ["testing", "mutation-testing", "test-quality", "stryker", "pitest"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "n8n-workflow-designer",
-      "source": "./plugins/ai-agency/n8n-workflow-designer",
-      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
-      "version": "1.13.0",
-      "category": "ai-agency",
-      "keywords": ["n8n", "workflow", "automation", "self-hosted", "open-source", "ai-agency"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "url": "https://github.com/jeremylongshore/claude-code-plugins"
-      },
-      "featured": true
-    },
-    {
-      "name": "network-latency-analyzer",
-      "source": "./plugins/performance/network-latency-analyzer",
-      "description": "Analyze network latency and optimize request patterns",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["network", "latency", "performance", "api"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "network-policy-manager",
-      "source": "./plugins/devops/network-policy-manager",
-      "description": "Manage Kubernetes network policies and firewall rules",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": ["network-policy", "security", "kubernetes", "firewall", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 90,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "neural-network-builder",
-      "source": "./plugins/ai-ml/neural-network-builder",
-      "description": "Build and configure neural network architectures",
-      "version": "1.20.0",
-      "category": "ai-ml",
-      "keywords": ["neural-networks", "deep-learning", "architecture", "pytorch", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "nft-rarity-analyzer",
-      "source": "./plugins/crypto/nft-rarity-analyzer",
-      "description": "Analyze NFT rarity scores and valuations across collections",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": ["nft", "rarity", "valuation", "traits", "opensea", "crypto"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 88,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "nlp-text-analyzer",
-      "source": "./plugins/ai-ml/nlp-text-analyzer",
-      "description": "Natural language processing and text analysis",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": ["nlp", "text", "analysis", "tokenization", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ollama-local-ai",
-      "source": "./plugins/ai-ml/ollama-local-ai",
-      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
-      "version": "1.18.0",
-      "category": "ai-ml",
-      "keywords": [
-        "ollama",
-        "local-llm",
-        "free-ai",
-        "self-hosted",
-        "llama",
-        "mistral",
-        "privacy",
-        "zero-cost",
-        "openai-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 1,
-        "total": 2
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "nosql-data-modeler",
-      "source": "./plugins/database/nosql-data-modeler",
-      "description": "Database plugin for nosql-data-modeler",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": ["database", "backend", "data"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "on-chain-analytics",
-      "source": "./plugins/crypto/on-chain-analytics",
-      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": ["on-chain", "analytics", "whale", "metrics", "blockchain"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "openbb-terminal",
-      "source": "./plugins/business-tools/openbb-terminal",
-      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
-      "version": "1.6.0",
-      "category": "business-tools",
-      "keywords": [
-        "finance",
-        "investment",
-        "openbb",
-        "stocks",
-        "crypto",
-        "portfolio",
-        "trading",
-        "financial-analysis",
-        "market-data",
-        "equity-research",
-        "options",
-        "forex",
-        "macroeconomics",
-        "quant",
-        "ai-finance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "components": {
-        "commands": 6,
-        "agents": 4,
-        "total": 10
-      }
-    },
-    {
-      "name": "options-flow-analyzer",
-      "source": "./plugins/crypto/options-flow-analyzer",
-      "description": "Track institutional options flow, unusual activity, and smart money movements",
-      "version": "1.29.0",
-      "category": "crypto",
-      "keywords": ["options", "flow", "institutional", "trading", "derivatives", "smart money"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "orm-code-generator",
-      "source": "./plugins/database/orm-code-generator",
-      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
-      "version": "1.28.0",
-      "category": "database",
-      "keywords": ["orm", "models", "code-generation", "database", "backend"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "overnight-dev",
-      "source": "./plugins/productivity/overnight-dev",
-      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
-      "version": "1.29.0",
-      "category": "productivity",
-      "keywords": [
-        "overnight",
-        "autonomous",
-        "tdd",
-        "testing",
-        "git-hooks",
-        "automation",
-        "continuous-integration",
-        "test-driven-development",
-        "productivity"
-      ],
-      "author": {
-        "name": "Intent Solutions IO",
-        "url": "https://intentsolutions.io",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "owasp-compliance-checker",
-      "source": "./plugins/security/owasp-compliance-checker",
-      "description": "Check OWASP Top 10 compliance",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "pci-dss-validator",
-      "source": "./plugins/security/pci-dss-validator",
-      "description": "Validate PCI DSS compliance",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "penetration-tester",
-      "source": "./plugins/security/penetration-tester",
-      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
-      "version": "3.30.0",
-      "category": "security",
-      "keywords": ["security", "penetration-testing", "pentesting", "owasp", "owasp-top-10", "vulnerability-scanning", "dependency-audit", "license-compliance", "engagement-governance", "chain-of-custody"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 84,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-budget-validator",
-      "source": "./plugins/performance/performance-budget-validator",
-      "description": "Validate application against performance budgets",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["performance-budget", "validation", "ci-cd", "testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-optimization-advisor",
-      "source": "./plugins/performance/performance-optimization-advisor",
-      "description": "Get comprehensive performance optimization recommendations",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": ["optimization", "performance", "best-practices", "advisor"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-regression-detector",
-      "source": "./plugins/performance/performance-regression-detector",
-      "description": "Detect performance regressions in CI/CD pipeline",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["regression", "performance", "ci-cd", "testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "performance-test-suite",
-      "source": "./plugins/testing/performance-test-suite",
-      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
-      "version": "1.30.0",
-      "category": "testing",
-      "keywords": ["testing", "performance", "load-testing", "benchmarking", "stress-testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "pi-pathfinder",
-      "source": "./plugins/examples/pi-pathfinder",
-      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
-      "version": "1.24.0",
-      "category": "examples",
-      "keywords": [
-        "agent-skills",
-        "pi",
-        "pathfinder",
-        "plugin-intelligence",
-        "task-router",
-        "auto-selector",
-        "skill-extraction",
-        "easy-mode",
-        "automatic",
-        "no-thinking-required"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "components": {
-        "skills": 1
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "code-cleanup",
-      "source": "./plugins/testing/code-cleanup",
-      "description": "Comprehensive codebase cleanup across 11 quality dimensions \u2014 dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
-      "version": "1.7.0",
-      "category": "testing",
-      "keywords": [
-        "code-quality",
-        "cleanup",
-        "refactoring",
-        "dead-code",
-        "deduplication",
-        "type-safety",
-        "security",
-        "performance",
-        "async",
-        "tech-debt",
-        "code-review"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 11
-      }
-    },
-    {
-      "name": "project-health-auditor",
-      "source": "./plugins/mcp/project-health-auditor",
-      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
-      "version": "1.18.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "code-quality",
-        "technical-debt",
-        "complexity",
-        "git-churn",
-        "test-coverage",
-        "analytics"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 4,
-      "zcf_metadata": {
-        "preset_id": "project-health-auditor",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "code-quality"
-      }
-    },
-    {
-      "name": "promptbook",
-      "source": "./plugins/business-tools/promptbook",
-      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating \u2014 no data transmitted without explicit opt-in. Background submission after session end.",
-      "version": "1.4.0",
-      "category": "business-tools",
-      "keywords": [
-        "analytics",
-        "telemetry",
-        "builds",
-        "portfolio",
-        "tracking",
-        "metrics",
-        "sessions"
-      ],
-      "author": {
-        "name": "Promptbook",
-        "email": "contact@promptbook.gg"
-      },
-      "homepage": "https://promptbook.gg",
-      "repository": "https://github.com/promptbookgg/claude-code-plugin",
-      "license": "MIT",
-      "components": {
-        "skills": 2,
-        "hooks": 4
-      }
-    },
-    {
-      "name": "query-performance-analyzer",
-      "source": "./plugins/database/query-performance-analyzer",
-      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["performance", "query", "optimization", "explain", "database"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "real-user-monitoring",
-      "source": "./plugins/performance/real-user-monitoring",
-      "description": "Implement Real User Monitoring for actual performance data",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["rum", "monitoring", "performance", "user-experience"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "recommendation-engine",
-      "source": "./plugins/ai-ml/recommendation-engine",
-      "description": "Build recommendation systems and engines",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": ["recommendations", "collaborative", "content-based", "ranking", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "regression-analysis-tool",
-      "source": "./plugins/ai-ml/regression-analysis-tool",
-      "description": "Regression analysis and modeling",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": ["regression", "prediction", "linear", "polynomial", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "regression-test-tracker",
-      "source": "./plugins/testing/regression-test-tracker",
-      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
-      "version": "1.26.0",
-      "category": "testing",
-      "keywords": ["testing", "regression-testing", "test-tracking", "ci-cd", "quality-assurance"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "research-to-deploy",
-      "source": "./plugins/skill-enhancers/research-to-deploy",
-      "description": "Transforms research findings into deployed solutions automatically",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": ["research", "automation", "deployment"],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "resource-usage-tracker",
-      "source": "./plugins/performance/resource-usage-tracker",
-      "description": "Track and optimize resource usage across the stack",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["resources", "monitoring", "optimization", "metrics"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "response-time-tracker",
-      "source": "./plugins/performance/response-time-tracker",
-      "description": "Track and optimize application response times",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["response-time", "latency", "performance", "monitoring"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "rest-api-generator",
-      "source": "./plugins/api-development/rest-api-generator",
-      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": ["api", "rest", "generator", "openapi", "swagger", "backend"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "roi-calculator",
-      "source": "./plugins/ai-agency/roi-calculator",
-      "description": "Calculate and present ROI for AI automation projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": ["roi", "return on investment", "calculator", "sales", "value", "ai-agency"],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "search-to-slack",
-      "source": "./plugins/skill-enhancers/search-to-slack",
-      "description": "Automatically posts search results to Slack channels",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": ["search", "slack", "automation", "integration"],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "secret-scanner",
-      "source": "./plugins/security/secret-scanner",
-      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "secrets", "api-keys", "credentials", "passwords"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "severity1-marketplace",
-      "source": "./plugins/security/severity1-marketplace",
-      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
-      "version": "1.6.0",
-      "category": "security",
-      "keywords": [
-        "severity",
-        "classification",
-        "prompt-improvement",
-        "marketplace",
-        "security",
-        "quality",
-        "triage",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "severity1",
-        "email": "severity1@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 2,
-        "agents": 1
-      }
-    },
-    {
-      "name": "secrets-manager-integrator",
-      "source": "./plugins/devops/secrets-manager-integrator",
-      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": ["secrets", "vault", "aws", "security", "credentials", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-agent",
-      "source": "./plugins/examples/security-agent",
-      "description": "Security review subagent for code analysis",
-      "version": "1.28.0",
-      "category": "examples",
-      "keywords": ["security", "agent", "code-review"],
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-audit-reporter",
-      "source": "./plugins/security/security-audit-reporter",
-      "description": "Generate comprehensive security audit reports",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-headers-analyzer",
-      "source": "./plugins/security/security-headers-analyzer",
-      "description": "Analyze HTTP security headers",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-incident-responder",
-      "source": "./plugins/security/security-incident-responder",
-      "description": "Assist with security incident response",
-      "version": "1.32.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-misconfiguration-finder",
-      "source": "./plugins/security/security-misconfiguration-finder",
-      "description": "Find security misconfigurations",
-      "version": "1.29.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-pro-pack",
-      "source": "./plugins/packages/security-pro-pack",
-      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
-      "version": "1.31.0",
-      "category": "packages",
-      "keywords": [
-        "security",
-        "vulnerability-scanning",
-        "compliance",
-        "HIPAA",
-        "PCI-DSS",
-        "GDPR",
-        "SOC2",
-        "cryptography",
-        "devsecops",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "pluginCount": 10,
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "security-test-scanner",
-      "source": "./plugins/testing/security-test-scanner",
-      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
-      "version": "1.29.0",
-      "category": "testing",
-      "keywords": ["testing", "security", "vulnerabilities", "owasp", "penetration-testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sentiment-analysis-tool",
-      "source": "./plugins/ai-ml/sentiment-analysis-tool",
-      "description": "Sentiment analysis on text data",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": ["sentiment", "opinion", "emotion", "polarity", "nlp"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "service-mesh-configurator",
-      "source": "./plugins/devops/service-mesh-configurator",
-      "description": "Configure service mesh (Istio, Linkerd) for microservices",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": ["service-mesh", "istio", "linkerd", "microservices", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "session-security-checker",
-      "source": "./plugins/security/session-security-checker",
-      "description": "Check session security implementation",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-plugin-tool",
-      "source": "./plugins/examples/jeremy-plugin-tool",
-      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
-      "version": "2.19.0",
-      "category": "examples",
-      "keywords": [
-        "skills",
-        "agent-skills",
-        "plugin-management",
-        "marketplace",
-        "validation",
-        "audit",
-        "versioning",
-        "meta-plugin",
-        "repository-tools"
-      ],
-      "author": {
-        "name": "Claude Code Plugins",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sla-sli-tracker",
-      "source": "./plugins/performance/sla-sli-tracker",
-      "description": "Track SLAs, SLIs, and SLOs for service reliability",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["sla", "sli", "slo", "sre", "reliability"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "smoke-test-runner",
-      "source": "./plugins/testing/smoke-test-runner",
-      "description": "Quick smoke test suites to verify critical functionality after deployments",
-      "version": "1.20.0",
-      "category": "testing",
-      "keywords": ["testing", "smoke-tests", "deployment", "sanity-check", "critical-path"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "snapshot-test-manager",
-      "source": "./plugins/testing/snapshot-test-manager",
-      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": ["testing", "snapshot", "jest", "vitest", "diff-analysis", "test-management"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "soc2-audit-helper",
-      "source": "./plugins/security/soc2-audit-helper",
-      "description": "Assist with SOC2 audit preparation",
-      "version": "1.30.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sow-generator",
-      "source": "./plugins/ai-agency/sow-generator",
-      "description": "Generate professional Statements of Work for AI projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": ["sow", "statement of work", "contract", "proposal", "agency", "ai-agency"],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "sql-injection-detector",
-      "source": "./plugins/security/sql-injection-detector",
-      "description": "Detect SQL injection vulnerabilities",
-      "version": "1.31.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sql-query-optimizer",
-      "source": "./plugins/database/sql-query-optimizer",
-      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": ["sql", "optimization", "performance", "database", "query"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ssl-certificate-manager",
-      "source": "./plugins/security/ssl-certificate-manager",
-      "description": "Manage and monitor SSL/TLS certificates",
-      "version": "1.21.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "staking-rewards-optimizer",
-      "source": "./plugins/crypto/staking-rewards-optimizer",
-      "description": "Optimize staking rewards across multiple protocols and chains",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": ["crypto", "staking", "defi", "yield", "optimization", "rewards"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 82,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "stored-procedure-generator",
-      "source": "./plugins/database/stored-procedure-generator",
-      "description": "Database plugin for stored-procedure-generator",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": ["database", "backend", "procedure"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 76,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-firestore",
-      "source": "./plugins/community/jeremy-firestore",
-      "description": "Firestore database specialist for schema design, queries, and real-time sync",
-      "version": "2.20.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "firestore",
-        "database",
-        "crud",
-        "security-rules",
-        "cloud-functions",
-        "batch-operations",
-        "data-migration",
-        "performance",
-        "cost-optimization",
-        "nosql",
-        "google-cloud",
-        "a2a",
-        "agent-to-agent",
-        "mcp",
-        "cloud-run",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]",
-        "url": "https://intentsolutions.io"
-      },
-      "featured": true,
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sugar",
-      "source": "./plugins/devops/sugar",
-      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
-      "version": "2.0.0",
-      "category": "devops",
-      "keywords": [
-        "autonomous",
-        "development",
-        "ai",
-        "task-management",
-        "automation",
-        "agents",
-        "enterprise",
-        "workflow",
-        "productivity",
-        "mcp"
-      ],
-      "author": {
-        "name": "Steven Leggett",
-        "email": "contact@roboticforce.io"
-      },
-      "featured": true,
-      "mcpTools": 7,
-      "repository": "https://github.com/cdnsteve/sugar",
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "synthetic-monitoring-setup",
-      "source": "./plugins/performance/synthetic-monitoring-setup",
-      "description": "Set up synthetic monitoring for proactive performance tracking",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": ["synthetic-monitoring", "uptime", "performance", "testing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "terraform-module-builder",
-      "source": "./plugins/devops/terraform-module-builder",
-      "description": "Build reusable Terraform modules",
-      "version": "1.23.0",
-      "category": "devops",
-      "keywords": ["terraform", "iac", "modules", "infrastructure", "devops"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-coverage-analyzer",
-      "source": "./plugins/testing/test-coverage-analyzer",
-      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": ["testing", "coverage", "code-coverage", "metrics", "analysis"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-data-generator",
-      "source": "./plugins/testing/test-data-generator",
-      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": ["testing", "test-data", "fake-data", "fixtures", "factory"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-doubles-generator",
-      "source": "./plugins/testing/test-doubles-generator",
-      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": ["testing", "mocks", "stubs", "spies", "fakes", "test-doubles", "jest", "sinon"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-environment-manager",
-      "source": "./plugins/testing/test-environment-manager",
-      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "environment",
-        "docker",
-        "testcontainers",
-        "isolation",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-orchestrator",
-      "source": "./plugins/testing/test-orchestrator",
-      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": ["testing", "orchestration", "workflow", "parallel", "test-selection", "ci-cd"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "test-report-generator",
-      "source": "./plugins/testing/test-report-generator",
-      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": ["testing", "reporting", "coverage", "metrics", "dashboard", "ci-cd"],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "throughput-analyzer",
-      "source": "./plugins/performance/throughput-analyzer",
-      "description": "Analyze and optimize system throughput",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": ["throughput", "performance", "capacity", "optimization"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "time-series-forecaster",
-      "source": "./plugins/ai-ml/time-series-forecaster",
-      "description": "Time series forecasting and analysis",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": ["time-series", "forecasting", "arima", "prophet", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "token-launch-tracker",
-      "source": "./plugins/crypto/token-launch-tracker",
-      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "token-launch",
-        "rugpull",
-        "security",
-        "scam-detection",
-        "contract-analysis",
-        "defi",
-        "new-tokens"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "trading-strategy-backtester",
-      "source": "./plugins/crypto/trading-strategy-backtester",
-      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": ["trading", "backtesting", "strategy", "historical", "performance", "risk"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 82,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "transfer-learning-adapter",
-      "source": "./plugins/ai-ml/transfer-learning-adapter",
-      "description": "Transfer learning adaptation",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": ["transfer-learning", "fine-tuning", "pretrained", "adapters", "ml"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "travel-assistant",
-      "source": "./plugins/productivity/travel-assistant",
-      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
-      "version": "1.15.0",
-      "category": "productivity",
-      "keywords": [
-        "travel",
-        "weather",
-        "currency",
-        "timezone",
-        "itinerary",
-        "vacation",
-        "trip-planning",
-        "ai-travel",
-        "real-time",
-        "api-integration",
-        "budget",
-        "packing-list"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "components": {
-        "commands": 6,
-        "agents": 4,
-        "hooks": 2,
-        "scripts": 3,
-        "total": 15
-      }
-    },
-    {
-      "name": "unit-test-generator",
-      "source": "./plugins/testing/unit-test-generator",
-      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": ["testing", "unit-tests", "test-generation", "jest", "pytest", "mocha", "junit"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "visual-regression-tester",
-      "source": "./plugins/testing/visual-regression-tester",
-      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "visual-regression",
-        "ui-testing",
-        "percy",
-        "chromatic",
-        "backstop",
-        "screenshot-testing"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 92,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "vulnerability-scanner",
-      "source": "./plugins/security/vulnerability-scanner",
-      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "vulnerability", "scanning", "cve", "sast"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wallet-portfolio-tracker",
-      "source": "./plugins/crypto/wallet-portfolio-tracker",
-      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
-      "version": "1.12.0",
-      "category": "crypto",
-      "keywords": ["wallet", "portfolio", "tracking", "blockchain", "defi", "crypto"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "web-to-github-issue",
-      "source": "./plugins/skill-enhancers/web-to-github-issue",
-      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
-      "version": "1.27.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "web-search",
-        "github",
-        "automation",
-        "research",
-        "issue-tracking",
-        "skill-enhancer",
-        "productivity",
-        "workflow"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "webhook-handler-creator",
-      "source": "./plugins/api-development/webhook-handler-creator",
-      "description": "Create secure webhook endpoints with signature verification and retry logic",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": ["webhook", "events", "signature", "security"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "websocket-server-builder",
-      "source": "./plugins/api-development/websocket-server-builder",
-      "description": "Build WebSocket servers for real-time bidirectional communication",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": ["websocket", "real-time", "socket.io", "ws"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "whale-alert-monitor",
-      "source": "./plugins/crypto/whale-alert-monitor",
-      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": ["whale", "alert", "monitor", "large", "transactions"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "workflow-orchestrator",
-      "source": "./plugins/mcp/workflow-orchestrator",
-      "description": "DAG-based workflow automation with parallel task execution and dependency management",
-      "version": "1.15.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "workflow",
-        "dag",
-        "automation",
-        "orchestration",
-        "cicd",
-        "parallel-execution"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "featured": true,
-      "mcpTools": 4,
-      "zcf_metadata": {
-        "preset_id": "workflow-orchestrator",
-        "bmad_compatible": true,
-        "ccr_compatible": true,
-        "category": "automation"
-      }
-    },
-    {
-      "name": "xss-vulnerability-scanner",
-      "source": "./plugins/security/xss-vulnerability-scanner",
-      "description": "Scan for XSS vulnerabilities",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": ["security", "compliance", "auditing"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "zapier-zap-builder",
-      "source": "./plugins/ai-agency/zapier-zap-builder",
-      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
-      "version": "1.10.0",
-      "category": "ai-agency",
-      "keywords": ["zapier", "zap", "automation", "integration", "workflow", "ai-agency"],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "jeremy-genkit-pro",
-      "source": "./plugins/ai-ml/jeremy-genkit-pro",
-      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
-      "version": "2.26.0",
-      "category": "ai-ml",
-      "keywords": ["firebase", "genkit", "ai-flows", "rag", "monitoring", "gemini", "vertex-ai"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 1,
-        "commands": 1,
-        "skills": 1
-      },
-      "verification": {
-        "score": 92,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -5089,17 +621,84 @@
       }
     },
     {
-      "name": "jeremy-vertex-validator",
-      "source": "./plugins/ai-ml/jeremy-vertex-validator",
-      "description": "Production readiness validator for Vertex AI deployments and configurations",
-      "version": "2.22.0",
+      "name": "jeremy-adk-software-engineer",
+      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
+      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
+      "version": "2.19.0",
       "category": "ai-ml",
-      "keywords": ["vertex-ai", "validation", "production-readiness", "security", "compliance"],
+      "keywords": [
+        "adk",
+        "software-engineer",
+        "agent-development",
+        "vertex-ai"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-gcp-starter-examples",
+      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
+      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
+      "version": "2.25.0",
+      "category": "ai-ml",
+      "keywords": [
+        "google-cloud",
+        "adk-samples",
+        "genkit-examples",
+        "vertex-ai",
+        "agent-starter-pack",
+        "code-examples",
+        "starter-kits",
+        "templates"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 1,
+        "skills": 1
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-genkit-pro",
+      "source": "./plugins/ai-ml/jeremy-genkit-pro",
+      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
+      "version": "2.26.0",
+      "category": "ai-ml",
+      "keywords": [
+        "firebase",
+        "genkit",
+        "ai-flows",
+        "rag",
+        "monitoring",
+        "gemini",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 1,
+        "commands": 1,
         "skills": 1
       },
       "verification": {
@@ -5112,7 +711,7 @@
     {
       "name": "jeremy-google-adk",
       "source": "./plugins/ai-ml/jeremy-google-adk",
-      "description": "Google Agent Development Kit (ADK) starter for building production AI agents \u2014 ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
       "version": "2.2.0",
       "category": "ai-ml",
       "keywords": [
@@ -5159,69 +758,6 @@
       }
     },
     {
-      "name": "jeremy-genkit-terraform",
-      "source": "./plugins/devops/jeremy-genkit-terraform",
-      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
-      "version": "2.21.0",
-      "category": "devops",
-      "keywords": ["terraform", "genkit", "firebase", "cloud-run", "infrastructure"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-adk-terraform",
-      "source": "./plugins/devops/jeremy-adk-terraform",
-      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
-      "version": "2.22.0",
-      "category": "devops",
-      "keywords": ["terraform", "adk", "agent-engine", "vertex-ai", "infrastructure", "vpc-sc"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-vertex-terraform",
-      "source": "./plugins/devops/jeremy-vertex-terraform",
-      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
-      "version": "2.22.0",
-      "category": "devops",
-      "keywords": ["terraform", "vertex-ai", "gemini", "model-garden", "infrastructure"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "jeremy-vertex-engine",
       "source": "./plugins/ai-ml/jeremy-vertex-engine",
       "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
@@ -5251,164 +787,24 @@
       }
     },
     {
-      "name": "jeremy-gcp-starter-examples",
-      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
-      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
-      "version": "2.25.0",
+      "name": "jeremy-vertex-validator",
+      "source": "./plugins/ai-ml/jeremy-vertex-validator",
+      "description": "Production readiness validator for Vertex AI deployments and configurations",
+      "version": "2.22.0",
       "category": "ai-ml",
       "keywords": [
-        "google-cloud",
-        "adk-samples",
-        "genkit-examples",
         "vertex-ai",
-        "agent-starter-pack",
-        "code-examples",
-        "starter-kits",
-        "templates"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 1,
-        "skills": 1
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "jeremy-github-actions-gcp",
-      "source": "./plugins/devops/jeremy-github-actions-gcp",
-      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
-      "version": "2.27.0",
-      "category": "devops",
-      "keywords": [
-        "github-actions",
-        "google-cloud",
-        "workload-identity-federation",
-        "wif",
-        "vertex-ai",
-        "agent-engine",
-        "deployment",
-        "ci-cd",
+        "validation",
+        "production-readiness",
         "security",
-        "best-practices",
-        "oidc",
-        "iam"
+        "compliance"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "components": {
-        "agents": 1,
-        "skills": 1,
-        "hooks": 1
-      },
-      "verification": {
-        "score": 93,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "prettier-markdown-hook",
-      "source": "./plugins/productivity/prettier-markdown-hook",
-      "description": "Automatically format markdown files with prettier when Claude stops responding, with configurable organization and path exclusions",
-      "version": "1.8.0",
-      "category": "productivity",
-      "keywords": [
-        "prettier",
-        "markdown",
-        "formatting",
-        "automation",
-        "hook",
-        "stop",
-        "git",
-        "conventional-commits"
-      ],
-      "author": {
-        "name": "Terry Li",
-        "email": "[email protected]",
-        "url": "https://github.com/terrylica"
-      },
-      "components": {
-        "hooks": 1,
-        "total": 1
-      }
-    },
-    {
-      "name": "axiom",
-      "source": "./plugins/skill-enhancers/axiom",
-      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
-      "version": "0.3.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "ios",
-        "debugging",
-        "swift",
-        "persistence",
-        "testing",
-        "performance",
-        "xcode",
-        "concurrency",
-        "database",
-        "swiftdata",
-        "grdb",
-        "liquid-glass",
-        "swiftui"
-      ],
-      "author": {
-        "name": "Charles Wiltgen",
-        "url": "https://github.com/CharlesWiltgen"
-      },
-      "components": {
-        "skills": 13,
-        "total": 13
-      }
-    },
-    {
-      "name": "skill-creator",
-      "source": "./plugins/skill-enhancers/skill-creator",
-      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.20.0",
-      "category": "skill-enhancers",
-      "keywords": ["skill-creation", "validation", "meta-tooling", "grading", "anthropic-spec"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "featured": true,
-      "pluginCount": 1,
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "claude-never-forgets",
-      "source": "./plugins/community/claude-never-forgets",
-      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
-      "version": "1.21.0",
-      "category": "community",
-      "keywords": ["memory", "context", "persistent", "preferences", "sessions", "recall"],
-      "author": {
-        "name": "yldrmahmet",
-        "url": "https://github.com/yldrmahmet"
-      },
-      "components": {
-        "hooks": 4,
-        "commands": 3,
-        "skills": 1,
-        "total": 8
+        "skills": 1
       },
       "verification": {
         "score": 92,
@@ -5418,66 +814,46 @@
       }
     },
     {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
-      "version": "1.13.0",
-      "category": "community",
+      "name": "local-tts",
+      "source": "./plugins/ai-ml/local-tts",
+      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+      "version": "1.3.0",
+      "category": "ai-ml",
       "keywords": [
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "research",
-        "games",
-        "accessibility",
-        "performance",
-        "flask",
-        "react",
-        "godot",
-        "corpus-linguistics",
-        "mcp"
+        "tts",
+        "text-to-speech",
+        "voice",
+        "voice-cloning",
+        "voice-design",
+        "offline",
+        "voxcpm",
+        "apple-silicon",
+        "audio",
+        "narration"
       ],
       "author": {
-        "name": "Luke Steuber",
-        "url": "https://github.com/lukeslp"
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
       },
-      "components": {
-        "agents": 51,
-        "total": 51
-      }
+      "license": "Apache-2.0",
+      "repository": "https://github.com/vdk888/local-tts"
     },
     {
-      "name": "sprint",
-      "source": "./plugins/community/sprint",
-      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
-      "version": "1.20.0",
-      "category": "community",
+      "name": "ml-model-trainer",
+      "source": "./plugins/ai-ml/ml-model-trainer",
+      "description": "Train and optimize machine learning models with automated workflows",
+      "version": "1.23.0",
+      "category": "ai-ml",
       "keywords": [
-        "autonomous",
-        "agentic",
-        "yolo",
-        "self-iterating",
-        "multi-agent",
-        "hands-off",
-        "auto-pilot",
-        "orchestration",
-        "sprint",
-        "testing",
-        "qa",
-        "mcp"
+        "ml",
+        "machine-learning",
+        "training",
+        "models",
+        "ai"
       ],
       "author": {
-        "name": "Damien Laine",
-        "email": "damien.laine@gmail.com",
-        "url": "https://github.com/damienlaine"
-      },
-      "components": {
-        "agents": 9,
-        "commands": 6,
-        "skills": 4,
-        "total": 19
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
       },
       "verification": {
         "score": 93,
@@ -5487,151 +863,990 @@
       }
     },
     {
-      "name": "vibe-guide",
-      "source": "./plugins/productivity/vibe-guide",
-      "description": "Non-technical progress summaries for Claude Code work (hides diffs/log noise).",
-      "version": "1.16.0",
-      "category": "productivity",
-      "keywords": [
-        "ux",
-        "accessibility",
-        "explain",
-        "pairing",
-        "non-technical",
-        "beginner-friendly",
-        "explanations",
-        "noise-filtering"
-      ],
-      "author": {
-        "name": "Intent Solutions",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "agents": 3,
-        "commands": 7,
-        "hooks": 1,
-        "total": 11
-      },
-      "tags": ["beginner-friendly", "explanations", "noise-filtering"],
-      "strict": true
-    },
-    {
-      "name": "jeremy-adk-software-engineer",
-      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
-      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
-      "version": "2.19.0",
+      "name": "model-deployment-helper",
+      "source": "./plugins/ai-ml/model-deployment-helper",
+      "description": "Deploy ML models to production",
+      "version": "1.19.0",
       "category": "ai-ml",
-      "keywords": ["adk", "software-engineer", "agent-development", "vertex-ai"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 97,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-      "version": "1.13.0",
-      "category": "community",
       "keywords": [
-        "mcp",
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
         "deployment",
-        "geepers",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Luke Steuber"
-      },
-      "homepage": "https://dr.eamer.dev/geepers/",
-      "repository": "https://github.com/lukeslp/geepers",
-      "components": {
-        "agents": 51
-      }
-    },
-    {
-      "name": "jeremy-firebase",
-      "source": "./plugins/community/jeremy-firebase",
-      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
-      "version": "2.23.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "vertex-ai",
-        "gemini",
-        "authentication",
-        "storage",
-        "hosting",
-        "cloud-functions",
-        "analytics",
-        "ai-integration",
-        "google-cloud",
-        "embeddings",
-        "model-deployment",
-        "ai-powered",
-        "production-ready"
+        "serving",
+        "production",
+        "api",
+        "mlops"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
+        "email": "[email protected]"
       },
       "verification": {
-        "score": 97,
+        "score": 93,
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
-      "name": "wallet-security-auditor",
-      "source": "./plugins/crypto/wallet-security-auditor",
-      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
-      "version": "1.17.0",
-      "category": "crypto",
-      "keywords": ["crypto", "wallet", "security", "audit", "web3"],
+      "name": "model-evaluation-suite",
+      "source": "./plugins/ai-ml/model-evaluation-suite",
+      "description": "Comprehensive model evaluation with multiple metrics",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "evaluation",
+        "metrics",
+        "testing",
+        "validation",
+        "ml"
+      ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1
+        "email": "[email protected]"
       },
       "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
-      "name": "mattyp-changelog",
-      "source": "./plugins/devops/mattyp-changelog",
-      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
-      "version": "0.3.0",
-      "category": "devops",
-      "keywords": ["changelog", "release-notes", "weekly-update", "git", "github", "automation"],
+      "name": "model-explainability-tool",
+      "source": "./plugins/ai-ml/model-explainability-tool",
+      "description": "Model interpretability and explainability",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "explainability",
+        "shap",
+        "lime",
+        "interpretability",
+        "ml"
+      ],
       "author": {
-        "name": "Mattyp",
-        "email": "mattyp@tonsofskills.com",
-        "url": "https://tonsofskills.com"
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "model-versioning-tracker",
+      "source": "./plugins/ai-ml/model-versioning-tracker",
+      "description": "Track and manage model versions",
+      "version": "1.24.0",
+      "category": "ai-ml",
+      "keywords": [
+        "versioning",
+        "mlflow",
+        "tracking",
+        "registry",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "neural-network-builder",
+      "source": "./plugins/ai-ml/neural-network-builder",
+      "description": "Build and configure neural network architectures",
+      "version": "1.20.0",
+      "category": "ai-ml",
+      "keywords": [
+        "neural-networks",
+        "deep-learning",
+        "architecture",
+        "pytorch",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "nlp-text-analyzer",
+      "source": "./plugins/ai-ml/nlp-text-analyzer",
+      "description": "Natural language processing and text analysis",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "nlp",
+        "text",
+        "analysis",
+        "tokenization",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ollama-local-ai",
+      "source": "./plugins/ai-ml/ollama-local-ai",
+      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
+      "version": "1.18.0",
+      "category": "ai-ml",
+      "keywords": [
+        "ollama",
+        "local-llm",
+        "free-ai",
+        "self-hosted",
+        "llama",
+        "mistral",
+        "privacy",
+        "zero-cost",
+        "openai-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
       },
       "components": {
         "skills": 1,
+        "commands": 1,
+        "total": 2
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "recommendation-engine",
+      "source": "./plugins/ai-ml/recommendation-engine",
+      "description": "Build recommendation systems and engines",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "recommendations",
+        "collaborative",
+        "content-based",
+        "ranking",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "regression-analysis-tool",
+      "source": "./plugins/ai-ml/regression-analysis-tool",
+      "description": "Regression analysis and modeling",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "regression",
+        "prediction",
+        "linear",
+        "polynomial",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sentiment-analysis-tool",
+      "source": "./plugins/ai-ml/sentiment-analysis-tool",
+      "description": "Sentiment analysis on text data",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "sentiment",
+        "opinion",
+        "emotion",
+        "polarity",
+        "nlp"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "time-series-forecaster",
+      "source": "./plugins/ai-ml/time-series-forecaster",
+      "description": "Time series forecasting and analysis",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "time-series",
+        "forecasting",
+        "arima",
+        "prophet",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "transfer-learning-adapter",
+      "source": "./plugins/ai-ml/transfer-learning-adapter",
+      "description": "Transfer learning adaptation",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "transfer-learning",
+        "fine-tuning",
+        "pretrained",
+        "adapters",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "web-analytics",
+      "source": "./plugins/analytics/web-analytics",
+      "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
+      "version": "1.4.0",
+      "category": "analytics",
+      "keywords": [
+        "analytics",
+        "umami",
+        "ga4",
+        "traffic",
+        "mcp",
+        "self-hosted",
+        "multi-agent",
+        "push-based"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 9
+      },
+      "verification": {
+        "score": 85,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-authentication-builder",
+      "source": "./plugins/api-development/api-authentication-builder",
+      "description": "Build authentication systems with JWT, OAuth2, and API keys",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": [
+        "authentication",
+        "jwt",
+        "oauth",
+        "security"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-batch-processor",
+      "source": "./plugins/api-development/api-batch-processor",
+      "description": "Implement batch API operations with bulk processing and job queues",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "batch",
+        "bulk",
+        "queue",
+        "job-processing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-cache-manager",
+      "source": "./plugins/api-development/api-cache-manager",
+      "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "caching",
+        "redis",
+        "cdn",
+        "performance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-contract-generator",
+      "source": "./plugins/api-development/api-contract-generator",
+      "description": "Generate API contracts for consumer-driven contract testing",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "contract",
+        "pact",
+        "testing",
+        "microservices"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-documentation-generator",
+      "source": "./plugins/api-development/api-documentation-generator",
+      "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
+      "version": "1.27.0",
+      "category": "api-development",
+      "keywords": [
+        "api",
+        "documentation",
+        "openapi",
+        "swagger",
+        "docs"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-error-handler",
+      "source": "./plugins/api-development/api-error-handler",
+      "description": "Implement standardized error handling with proper HTTP status codes",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "error-handling",
+        "api",
+        "http-status",
+        "exceptions"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-event-emitter",
+      "source": "./plugins/api-development/api-event-emitter",
+      "description": "Implement event-driven APIs with message queues and event streaming",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "events",
+        "messaging",
+        "kafka",
+        "rabbitmq",
+        "event-driven"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-gateway-builder",
+      "source": "./plugins/api-development/api-gateway-builder",
+      "description": "Build API gateway with routing, authentication, and rate limiting",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "api-gateway",
+        "routing",
+        "proxy",
+        "microservices"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-load-tester",
+      "source": "./plugins/api-development/api-load-tester",
+      "description": "Load test APIs with k6, Gatling, or Artillery",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "load-testing",
+        "performance",
+        "k6",
+        "stress-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-migration-tool",
+      "source": "./plugins/api-development/api-migration-tool",
+      "description": "Migrate APIs between versions with backward compatibility",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "migration",
+        "versioning",
+        "api",
+        "backward-compatibility"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-mock-server",
+      "source": "./plugins/api-development/api-mock-server",
+      "description": "Create mock API servers from OpenAPI specs for testing",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "mock",
+        "testing",
+        "openapi",
+        "stub"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-monitoring-dashboard",
+      "source": "./plugins/api-development/api-monitoring-dashboard",
+      "description": "Create monitoring dashboards for API health, metrics, and alerts",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "monitoring",
+        "metrics",
+        "observability",
+        "dashboard"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-rate-limiter",
+      "source": "./plugins/api-development/api-rate-limiter",
+      "description": "Implement rate limiting with token bucket, sliding window, and Redis",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "rate-limiting",
+        "throttling",
+        "api",
+        "redis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-request-logger",
+      "source": "./plugins/api-development/api-request-logger",
+      "description": "Log API requests with structured logging and correlation IDs",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "logging",
+        "observability",
+        "audit",
+        "correlation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-response-validator",
+      "source": "./plugins/api-development/api-response-validator",
+      "description": "Validate API responses against schemas and contracts",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "validation",
+        "schema",
+        "testing",
+        "api"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-schema-validator",
+      "source": "./plugins/api-development/api-schema-validator",
+      "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "schema",
+        "validation",
+        "json-schema",
+        "joi",
+        "zod"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-sdk-generator",
+      "source": "./plugins/api-development/api-sdk-generator",
+      "description": "Generate client SDKs from OpenAPI specs for multiple languages",
+      "version": "1.22.0",
+      "category": "api-development",
+      "keywords": [
+        "sdk",
+        "client",
+        "openapi",
+        "codegen"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-security-scanner",
+      "source": "./plugins/api-development/api-security-scanner",
+      "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "security",
+        "api",
+        "owasp",
+        "vulnerability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-throttling-manager",
+      "source": "./plugins/api-development/api-throttling-manager",
+      "description": "Manage API throttling with dynamic rate limits and quota management",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "throttling",
+        "rate-limiting",
+        "quota",
+        "traffic-management"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-versioning-manager",
+      "source": "./plugins/api-development/api-versioning-manager",
+      "description": "Manage API versions with migration strategies and backward compatibility",
+      "version": "1.26.0",
+      "category": "api-development",
+      "keywords": [
+        "api",
+        "versioning",
+        "migration",
+        "backward-compatibility"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "graphql-server-builder",
+      "source": "./plugins/api-development/graphql-server-builder",
+      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
+      "version": "1.22.0",
+      "category": "api-development",
+      "keywords": [
+        "graphql",
+        "api",
+        "server",
+        "apollo",
+        "schema",
+        "resolvers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "grpc-service-generator",
+      "source": "./plugins/api-development/grpc-service-generator",
+      "description": "Generate gRPC services with Protocol Buffers and streaming support",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": [
+        "grpc",
+        "protobuf",
+        "microservices",
+        "streaming"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "rest-api-generator",
+      "source": "./plugins/api-development/rest-api-generator",
+      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": [
+        "api",
+        "rest",
+        "generator",
+        "openapi",
+        "swagger",
+        "backend"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "webhook-handler-creator",
+      "source": "./plugins/api-development/webhook-handler-creator",
+      "description": "Create secure webhook endpoints with signature verification and retry logic",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "webhook",
+        "events",
+        "signature",
+        "security"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "websocket-server-builder",
+      "source": "./plugins/api-development/websocket-server-builder",
+      "description": "Build WebSocket servers for real-time bidirectional communication",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "websocket",
+        "real-time",
+        "socket.io",
+        "ws"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "x-twitter-scraper",
+      "source": "./plugins/api-development/x-twitter-scraper",
+      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
+      "version": "0.1.0",
+      "category": "api-development",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
+      "license": "MIT"
+    },
+    {
+      "name": "brand-strategy-framework",
+      "source": "./plugins/business-tools/brand-strategy-framework",
+      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
+      "version": "1.7.0",
+      "category": "business-tools",
+      "keywords": [
+        "brand-strategy",
+        "marketing",
+        "branding",
+        "positioning",
+        "messaging",
+        "brand-guidelines",
+        "audience-architecture",
+        "brand-identity"
+      ],
+      "author": {
+        "name": "Rowan Brooks",
+        "email": "rowanbrooks100@github.com"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "excel-analyst-pro",
+      "source": "./plugins/business-tools/excel-analyst-pro",
+      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
+      "version": "1.21.0",
+      "category": "business-tools",
+      "keywords": [
+        "excel",
+        "financial-modeling",
+        "dcf",
+        "lbo",
+        "valuation",
+        "variance-analysis",
+        "pivot-tables",
+        "investment-banking",
+        "private-equity",
+        "financial-analysis",
+        "skills",
+        "mcp"
+      ],
+      "author": {
+        "name": "ClaudeCodePlugins",
+        "email": "plugins@tonsofskills.com"
+      },
+      "featured": true,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "components": {
+        "skills": 4,
         "commands": 3
       },
       "verification": {
@@ -5642,1538 +1857,90 @@
       }
     },
     {
-      "name": "supabase-pack",
-      "source": "./plugins/saas-packs/supabase-pack",
-      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.53.0",
-      "category": "saas-packs",
-      "keywords": [
-        "supabase",
-        "postgres",
-        "database",
-        "authentication",
-        "realtime",
-        "storage",
-        "edge-functions",
-        "rls",
-        "row-level-security",
-        "baas",
-        "backend-as-a-service",
-        "firebase-alternative"
-      ],
+      "name": "executive-assistant-skills",
+      "source": "./plugins/business-tools/executive-assistant-skills",
+      "version": "1.8.0",
+      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
+        "name": "Martin Gontovnikas",
+        "email": "gonto@hypergrowthpartners.com",
+        "url": "https://github.com/mgonto"
       },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "vercel-pack",
-      "source": "./plugins/saas-packs/vercel-pack",
-      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
+      "category": "business-tools",
       "keywords": [
-        "vercel",
-        "deployment",
-        "edge-functions",
-        "serverless",
-        "preview",
-        "ci-cd",
-        "hosting",
-        "next-js",
-        "jamstack",
-        "frontend-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 87,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "clay-pack",
-      "source": "./plugins/saas-packs/clay-pack",
-      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clay",
-        "data-enrichment",
-        "waterfall",
-        "gtm",
-        "sales-ops",
-        "lead-enrichment",
-        "ai-agents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "cursor-pack",
-      "source": "./plugins/saas-packs/cursor-pack",
-      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "cursor",
-        "ai-editor",
-        "code-editor",
-        "composer",
-        "ai-coding",
-        "vscode-fork",
-        "copilot-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "exa-pack",
-      "source": "./plugins/saas-packs/exa-pack",
-      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "exa",
-        "neural-search",
-        "semantic-search",
-        "web-search",
-        "ai-search",
-        "retrieval",
-        "embeddings"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "firecrawl-pack",
-      "source": "./plugins/saas-packs/firecrawl-pack",
-      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "firecrawl",
-        "web-scraping",
-        "crawling",
-        "markdown",
-        "llm-ready",
-        "data-extraction",
-        "scraper"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "klingai-pack",
-      "source": "./plugins/saas-packs/klingai-pack",
-      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "klingai",
-        "kling",
-        "video-generation",
-        "text-to-video",
-        "ai-video",
-        "generative-ai",
-        "creative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 94,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "openrouter-pack",
-      "source": "./plugins/saas-packs/openrouter-pack",
-      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-      "version": "1.20.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openrouter",
-        "llm-routing",
-        "model-selection",
-        "ai-gateway",
-        "multi-model",
-        "cost-optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "perplexity-pack",
-      "source": "./plugins/saas-packs/perplexity-pack",
-      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "perplexity",
-        "ai-search",
-        "research",
-        "citations",
-        "real-time",
-        "knowledge",
-        "answers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "replit-pack",
-      "source": "./plugins/saas-packs/replit-pack",
-      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "replit",
-        "cloud-ide",
-        "deployments",
-        "collaborative",
-        "ai-coding",
-        "browser-ide",
-        "hosting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "retellai-pack",
-      "source": "./plugins/saas-packs/retellai-pack",
-      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
-      "version": "1.9.0",
-      "category": "saas-packs",
-      "keywords": [
-        "retellai",
-        "retell",
-        "voice-ai",
-        "phone-agents",
-        "conversational-ai",
-        "call-center",
-        "ivr"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "sentry-pack",
-      "source": "./plugins/saas-packs/sentry-pack",
-      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
-      "version": "1.51.0",
-      "category": "saas-packs",
-      "keywords": [
-        "sentry",
-        "error-monitoring",
-        "performance",
-        "observability",
-        "debugging",
-        "crash-reporting",
-        "apm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 91,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "windsurf-pack",
-      "source": "./plugins/saas-packs/windsurf-pack",
-      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "windsurf",
-        "ai-editor",
-        "cascade",
-        "codeium",
-        "ai-coding",
-        "code-completion",
-        "refactoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 30
-      },
-      "verification": {
-        "score": 79,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "coderabbit-pack",
-      "source": "./plugins/saas-packs/coderabbit-pack",
-      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "coderabbit",
-        "code-review",
-        "pr-automation",
-        "ai-review",
-        "code-quality",
-        "github-integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "fireflies-pack",
-      "source": "./plugins/saas-packs/fireflies-pack",
-      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "fireflies",
-        "meeting-transcription",
-        "ai-notes",
-        "conversation-intelligence",
-        "summaries"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "groq-pack",
-      "source": "./plugins/saas-packs/groq-pack",
-      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "groq",
-        "lpu",
-        "fast-inference",
-        "llm",
-        "groq-cloud",
-        "low-latency",
-        "ai-acceleration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ideogram-pack",
-      "source": "./plugins/saas-packs/ideogram-pack",
-      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
-      "version": "1.10.0",
-      "category": "saas-packs",
-      "keywords": [
-        "ideogram",
-        "image-generation",
-        "text-to-image",
-        "ai-art",
-        "typography",
-        "creative",
-        "design"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "instantly-pack",
-      "source": "./plugins/saas-packs/instantly-pack",
-      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "instantly",
-        "cold-email",
-        "outreach",
-        "email-automation",
-        "lead-generation",
-        "sales"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "posthog-pack",
-      "source": "./plugins/saas-packs/posthog-pack",
-      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "posthog",
-        "product-analytics",
-        "feature-flags",
-        "session-replay",
-        "ab-testing",
-        "experimentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "vastai-pack",
-      "source": "./plugins/saas-packs/vastai-pack",
-      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vastai",
-        "vast-ai",
-        "gpu-marketplace",
-        "cloud-gpu",
-        "ml-infrastructure",
-        "compute",
-        "training"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 81,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "apollo-pack",
-      "source": "./plugins/saas-packs/apollo-pack",
-      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "apollo",
-        "sales",
-        "prospecting",
-        "sequences",
-        "outbound",
-        "crm",
-        "sales-engagement",
-        "lead-generation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 65,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "deepgram-pack",
-      "source": "./plugins/saas-packs/deepgram-pack",
-      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "deepgram",
-        "speech-to-text",
-        "transcription",
-        "voice",
-        "audio",
-        "asr",
-        "real-time",
-        "voice-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 65,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "juicebox-pack",
-      "source": "./plugins/saas-packs/juicebox-pack",
-      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
-      "version": "1.16.0",
-      "category": "saas-packs",
-      "keywords": [
-        "juicebox",
-        "people-data",
-        "enrichment",
-        "contacts",
-        "search",
-        "data-api",
-        "lead-enrichment"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 71,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "customerio-pack",
-      "source": "./plugins/saas-packs/customerio-pack",
-      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "customerio",
-        "customer-io",
-        "marketing",
+        "executive-assistant",
+        "meeting-prep",
         "email",
+        "productivity",
         "automation",
-        "campaigns",
-        "sms",
-        "push-notifications"
+        "todoist"
       ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 68,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "langchain-py-pack",
-      "source": "./plugins/saas-packs/langchain-py-pack",
-      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
-      "version": "2.5.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langchain",
-        "langgraph",
-        "python",
-        "llm",
-        "agents",
-        "rag",
-        "checkpointing",
-        "streaming",
-        "middleware",
-        "langsmith"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 2
-      }
-    },
-    {
-      "name": "lindy-pack",
-      "source": "./plugins/saas-packs/lindy-pack",
-      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
-      "version": "1.15.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lindy",
-        "ai-assistant",
-        "automation",
-        "workflows",
-        "tasks",
-        "intelligent-automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 75,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "granola-pack",
-      "source": "./plugins/saas-packs/granola-pack",
-      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "granola",
-        "meeting-notes",
-        "transcription",
-        "summaries",
-        "meetings",
-        "ai-notes",
-        "meeting-intelligence"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 72,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "ga4-pack",
-      "source": "./plugins/saas-packs/ga4-pack",
-      "description": "Claude Code skill pack for Google Analytics 4 \u2014 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
-      "version": "1.2.0",
-      "category": "saas-packs",
-      "keywords": [
-        "google-analytics",
-        "ga4",
-        "analytics",
-        "data-api",
-        "bigquery",
-        "reporting",
-        "dau-mau",
-        "cohort-retention"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
+      "license": "MIT",
+      "repository": "https://github.com/mgonto/executive-assistant-skills",
+      "featured": true,
       "components": {
         "skills": 5
-      },
-      "verification": {
-        "score": 70,
-        "grade": "B",
-        "badge": "silver",
-        "lastValidated": "2026-05-20T00:00:00.000Z"
       }
     },
     {
-      "name": "gamma-pack",
-      "source": "./plugins/saas-packs/gamma-pack",
-      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "gamma",
-        "presentations",
-        "documents",
-        "ai-generation",
-        "templates",
-        "slides",
-        "visual-content"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 71,
-        "grade": "C",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "clerk-pack",
-      "source": "./plugins/saas-packs/clerk-pack",
-      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clerk",
-        "authentication",
-        "auth",
-        "users",
-        "identity",
-        "sso",
-        "embeddable-ui",
-        "user-management"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "linear-pack",
-      "source": "./plugins/saas-packs/linear-pack",
-      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "linear",
-        "issues",
-        "project-management",
-        "tracking",
-        "workflows",
-        "agile",
-        "team-collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 67,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "databricks-pack",
-      "source": "./plugins/saas-packs/databricks-pack",
-      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
-      "version": "2.27.0",
-      "category": "saas-packs",
-      "keywords": [
-        "databricks",
-        "delta-lake",
-        "mlflow",
-        "spark",
-        "notebooks",
-        "clusters",
-        "data-engineering",
-        "lakehouse"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "mistral-pack",
-      "source": "./plugins/saas-packs/mistral-pack",
-      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "mistral",
-        "llm",
-        "inference",
-        "embeddings",
-        "fine-tuning",
-        "ai",
-        "machine-learning"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 68,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "langfuse-pack",
-      "source": "./plugins/saas-packs/langfuse-pack",
-      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langfuse",
-        "observability",
-        "tracing",
-        "prompts",
-        "evaluation",
-        "llm-ops",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 67,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "obsidian-pack",
-      "source": "./plugins/saas-packs/obsidian-pack",
-      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "obsidian",
-        "notes",
-        "vault",
-        "plugins",
-        "markdown",
-        "knowledge-management",
-        "pkm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "documenso-pack",
-      "source": "./plugins/saas-packs/documenso-pack",
-      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "documenso",
-        "document-signing",
-        "e-signature",
-        "templates",
-        "workflows",
-        "contracts",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 66,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "evernote-pack",
-      "source": "./plugins/saas-packs/evernote-pack",
-      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "evernote",
-        "notes",
-        "notebooks",
-        "tags",
-        "search",
-        "productivity",
-        "organization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "guidewire-pack",
-      "source": "./plugins/saas-packs/guidewire-pack",
-      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
-      "version": "1.25.0",
-      "category": "saas-packs",
-      "keywords": [
-        "guidewire",
-        "insurance",
-        "policycenter",
-        "claimcenter",
-        "billingcenter",
-        "insurancesuite",
-        "enterprise"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 62,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "lokalise-pack",
-      "source": "./plugins/saas-packs/lokalise-pack",
-      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lokalise",
-        "translation",
-        "localization",
-        "i18n",
-        "l10n",
-        "tms",
-        "internationalization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 69,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "maintainx-pack",
-      "source": "./plugins/saas-packs/maintainx-pack",
-      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "maintainx",
-        "cmms",
-        "work-orders",
-        "maintenance",
-        "assets",
-        "facilities",
-        "operations"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "openevidence-pack",
-      "source": "./plugins/saas-packs/openevidence-pack",
-      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openevidence",
-        "medical-ai",
-        "clinical",
-        "healthcare",
-        "evidence-based",
-        "decision-support",
-        "medicine"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 66,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "speak-pack",
-      "source": "./plugins/saas-packs/speak-pack",
-      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "speak",
-        "language-learning",
-        "speech",
-        "ai-tutor",
-        "education",
-        "conversation",
-        "edtech"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 68,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "twinmind-pack",
-      "source": "./plugins/saas-packs/twinmind-pack",
-      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "twinmind",
-        "meetings",
-        "transcription",
-        "summaries",
-        "ai-assistant",
-        "productivity",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 24
-      },
-      "verification": {
-        "score": 66,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gastown",
-      "source": "./plugins/community/gastown",
-      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "multi-agent",
-        "orchestration",
-        "automation",
-        "polecats",
-        "convoys",
-        "beads",
-        "work-tracking",
-        "ai-factory",
-        "gastown",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      },
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "numman-ali/n-skills",
-        "source_path": "skills/tools/gastown"
-      },
-      "verification": {
-        "score": 95,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "zai-cli",
-      "source": "./plugins/community/zai-cli",
-      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "vision",
-        "image-analysis",
-        "ocr",
-        "web-search",
-        "web-reader",
-        "github",
-        "mcp",
-        "z-ai",
-        "glm-4",
-        "multimodal"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      },
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "numman-ali/n-skills",
-        "source_path": "skills/tools/zai-cli"
-      },
-      "verification": {
-        "score": 96,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "claude-reflect",
-      "source": "./plugins/community/claude-reflect",
-      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": [
-        "claude-code",
-        "self-learning",
-        "corrections",
-        "CLAUDE.md",
-        "memory",
-        "learnings",
-        "hooks",
-        "automation"
-      ],
-      "author": {
-        "name": "Bayram Annakov",
-        "url": "https://github.com/bayramannakov"
-      },
-      "repository": "https://github.com/bayramannakov/claude-reflect",
-      "components": {
-        "commands": 3,
-        "skills": 1,
-        "hooks": 2
-      }
-    },
-    {
-      "name": "contributing-clanker",
-      "source": "./plugins/community/contributing-clanker",
-      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
-      "version": "0.8.0",
-      "category": "community",
-      "keywords": [
-        "oss",
-        "contributions",
-        "github",
-        "ai-slop-prevention",
-        "code-review",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
-      "repository": "https://github.com/jeremylongshore/contributing-clanker",
-      "license": "MIT"
-    },
-    {
-      "name": "neurodivergent-visual-org",
-      "source": "./plugins/productivity/neurodivergent-visual-org",
-      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
-      "version": "3.10.0",
-      "category": "productivity",
-      "keywords": [
-        "neurodivergent",
-        "adhd",
-        "autism",
-        "accessibility",
-        "mermaid-diagrams",
-        "visual-organization",
-        "task-breakdown",
-        "decision-trees"
-      ],
-      "author": {
-        "name": "Jack Reis",
-        "url": "https://github.com/JackReis"
-      },
-      "repository": "https://github.com/JackReis/neurodivergent-visual-org",
-      "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 52,
-        "grade": "F",
-        "badge": null,
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "gh-dash",
-      "source": "./plugins/devops/gh-dash",
-      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
+      "name": "openbb-terminal",
+      "source": "./plugins/business-tools/openbb-terminal",
+      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
       "version": "1.6.0",
-      "category": "devops",
+      "category": "business-tools",
       "keywords": [
-        "github",
-        "pull-request",
-        "ci-cd",
-        "dashboard",
-        "devops",
-        "merge",
-        "code-review"
+        "finance",
+        "investment",
+        "openbb",
+        "stocks",
+        "crypto",
+        "portfolio",
+        "trading",
+        "financial-analysis",
+        "market-data",
+        "equity-research",
+        "options",
+        "forex",
+        "macroeconomics",
+        "quant",
+        "ai-finance"
       ],
       "author": {
-        "name": "Jake Kozloski",
-        "email": "jakozloski@gmail.com"
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
       },
+      "featured": true,
       "components": {
-        "commands": 1
-      },
-      "featured": true
-    },
-    {
-      "name": "youtube-strategy",
-      "source": "./plugins/productivity/youtube-strategy",
-      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
-      "version": "1.10.0",
-      "category": "productivity",
-      "keywords": [
-        "youtube",
-        "content-strategy",
-        "video-production",
-        "ideation",
-        "research",
-        "thumbnails",
-        "titles",
-        "outlining",
-        "content-creation"
-      ],
-      "author": {
-        "name": "Claude Code Plugins"
-      },
-      "components": {
-        "skills": 5,
-        "commands": 7,
-        "agents": 3
-      },
-      "verification": {
-        "score": 67,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
+        "commands": 6,
+        "agents": 4,
+        "total": 10
       }
     },
     {
-      "name": "b12-claude-plugin",
-      "source": "./plugins/community/b12-claude-plugin",
-      "description": "B12 Website Generator \u2014 an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
-      "version": "1.9.0",
-      "category": "community",
+      "name": "promptbook",
+      "source": "./plugins/business-tools/promptbook",
+      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
+      "version": "1.4.0",
+      "category": "business-tools",
       "keywords": [
-        "website",
-        "b12",
-        "hosting",
-        "web-design",
-        "ai-website",
-        "website-generator",
-        "saas"
+        "analytics",
+        "telemetry",
+        "builds",
+        "portfolio",
+        "tracking",
+        "metrics",
+        "sessions"
       ],
       "author": {
-        "name": "B12.io",
-        "url": "https://github.com/b12io"
+        "name": "Promptbook",
+        "email": "contact@promptbook.gg"
       },
+      "homepage": "https://promptbook.gg",
+      "repository": "https://github.com/promptbookgg/claude-code-plugin",
+      "license": "MIT",
       "components": {
-        "skills": 1
-      },
-      "verification": {
-        "score": 75,
-        "grade": "C",
-        "badge": "silver",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
+        "skills": 2,
+        "hooks": 4
       }
     },
     {
@@ -7325,80 +2092,6 @@
       }
     },
     {
-      "name": "wondelai-design-everyday-things",
-      "source": "./plugins/design/wondelai-design-everyday-things",
-      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "design",
-        "ux",
-        "affordances",
-        "signifiers",
-        "human-centered-design",
-        "usability",
-        "don-norman",
-        "hcd"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "design-everyday-things"
-      },
-      "verification": {
-        "score": 62,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-design-sprint",
-      "source": "./plugins/productivity/wondelai-design-sprint",
-      "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "design-sprint",
-        "prototyping",
-        "user-testing",
-        "validation",
-        "gv",
-        "product-design",
-        "rapid-iteration",
-        "mvp"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "design-sprint"
-      },
-      "verification": {
-        "score": 58,
-        "grade": "F",
-        "badge": null,
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "wondelai-drive-motivation",
       "source": "./plugins/business-tools/wondelai-drive-motivation",
       "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
@@ -7430,43 +2123,6 @@
       },
       "verification": {
         "score": 62,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-hooked-ux",
-      "source": "./plugins/design/wondelai-hooked-ux",
-      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "habits",
-        "engagement",
-        "retention",
-        "hook-model",
-        "triggers",
-        "rewards",
-        "onboarding",
-        "ux"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "hooked-ux"
-      },
-      "verification": {
-        "score": 64,
         "grade": "D",
         "badge": "bronze",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -7547,43 +2203,6 @@
       }
     },
     {
-      "name": "wondelai-ios-hig-design",
-      "source": "./plugins/design/wondelai-ios-hig-design",
-      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ios",
-        "apple",
-        "hig",
-        "swiftui",
-        "uikit",
-        "mobile-design",
-        "accessibility",
-        "interface-guidelines"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "ios-hig-design"
-      },
-      "verification": {
-        "score": 57,
-        "grade": "F",
-        "badge": null,
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "wondelai-jobs-to-be-done",
       "source": "./plugins/business-tools/wondelai-jobs-to-be-done",
       "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
@@ -7618,84 +2237,6 @@
         "grade": "D",
         "badge": "bronze",
         "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "wondelai-lean-startup",
-      "source": "./plugins/productivity/wondelai-lean-startup",
-      "description": "Lean Startup methodology for validated learning, MVPs, and innovation accounting. Design experiments, decide when to pivot vs. persevere, and reduce development waste.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "lean-startup",
-        "mvp",
-        "validated-learning",
-        "pivot",
-        "metrics",
-        "innovation-accounting",
-        "experimentation",
-        "build-measure-learn"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "lean-startup"
-      },
-      "verification": {
-        "score": 63,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "navigating-github",
-      "source": "./plugins/productivity/navigating-github",
-      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
-      "version": "2.5.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "git",
-        "learning",
-        "onboarding",
-        "beginner-friendly",
-        "interactive-learning",
-        "version-control",
-        "vibe-coding",
-        "setup",
-        "collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/jeremylongshore/navigating-github",
-      "components": {
-        "skills": 1,
-        "commands": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "jeremylongshore/navigating-github",
-        "source_path": "."
-      },
-      "verification": {
-        "score": 98,
-        "grade": "A",
-        "badge": "gold",
-        "lastValidated": "2026-03-16T00:00:00.000Z"
       }
     },
     {
@@ -7885,43 +2426,6 @@
       }
     },
     {
-      "name": "wondelai-refactoring-ui",
-      "source": "./plugins/design/wondelai-refactoring-ui",
-      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ui-design",
-        "visual-hierarchy",
-        "typography",
-        "color-palette",
-        "tailwind",
-        "shadows",
-        "spacing",
-        "refactoring-ui"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "refactoring-ui"
-      },
-      "verification": {
-        "score": 64,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "wondelai-scorecard-marketing",
       "source": "./plugins/business-tools/wondelai-scorecard-marketing",
       "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
@@ -7996,43 +2500,6 @@
       }
     },
     {
-      "name": "wondelai-top-design",
-      "source": "./plugins/design/wondelai-top-design",
-      "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "web-design",
-        "awwwards",
-        "animations",
-        "typography",
-        "scroll-effects",
-        "brand-website",
-        "premium-design",
-        "motion"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills",
-      "components": {
-        "skills": 1
-      },
-      "external_sync": {
-        "enabled": true,
-        "source_repo": "wondelai/skills",
-        "source_path": "top-design"
-      },
-      "verification": {
-        "score": 61,
-        "grade": "D",
-        "badge": "bronze",
-        "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
       "name": "wondelai-traction-eos",
       "source": "./plugins/business-tools/wondelai-traction-eos",
       "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
@@ -8064,6 +2531,2103 @@
       },
       "verification": {
         "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "b12-claude-plugin",
+      "source": "./plugins/community/b12-claude-plugin",
+      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+      "version": "1.9.0",
+      "category": "community",
+      "keywords": [
+        "website",
+        "b12",
+        "hosting",
+        "web-design",
+        "ai-website",
+        "website-generator",
+        "saas"
+      ],
+      "author": {
+        "name": "B12.io",
+        "url": "https://github.com/b12io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 75,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "boycott-filter",
+      "source": "./plugins/community/boycott-filter",
+      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
+      "version": "1.2.0",
+      "category": "community",
+      "keywords": [
+        "boycott",
+        "consumer",
+        "shopping",
+        "brands",
+        "chrome-extension",
+        "conversational",
+        "privacy",
+        "ethical-consumption"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "claude-never-forgets",
+      "source": "./plugins/community/claude-never-forgets",
+      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "version": "1.21.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "context",
+        "persistent",
+        "preferences",
+        "sessions",
+        "recall"
+      ],
+      "author": {
+        "name": "yldrmahmet",
+        "url": "https://github.com/yldrmahmet"
+      },
+      "components": {
+        "hooks": 4,
+        "commands": 3,
+        "skills": 1,
+        "total": 8
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "claude-reflect",
+      "source": "./plugins/community/claude-reflect",
+      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": [
+        "claude-code",
+        "self-learning",
+        "corrections",
+        "CLAUDE.md",
+        "memory",
+        "learnings",
+        "hooks",
+        "automation"
+      ],
+      "author": {
+        "name": "Bayram Annakov",
+        "url": "https://github.com/bayramannakov"
+      },
+      "repository": "https://github.com/bayramannakov/claude-reflect",
+      "components": {
+        "commands": 3,
+        "skills": 1,
+        "hooks": 2
+      }
+    },
+    {
+      "name": "contributing-clanker",
+      "source": "./plugins/community/contributing-clanker",
+      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
+      "version": "0.8.0",
+      "category": "community",
+      "keywords": [
+        "oss",
+        "contributions",
+        "github",
+        "ai-slop-prevention",
+        "code-review",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
+      "repository": "https://github.com/jeremylongshore/contributing-clanker",
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-anti-deception",
+      "source": "./plugins/community/ejentum-anti-deception",
+      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-code",
+      "source": "./plugins/community/ejentum-code",
+      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-memory",
+      "source": "./plugins/community/ejentum-memory",
+      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-reasoning",
+      "source": "./plugins/community/ejentum-reasoning",
+      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "fairdb-ops-manager",
+      "source": "./plugins/community/fairdb-ops-manager",
+      "description": "Database operations management for FairDB PostgreSQL clusters",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": [
+        "database",
+        "postgresql",
+        "operations"
+      ],
+      "author": {
+        "name": "Community"
+      }
+    },
+    {
+      "name": "framecraft",
+      "source": "./plugins/community/framecraft",
+      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
+      "version": "1.3.0",
+      "category": "community",
+      "keywords": [
+        "demo-video",
+        "video-generation",
+        "playwright",
+        "ffmpeg",
+        "edge-tts",
+        "mcp"
+      ],
+      "author": {
+        "name": "vaddisrinivas",
+        "url": "https://github.com/vaddisrinivas"
+      },
+      "components": {
+        "skills": 1
+      },
+      "featured": false
+    },
+    {
+      "name": "gastown",
+      "source": "./plugins/community/gastown",
+      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "multi-agent",
+        "orchestration",
+        "automation",
+        "polecats",
+        "convoys",
+        "beads",
+        "work-tracking",
+        "ai-factory",
+        "gastown",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      },
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "numman-ali/n-skills",
+        "source_path": "skills/tools/gastown"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "research",
+        "games",
+        "accessibility",
+        "performance",
+        "flask",
+        "react",
+        "godot",
+        "corpus-linguistics",
+        "mcp"
+      ],
+      "author": {
+        "name": "Luke Steuber",
+        "url": "https://github.com/lukeslp"
+      },
+      "components": {
+        "agents": 51,
+        "total": 51
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "mcp",
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "geepers",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Luke Steuber"
+      },
+      "homepage": "https://dr.eamer.dev/geepers/",
+      "repository": "https://github.com/lukeslp/geepers",
+      "components": {
+        "agents": 51
+      }
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./plugins/community/hermes-tweet",
+      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
+      "version": "0.1.6",
+      "category": "community",
+      "keywords": [
+        "hermes-agent",
+        "hermes-plugin",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
+      ],
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
+      "repository": "https://github.com/Xquik-dev/hermes-tweet",
+      "license": "MIT"
+    },
+    {
+      "name": "jeremy-firebase",
+      "source": "./plugins/community/jeremy-firebase",
+      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
+      "version": "2.23.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "vertex-ai",
+        "gemini",
+        "authentication",
+        "storage",
+        "hosting",
+        "cloud-functions",
+        "analytics",
+        "ai-integration",
+        "google-cloud",
+        "embeddings",
+        "model-deployment",
+        "ai-powered",
+        "production-ready"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-firestore",
+      "source": "./plugins/community/jeremy-firestore",
+      "description": "Firestore database specialist for schema design, queries, and real-time sync",
+      "version": "2.20.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "firestore",
+        "database",
+        "crud",
+        "security-rules",
+        "cloud-functions",
+        "batch-operations",
+        "data-migration",
+        "performance",
+        "cost-optimization",
+        "nosql",
+        "google-cloud",
+        "a2a",
+        "agent-to-agent",
+        "mcp",
+        "cloud-run",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]",
+        "url": "https://intentsolutions.io"
+      },
+      "featured": true,
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "llm-box",
+      "source": "./plugins/community/llm-box",
+      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
+      "version": "0.3.0",
+      "category": "community",
+      "keywords": [
+        "workflow",
+        "automation",
+        "terminal",
+        "cli",
+        "yaml",
+        "llm",
+        "mcp"
+      ],
+      "author": {
+        "name": "alib8b8",
+        "url": "https://github.com/alib8b8"
+      },
+      "homepage": "https://github.com/alib8b8/llm-box",
+      "repository": "https://github.com/alib8b8/llm-box",
+      "license": "MIT"
+    },
+    {
+      "name": "mnemos",
+      "source": "./plugins/community/mnemos",
+      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
+      "version": "0.9.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "mcp",
+        "claude-code",
+        "persistent-memory",
+        "agent-memory",
+        "knowledge-graph",
+        "context",
+        "skill",
+        "observations",
+        "provenance",
+        "learning-loop",
+        "golang"
+      ],
+      "author": {
+        "name": "André Figueira",
+        "url": "https://polyxmedia.com",
+        "email": "andre@polyxmedia.com"
+      },
+      "homepage": "https://github.com/polyxmedia/mnemos",
+      "repository": "https://github.com/polyxmedia/mnemos",
+      "license": "MIT"
+    },
+    {
+      "name": "portaljs",
+      "source": "./plugins/community/portaljs",
+      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
+      "version": "0.1.0",
+      "category": "community",
+      "keywords": [
+        "portaljs",
+        "data-portal",
+        "ckan",
+        "nextjs",
+        "data-catalog"
+      ],
+      "author": {
+        "name": "Datopian",
+        "url": "https://www.datopian.com"
+      },
+      "homepage": "https://github.com/datopian/portaljs",
+      "repository": "https://github.com/datopian/portaljs",
+      "license": "MIT"
+    },
+    {
+      "name": "quit-sponsor",
+      "source": "./plugins/community/quit-sponsor",
+      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "metr0x",
+        "url": "https://github.com/metrox-eth"
+      },
+      "repository": "https://github.com/metrox-eth/quit-sponsor",
+      "license": "MIT"
+    },
+    {
+      "name": "skills-janitor",
+      "source": "./plugins/community/skills-janitor",
+      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
+      "version": "0.1.0",
+      "category": "community",
+      "keywords": [
+        "skills",
+        "cleanup",
+        "context-window",
+        "token-budget",
+        "maintenance",
+        "tui"
+      ],
+      "author": {
+        "name": "Krzysztof Hendzel",
+        "url": "https://github.com/khendzel",
+        "email": "krzysztoff.hendzel@gmail.com"
+      },
+      "repository": "https://github.com/khendzel/skills-janitor",
+      "license": "MIT"
+    },
+    {
+      "name": "sprint",
+      "source": "./plugins/community/sprint",
+      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
+      "version": "1.20.0",
+      "category": "community",
+      "keywords": [
+        "autonomous",
+        "agentic",
+        "yolo",
+        "self-iterating",
+        "multi-agent",
+        "hands-off",
+        "auto-pilot",
+        "orchestration",
+        "sprint",
+        "testing",
+        "qa",
+        "mcp"
+      ],
+      "author": {
+        "name": "Damien Laine",
+        "email": "damien.laine@gmail.com",
+        "url": "https://github.com/damienlaine"
+      },
+      "components": {
+        "agents": 9,
+        "commands": 6,
+        "skills": 4,
+        "total": 19
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "walkie-talkie",
+      "source": "./plugins/community/walkie-talkie",
+      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Walkie-Talkie Maintainers",
+        "url": "https://github.com/walkie-talkie-skill"
+      },
+      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
+      "license": "MIT"
+    },
+    {
+      "name": "zai-cli",
+      "source": "./plugins/community/zai-cli",
+      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "vision",
+        "image-analysis",
+        "ocr",
+        "web-search",
+        "web-reader",
+        "github",
+        "mcp",
+        "z-ai",
+        "glm-4",
+        "multimodal"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      },
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "numman-ali/n-skills",
+        "source_path": "skills/tools/zai-cli"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "aomi",
+      "source": "./plugins/crypto/aomi",
+      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
+      "version": "0.10.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "defi",
+        "web3",
+        "evm",
+        "ethereum",
+        "wallet",
+        "account-abstraction",
+        "trading",
+        "agent",
+        "mcp"
+      ],
+      "author": {
+        "name": "aomi-labs",
+        "url": "https://aomi.dev",
+        "email": "info@aomi.dev"
+      },
+      "featured": false
+    },
+    {
+      "name": "arbitrage-opportunity-finder",
+      "source": "./plugins/crypto/arbitrage-opportunity-finder",
+      "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": [
+        "arbitrage",
+        "trading",
+        "defi",
+        "mev",
+        "profit"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "blockchain-explorer-cli",
+      "source": "./plugins/crypto/blockchain-explorer-cli",
+      "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "blockchain",
+        "explorer",
+        "etherscan",
+        "transactions",
+        "addresses",
+        "contracts"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cross-chain-bridge-monitor",
+      "source": "./plugins/crypto/cross-chain-bridge-monitor",
+      "description": "Monitor cross-chain bridge activity, track transfers, analyze security, and detect bridge exploits",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "cross-chain",
+        "bridge",
+        "security",
+        "monitoring",
+        "layer2",
+        "multichain",
+        "defi"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-derivatives-tracker",
+      "source": "./plugins/crypto/crypto-derivatives-tracker",
+      "description": "Track crypto futures, options, perpetual swaps with funding rates, open interest, and derivatives market analysis",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "derivatives",
+        "futures",
+        "options",
+        "perpetuals",
+        "funding-rate",
+        "open-interest",
+        "trading"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-news-aggregator",
+      "source": "./plugins/crypto/crypto-news-aggregator",
+      "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": [
+        "news",
+        "aggregator",
+        "sentiment",
+        "crypto",
+        "media"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-portfolio-tracker",
+      "source": "./plugins/crypto/crypto-portfolio-tracker",
+      "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "portfolio",
+        "trading",
+        "investment",
+        "bitcoin",
+        "ethereum",
+        "defi"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-signal-generator",
+      "source": "./plugins/crypto/crypto-signal-generator",
+      "description": "Generate trading signals from technical indicators and market analysis",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "trading",
+        "signals",
+        "technical-analysis",
+        "indicators",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "crypto-tax-calculator",
+      "source": "./plugins/crypto/crypto-tax-calculator",
+      "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "tax",
+        "calculator",
+        "fifo",
+        "lifo",
+        "capital gains"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "defi-yield-optimizer",
+      "source": "./plugins/crypto/defi-yield-optimizer",
+      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "defi",
+        "yield",
+        "farming",
+        "liquidity",
+        "apy",
+        "optimization",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 80,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "dex-aggregator-router",
+      "source": "./plugins/crypto/dex-aggregator-router",
+      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": [
+        "dex",
+        "swap",
+        "trading",
+        "defi",
+        "aggregator",
+        "routing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "flash-loan-simulator",
+      "source": "./plugins/crypto/flash-loan-simulator",
+      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "flash-loans",
+        "defi",
+        "aave",
+        "arbitrage",
+        "liquidation",
+        "ethereum",
+        "simulation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 86,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gas-fee-optimizer",
+      "source": "./plugins/crypto/gas-fee-optimizer",
+      "description": "Optimize transaction gas fees with timing and routing recommendations",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "gas",
+        "fees",
+        "ethereum",
+        "optimization",
+        "transaction",
+        "l2"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 88,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "liquidity-pool-analyzer",
+      "source": "./plugins/crypto/liquidity-pool-analyzer",
+      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
+      "version": "1.23.0",
+      "category": "crypto",
+      "keywords": [
+        "liquidity",
+        "pool",
+        "defi",
+        "impermanent",
+        "loss",
+        "apy"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "market-movers-scanner",
+      "source": "./plugins/crypto/market-movers-scanner",
+      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "market",
+        "scanner",
+        "movers",
+        "gainers",
+        "losers",
+        "volume",
+        "trading"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 82,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "market-price-tracker",
+      "source": "./plugins/crypto/market-price-tracker",
+      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "market",
+        "price",
+        "tracking",
+        "trading",
+        "crypto",
+        "stocks",
+        "forex"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "market-sentiment-analyzer",
+      "source": "./plugins/crypto/market-sentiment-analyzer",
+      "description": "Analyze market sentiment from social media, news, and on-chain data",
+      "version": "1.24.0",
+      "category": "crypto",
+      "keywords": [
+        "sentiment",
+        "analysis",
+        "social",
+        "news",
+        "market",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 83,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mempool-analyzer",
+      "source": "./plugins/crypto/mempool-analyzer",
+      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
+      "version": "1.32.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "mempool",
+        "mev",
+        "ethereum",
+        "blockchain",
+        "gas",
+        "pending-transactions",
+        "arbitrage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 85,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "nft-rarity-analyzer",
+      "source": "./plugins/crypto/nft-rarity-analyzer",
+      "description": "Analyze NFT rarity scores and valuations across collections",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": [
+        "nft",
+        "rarity",
+        "valuation",
+        "traits",
+        "opensea",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 88,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "on-chain-analytics",
+      "source": "./plugins/crypto/on-chain-analytics",
+      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "on-chain",
+        "analytics",
+        "whale",
+        "metrics",
+        "blockchain"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "options-flow-analyzer",
+      "source": "./plugins/crypto/options-flow-analyzer",
+      "description": "Track institutional options flow, unusual activity, and smart money movements",
+      "version": "1.29.0",
+      "category": "crypto",
+      "keywords": [
+        "options",
+        "flow",
+        "institutional",
+        "trading",
+        "derivatives",
+        "smart money"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "staking-rewards-optimizer",
+      "source": "./plugins/crypto/staking-rewards-optimizer",
+      "description": "Optimize staking rewards across multiple protocols and chains",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "staking",
+        "defi",
+        "yield",
+        "optimization",
+        "rewards"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 82,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "token-launch-tracker",
+      "source": "./plugins/crypto/token-launch-tracker",
+      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "token-launch",
+        "rugpull",
+        "security",
+        "scam-detection",
+        "contract-analysis",
+        "defi",
+        "new-tokens"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "trading-strategy-backtester",
+      "source": "./plugins/crypto/trading-strategy-backtester",
+      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "trading",
+        "backtesting",
+        "strategy",
+        "historical",
+        "performance",
+        "risk"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 82,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wallet-portfolio-tracker",
+      "source": "./plugins/crypto/wallet-portfolio-tracker",
+      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
+      "version": "1.12.0",
+      "category": "crypto",
+      "keywords": [
+        "wallet",
+        "portfolio",
+        "tracking",
+        "blockchain",
+        "defi",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "wallet-security-auditor",
+      "source": "./plugins/crypto/wallet-security-auditor",
+      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
+      "version": "1.17.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "wallet",
+        "security",
+        "audit",
+        "web3"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "whale-alert-monitor",
+      "source": "./plugins/crypto/whale-alert-monitor",
+      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": [
+        "whale",
+        "alert",
+        "monitor",
+        "large",
+        "transactions"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-seeder-generator",
+      "source": "./plugins/database/data-seeder-generator",
+      "description": "Generate realistic test data and database seed scripts for development and testing environments",
+      "version": "1.22.0",
+      "category": "database",
+      "keywords": [
+        "seeding",
+        "test-data",
+        "fixtures",
+        "database",
+        "testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-validation-engine",
+      "source": "./plugins/database/data-validation-engine",
+      "description": "Database plugin for data-validation-engine",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "validation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-archival-system",
+      "source": "./plugins/database/database-archival-system",
+      "description": "Database plugin for database-archival-system",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "archival"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-audit-logger",
+      "source": "./plugins/database/database-audit-logger",
+      "description": "Database plugin for database-audit-logger",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "audit"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-backup-automator",
+      "source": "./plugins/database/database-backup-automator",
+      "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
+      "version": "1.26.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backup",
+        "automation",
+        "disaster-recovery",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 74,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-cache-layer",
+      "source": "./plugins/database/database-cache-layer",
+      "description": "Database plugin for database-cache-layer",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "cache"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-connection-pooler",
+      "source": "./plugins/database/database-connection-pooler",
+      "description": "Implement and optimize database connection pooling for improved performance and resource management",
+      "version": "1.23.0",
+      "category": "database",
+      "keywords": [
+        "connection-pool",
+        "database",
+        "performance",
+        "backend",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-deadlock-detector",
+      "source": "./plugins/database/database-deadlock-detector",
+      "description": "Database plugin for database-deadlock-detector",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "deadlock"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-diff-tool",
+      "source": "./plugins/database/database-diff-tool",
+      "description": "Database plugin for database-diff-tool",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "diff"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-documentation-gen",
+      "source": "./plugins/database/database-documentation-gen",
+      "description": "Database plugin for database-documentation-gen",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "documentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-health-monitor",
+      "source": "./plugins/database/database-health-monitor",
+      "description": "Database plugin for database-health-monitor",
+      "version": "1.25.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "health"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-index-advisor",
+      "source": "./plugins/database/database-index-advisor",
+      "description": "Analyze query patterns and recommend optimal database indexes with impact analysis",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "indexes",
+        "optimization",
+        "performance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-migration-manager",
+      "source": "./plugins/database/database-migration-manager",
+      "description": "Manage database migrations with version control, rollback capabilities, and automated schema evolution tracking",
+      "version": "1.23.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "migration",
+        "schema",
+        "version-control",
+        "backend"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-partition-manager",
+      "source": "./plugins/database/database-partition-manager",
+      "description": "Database plugin for database-partition-manager",
+      "version": "1.25.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "partition"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-recovery-manager",
+      "source": "./plugins/database/database-recovery-manager",
+      "description": "Database plugin for database-recovery-manager",
+      "version": "1.26.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "recovery"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-replication-manager",
+      "source": "./plugins/database/database-replication-manager",
+      "description": "Manage database replication, failover, and high availability configurations",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": [
+        "replication",
+        "high-availability",
+        "failover",
+        "database",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-schema-designer",
+      "source": "./plugins/database/database-schema-designer",
+      "description": "Design and visualize database schemas with normalization guidance, relationship mapping, and ERD generation",
+      "version": "1.24.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "schema",
+        "design",
+        "erd",
+        "normalization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-security-scanner",
+      "source": "./plugins/database/database-security-scanner",
+      "description": "Database plugin for database-security-scanner",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "security"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-sharding-manager",
+      "source": "./plugins/database/database-sharding-manager",
+      "description": "Database plugin for database-sharding-manager",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "sharding"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-transaction-monitor",
+      "source": "./plugins/database/database-transaction-monitor",
+      "description": "Database plugin for database-transaction-monitor",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "transaction"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "freshie-inventory-manager",
+      "source": "./plugins/database/freshie-inventory-manager",
+      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+      "version": "1.5.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "inventory",
+        "freshie",
+        "compliance",
+        "sqlite",
+        "ecosystem",
+        "audit",
+        "subagents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 3
+      }
+    },
+    {
+      "name": "nosql-data-modeler",
+      "source": "./plugins/database/nosql-data-modeler",
+      "description": "Database plugin for nosql-data-modeler",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "data"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "orm-code-generator",
+      "source": "./plugins/database/orm-code-generator",
+      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
+      "version": "1.28.0",
+      "category": "database",
+      "keywords": [
+        "orm",
+        "models",
+        "code-generation",
+        "database",
+        "backend"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "query-performance-analyzer",
+      "source": "./plugins/database/query-performance-analyzer",
+      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "performance",
+        "query",
+        "optimization",
+        "explain",
+        "database"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sql-query-optimizer",
+      "source": "./plugins/database/sql-query-optimizer",
+      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "sql",
+        "optimization",
+        "performance",
+        "database",
+        "query"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "stored-procedure-generator",
+      "source": "./plugins/database/stored-procedure-generator",
+      "description": "Database plugin for stored-procedure-generator",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "procedure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 76,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "brand-forge",
+      "source": "./plugins/design/brand-forge",
+      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
+      "version": "0.5.1",
+      "category": "design",
+      "keywords": [
+        "branding",
+        "logo",
+        "brand-identity",
+        "design",
+        "svg",
+        "templates",
+        "image-generation"
+      ],
+      "author": {
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
+      },
+      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
+    },
+    {
+      "name": "wondelai-design-everyday-things",
+      "source": "./plugins/design/wondelai-design-everyday-things",
+      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "design",
+        "ux",
+        "affordances",
+        "signifiers",
+        "human-centered-design",
+        "usability",
+        "don-norman",
+        "hcd"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "design-everyday-things"
+      },
+      "verification": {
+        "score": 62,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-hooked-ux",
+      "source": "./plugins/design/wondelai-hooked-ux",
+      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "habits",
+        "engagement",
+        "retention",
+        "hook-model",
+        "triggers",
+        "rewards",
+        "onboarding",
+        "ux"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "hooked-ux"
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-ios-hig-design",
+      "source": "./plugins/design/wondelai-ios-hig-design",
+      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ios",
+        "apple",
+        "hig",
+        "swiftui",
+        "uikit",
+        "mobile-design",
+        "accessibility",
+        "interface-guidelines"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "ios-hig-design"
+      },
+      "verification": {
+        "score": 57,
+        "grade": "F",
+        "badge": null,
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-refactoring-ui",
+      "source": "./plugins/design/wondelai-refactoring-ui",
+      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ui-design",
+        "visual-hierarchy",
+        "typography",
+        "color-palette",
+        "tailwind",
+        "shadows",
+        "spacing",
+        "refactoring-ui"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "refactoring-ui"
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-top-design",
+      "source": "./plugins/design/wondelai-top-design",
+      "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "web-design",
+        "awwwards",
+        "animations",
+        "typography",
+        "scroll-effects",
+        "brand-website",
+        "premium-design",
+        "motion"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "top-design"
+      },
+      "verification": {
+        "score": 61,
         "grade": "D",
         "badge": "bronze",
         "lastValidated": "2026-03-10T00:00:00.000Z"
@@ -8144,12 +4708,3167 @@
       }
     },
     {
+      "name": "ansible-playbook-creator",
+      "source": "./plugins/devops/ansible-playbook-creator",
+      "description": "Create Ansible playbooks for configuration management",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "ansible",
+        "automation",
+        "configuration",
+        "playbooks",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "auto-scaling-configurator",
+      "source": "./plugins/devops/auto-scaling-configurator",
+      "description": "Configure auto-scaling policies for applications and infrastructure",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "autoscaling",
+        "scaling",
+        "hpa",
+        "kubernetes",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "backup-strategy-implementor",
+      "source": "./plugins/devops/backup-strategy-implementor",
+      "description": "Implement backup strategies for databases and applications",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "backup",
+        "disaster-recovery",
+        "restoration",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ci-cd-pipeline-builder",
+      "source": "./plugins/devops/ci-cd-pipeline-builder",
+      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "ci-cd",
+        "github-actions",
+        "gitlab-ci",
+        "jenkins",
+        "devops",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cloud-cost-optimizer",
+      "source": "./plugins/devops/cloud-cost-optimizer",
+      "description": "Optimize cloud costs and generate cost reports",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "cost",
+        "optimization",
+        "finops",
+        "cloud",
+        "aws",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "compliance-checker",
+      "source": "./plugins/devops/compliance-checker",
+      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "compliance",
+        "security",
+        "audit",
+        "soc2",
+        "hipaa",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "container-registry-manager",
+      "source": "./plugins/devops/container-registry-manager",
+      "description": "Manage container registries (ECR, GCR, Harbor)",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "registry",
+        "containers",
+        "docker",
+        "ecr",
+        "gcr",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "container-security-scanner",
+      "source": "./plugins/devops/container-security-scanner",
+      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "security",
+        "containers",
+        "scanning",
+        "vulnerabilities",
+        "trivy",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "deployment-pipeline-orchestrator",
+      "source": "./plugins/devops/deployment-pipeline-orchestrator",
+      "description": "Orchestrate complex multi-stage deployment pipelines",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "pipeline",
+        "orchestration",
+        "deployment",
+        "cicd",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "deployment-rollback-manager",
+      "source": "./plugins/devops/deployment-rollback-manager",
+      "description": "Manage and execute deployment rollbacks with safety checks",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "rollback",
+        "deployment",
+        "kubernetes",
+        "recovery",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "disaster-recovery-planner",
+      "source": "./plugins/devops/disaster-recovery-planner",
+      "description": "Plan and implement disaster recovery procedures",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "disaster-recovery",
+        "dr",
+        "business-continuity",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "docker-compose-generator",
+      "source": "./plugins/devops/docker-compose-generator",
+      "description": "Generate Docker Compose configurations for multi-container applications with best practices",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "docker",
+        "docker-compose",
+        "containers",
+        "orchestration",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "engineer-design-diagram",
+      "source": "./plugins/devops/engineer-design-diagram",
+      "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
+      "version": "0.5.0",
+      "category": "devops",
+      "keywords": [
+        "architecture",
+        "diagram",
+        "visualization",
+        "svg",
+        "html",
+        "pr-review",
+        "drift-detection",
+        "sequence-diagram",
+        "engineering-design",
+        "documentation",
+        "onboarding"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "components": {
+        "skills": 1
+      }
+    },
+    {
+      "name": "environment-config-manager",
+      "source": "./plugins/devops/environment-config-manager",
+      "description": "Manage environment configurations and secrets across deployments",
+      "version": "1.23.0",
+      "category": "devops",
+      "keywords": [
+        "config",
+        "environment",
+        "secrets",
+        "configuration",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "fairdb-operations-kit",
+      "source": "./plugins/devops/fairdb-operations-kit",
+      "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "fairdb",
+        "postgresql",
+        "database",
+        "saas",
+        "operations",
+        "devops",
+        "backup",
+        "monitoring",
+        "vps",
+        "contabo",
+        "wasabi",
+        "pgbackrest",
+        "automation",
+        "incident-response"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "featured": false,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gh-dash",
+      "source": "./plugins/devops/gh-dash",
+      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
+      "version": "1.6.0",
+      "category": "devops",
+      "keywords": [
+        "github",
+        "pull-request",
+        "ci-cd",
+        "dashboard",
+        "devops",
+        "merge",
+        "code-review"
+      ],
+      "author": {
+        "name": "Jake Kozloski",
+        "email": "jakozloski@gmail.com"
+      },
+      "components": {
+        "commands": 1
+      },
+      "featured": true
+    },
+    {
+      "name": "git-commit-smart",
+      "source": "./plugins/devops/git-commit-smart",
+      "description": "AI-powered conventional commit message generator with smart analysis",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "git",
+        "commits",
+        "conventional-commits",
+        "automation",
+        "devops",
+        "productivity"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gitops-workflow-builder",
+      "source": "./plugins/devops/gitops-workflow-builder",
+      "description": "Build GitOps workflows with ArgoCD and Flux",
+      "version": "1.22.0",
+      "category": "devops",
+      "keywords": [
+        "gitops",
+        "argocd",
+        "flux",
+        "cd",
+        "kubernetes",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "helm-chart-generator",
+      "source": "./plugins/devops/helm-chart-generator",
+      "description": "Generate Helm charts for Kubernetes applications",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "helm",
+        "kubernetes",
+        "packaging",
+        "charts",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "infrastructure-as-code-generator",
+      "source": "./plugins/devops/infrastructure-as-code-generator",
+      "description": "Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "iac",
+        "terraform",
+        "cloudformation",
+        "pulumi",
+        "infrastructure",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "infrastructure-drift-detector",
+      "source": "./plugins/devops/infrastructure-drift-detector",
+      "description": "Detect infrastructure drift from desired state",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "drift",
+        "terraform",
+        "infrastructure",
+        "monitoring",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-adk-terraform",
+      "source": "./plugins/devops/jeremy-adk-terraform",
+      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
+      "version": "2.22.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "adk",
+        "agent-engine",
+        "vertex-ai",
+        "infrastructure",
+        "vpc-sc"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-genkit-terraform",
+      "source": "./plugins/devops/jeremy-genkit-terraform",
+      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
+      "version": "2.21.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "genkit",
+        "firebase",
+        "cloud-run",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-github-actions-gcp",
+      "source": "./plugins/devops/jeremy-github-actions-gcp",
+      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
+      "version": "2.27.0",
+      "category": "devops",
+      "keywords": [
+        "github-actions",
+        "google-cloud",
+        "workload-identity-federation",
+        "wif",
+        "vertex-ai",
+        "agent-engine",
+        "deployment",
+        "ci-cd",
+        "security",
+        "best-practices",
+        "oidc",
+        "iam"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 1,
+        "skills": 1,
+        "hooks": 1
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "jeremy-vertex-terraform",
+      "source": "./plugins/devops/jeremy-vertex-terraform",
+      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
+      "version": "2.22.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "vertex-ai",
+        "gemini",
+        "model-garden",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "kubernetes-deployment-creator",
+      "source": "./plugins/devops/kubernetes-deployment-creator",
+      "description": "Create Kubernetes deployments, services, and configurations with best practices",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "kubernetes",
+        "k8s",
+        "deployment",
+        "orchestration",
+        "containers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 63,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "load-balancer-configurator",
+      "source": "./plugins/devops/load-balancer-configurator",
+      "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
+      "version": "1.28.0",
+      "category": "devops",
+      "keywords": [
+        "load-balancer",
+        "alb",
+        "nginx",
+        "haproxy",
+        "networking",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "log-aggregation-setup",
+      "source": "./plugins/devops/log-aggregation-setup",
+      "description": "Set up log aggregation (ELK, Loki, Splunk)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "logging",
+        "elk",
+        "loki",
+        "splunk",
+        "observability",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mattyp-changelog",
+      "source": "./plugins/devops/mattyp-changelog",
+      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
+      "version": "0.3.0",
+      "category": "devops",
+      "keywords": [
+        "changelog",
+        "release-notes",
+        "weekly-update",
+        "git",
+        "github",
+        "automation"
+      ],
+      "author": {
+        "name": "Mattyp",
+        "email": "mattyp@tonsofskills.com",
+        "url": "https://tonsofskills.com"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 3
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "monitoring-stack-deployer",
+      "source": "./plugins/devops/monitoring-stack-deployer",
+      "description": "Deploy monitoring stacks (Prometheus, Grafana, Datadog)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "monitoring",
+        "prometheus",
+        "grafana",
+        "observability",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "network-policy-manager",
+      "source": "./plugins/devops/network-policy-manager",
+      "description": "Manage Kubernetes network policies and firewall rules",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "network-policy",
+        "security",
+        "kubernetes",
+        "firewall",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 90,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "secrets-manager-integrator",
+      "source": "./plugins/devops/secrets-manager-integrator",
+      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "secrets",
+        "vault",
+        "aws",
+        "security",
+        "credentials",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "service-mesh-configurator",
+      "source": "./plugins/devops/service-mesh-configurator",
+      "description": "Configure service mesh (Istio, Linkerd) for microservices",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "service-mesh",
+        "istio",
+        "linkerd",
+        "microservices",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sugar",
+      "source": "./plugins/devops/sugar",
+      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
+      "version": "2.0.0",
+      "category": "devops",
+      "keywords": [
+        "autonomous",
+        "development",
+        "ai",
+        "task-management",
+        "automation",
+        "agents",
+        "enterprise",
+        "workflow",
+        "productivity",
+        "mcp"
+      ],
+      "author": {
+        "name": "Steven Leggett",
+        "email": "contact@roboticforce.io"
+      },
+      "featured": true,
+      "mcpTools": 7,
+      "repository": "https://github.com/cdnsteve/sugar",
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "terraform-module-builder",
+      "source": "./plugins/devops/terraform-module-builder",
+      "description": "Build reusable Terraform modules",
+      "version": "1.23.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "iac",
+        "modules",
+        "infrastructure",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "tweetclaw",
+      "source": "./plugins/devops/tweetclaw",
+      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
+      "version": "1.5.3",
+      "category": "devops",
+      "keywords": [
+        "twitter",
+        "x",
+        "automation",
+        "social-media",
+        "tweets",
+        "monitoring",
+        "giveaway",
+        "scraping"
+      ],
+      "author": {
+        "name": "Burak Bayir",
+        "email": "burak@xquik.com",
+        "url": "https://xquik.com"
+      },
+      "repository": "https://github.com/Xquik-dev/tweetclaw",
+      "homepage": "https://xquik.com",
+      "license": "MIT",
+      "pricing": "paid",
+      "components": {
+        "skills": 1,
+        "commands": 2
+      }
+    },
+    {
+      "name": "formatter",
+      "source": "./plugins/examples/formatter",
+      "description": "Code formatting plugin using hooks to auto-format on save",
+      "version": "2.26.0",
+      "category": "examples",
+      "keywords": [
+        "formatting",
+        "hooks",
+        "automation"
+      ],
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "hello-world",
+      "source": "./plugins/examples/hello-world",
+      "description": "Simple example plugin demonstrating basic slash commands",
+      "version": "1.12.0",
+      "category": "examples",
+      "keywords": [
+        "example",
+        "tutorial",
+        "beginner"
+      ],
+      "author": {
+        "name": "Jeremy Longshore"
+      }
+    },
+    {
+      "name": "jeremy-plugin-tool",
+      "source": "./plugins/examples/jeremy-plugin-tool",
+      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
+      "version": "2.19.0",
+      "category": "examples",
+      "keywords": [
+        "skills",
+        "agent-skills",
+        "plugin-management",
+        "marketplace",
+        "validation",
+        "audit",
+        "versioning",
+        "meta-plugin",
+        "repository-tools"
+      ],
+      "author": {
+        "name": "Claude Code Plugins",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "pi-pathfinder",
+      "source": "./plugins/examples/pi-pathfinder",
+      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
+      "version": "1.24.0",
+      "category": "examples",
+      "keywords": [
+        "agent-skills",
+        "pi",
+        "pathfinder",
+        "plugin-intelligence",
+        "task-router",
+        "auto-selector",
+        "skill-extraction",
+        "easy-mode",
+        "automatic",
+        "no-thinking-required"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "skills": 1
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-agent",
+      "source": "./plugins/examples/security-agent",
+      "description": "Security review subagent for code analysis",
+      "version": "1.28.0",
+      "category": "examples",
+      "keywords": [
+        "security",
+        "agent",
+        "code-review"
+      ],
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "a2a-client",
+      "source": "./plugins/mcp/a2a-client",
+      "description": "Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "a2a",
+        "agent2agent",
+        "agent-card",
+        "multi-agent",
+        "interoperability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "featured": true,
+      "mcpTools": 7
+    },
+    {
+      "name": "ai-experiment-logger",
+      "source": "./plugins/mcp/ai-experiment-logger",
+      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
+      "version": "1.12.0",
+      "category": "mcp",
+      "keywords": [
+        "ai",
+        "experiments",
+        "logging",
+        "mcp"
+      ],
+      "author": {
+        "name": "Claude Code Plugins"
+      },
+      "zcf_metadata": {
+        "preset_id": "ai-experiment-logger",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "ai-ml"
+      }
+    },
+    {
+      "name": "beads-dolt",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "beads",
+        "bd",
+        "dolt",
+        "dolthub",
+        "task-tracking",
+        "mcp",
+        "version-control",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "conversational-api-debugger",
+      "source": "./plugins/mcp/conversational-api-debugger",
+      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "api",
+        "debugging",
+        "openapi",
+        "har",
+        "rest",
+        "curl",
+        "http"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 4,
+      "zcf_metadata": {
+        "preset_id": "conversational-api-debugger",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "api"
+      }
+    },
+    {
+      "name": "databricks-workspace-mcp",
+      "source": "./plugins/mcp/databricks-workspace-mcp",
+      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "model-context-protocol",
+        "databricks",
+        "lakehouse",
+        "unity-catalog",
+        "clusters",
+        "dlt",
+        "finops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://tonsofskills.com/learn/databricks/",
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "license": "MIT",
+      "mcpTools": 8
+    },
+    {
+      "name": "design-to-code",
+      "source": "./plugins/mcp/design-to-code",
+      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "design",
+        "figma",
+        "react",
+        "svelte",
+        "vue",
+        "accessibility",
+        "component-generation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 3,
+      "zcf_metadata": {
+        "preset_id": "design-to-code",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "design"
+      }
+    },
+    {
+      "name": "dolt-mcp-vcs",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "dolt-mcp-vcs",
+        "dolt",
+        "dolthub",
+        "dolt-mcp",
+        "version-control",
+        "vcs",
+        "mcp",
+        "sql",
+        "beads",
+        "bd"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "domain-memory-agent",
+      "source": "./plugins/mcp/domain-memory-agent",
+      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
+      "version": "1.17.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "knowledge-base",
+        "semantic-search",
+        "tfidf",
+        "summarization",
+        "rag",
+        "documentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 6,
+      "zcf_metadata": {
+        "preset_id": "domain-memory-agent",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "knowledge"
+      }
+    },
+    {
+      "name": "governed-second-brain",
+      "source": "./plugins/mcp/governed-second-brain",
+      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
+      "version": "1.1.2",
+      "category": "mcp",
+      "keywords": [
+        "memory",
+        "knowledge",
+        "governance",
+        "qmd",
+        "brain",
+        "citations",
+        "local-first",
+        "second-brain"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "lumera-agent-memory",
+      "source": "./plugins/mcp/lumera-agent-memory",
+      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
+      "version": "1.7.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "memory",
+        "cascade",
+        "storage",
+        "encryption",
+        "search",
+        "fts",
+        "agent"
+      ],
+      "author": {
+        "name": "Intent Solutions IO",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "mcpTools": [
+        "store_memory",
+        "recall_memory",
+        "search_memory",
+        "delete_memory"
+      ]
+    },
+    {
+      "name": "pr-to-spec",
+      "source": "./plugins/mcp/pr-to-spec",
+      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+      "version": "0.8.0",
+      "category": "mcp",
+      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "license": "MIT",
+      "featured": true,
+      "external_sync": true,
+      "mcpTools": 6,
+      "keywords": [
+        "mcp",
+        "pr-analysis",
+        "intent-drift",
+        "code-review",
+        "agent-protocol"
+      ]
+    },
+    {
+      "name": "project-health-auditor",
+      "source": "./plugins/mcp/project-health-auditor",
+      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
+      "version": "1.18.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "code-quality",
+        "technical-debt",
+        "complexity",
+        "git-churn",
+        "test-coverage",
+        "analytics"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 4,
+      "zcf_metadata": {
+        "preset_id": "project-health-auditor",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "code-quality"
+      }
+    },
+    {
+      "name": "servicegraph",
+      "source": "./plugins/mcp/servicegraph",
+      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
+      "version": "0.2.0",
+      "category": "mcp",
+      "keywords": [
+        "servicegraph",
+        "service-providers",
+        "agencies",
+        "law-firms",
+        "consulting",
+        "accounting",
+        "marketing",
+        "lead-generation",
+        "professional-services",
+        "us-firms",
+        "product-directories",
+        "saas-directories",
+        "mcp-directories",
+        "ai-directories",
+        "product-launch",
+        "backlinks"
+      ],
+      "author": {
+        "name": "Artur Briugeman",
+        "url": "https://servicegraph.co",
+        "email": "artur@nostr.band"
+      },
+      "homepage": "https://servicegraph.co",
+      "repository": "https://github.com/nostrband/servicegraph",
+      "license": "MIT"
+    },
+    {
+      "name": "slack-channel",
+      "source": "./plugins/mcp/slack-channel",
+      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "slack",
+        "channel",
+        "mcp",
+        "socket-mode",
+        "chatops",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT",
+      "featured": true,
+      "pricing": "free",
+      "external_sync": true,
+      "mcpTools": 5,
+      "components": {
+        "skills": 2
+      }
+    },
+    {
+      "name": "workflow-orchestrator",
+      "source": "./plugins/mcp/workflow-orchestrator",
+      "description": "DAG-based workflow automation with parallel task execution and dependency management",
+      "version": "1.15.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "workflow",
+        "dag",
+        "automation",
+        "orchestration",
+        "cicd",
+        "parallel-execution"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "mcpTools": 4,
+      "zcf_metadata": {
+        "preset_id": "workflow-orchestrator",
+        "bmad_compatible": true,
+        "ccr_compatible": true,
+        "category": "automation"
+      }
+    },
+    {
+      "name": "x-bug-triage",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "triage",
+        "x-api",
+        "bug-tracking",
+        "clustering"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "license": "MIT"
+    },
+    {
+      "name": "x-bug-triage-plugin",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "keywords": [
+        "bug-triage",
+        "x-twitter",
+        "slack",
+        "devops",
+        "mcp"
+      ],
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT",
+      "featured": false,
+      "pricing": "free",
+      "external_sync": true,
+      "mcpTools": 6,
+      "components": {
+        "skills": 5,
+        "agents": 4
+      }
+    },
+    {
+      "name": "ai-ml-engineering-pack",
+      "source": "./plugins/packages/ai-ml-engineering-pack",
+      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "ai",
+        "ml",
+        "llm",
+        "prompt-engineering",
+        "rag",
+        "vector-database",
+        "ai-safety",
+        "openai",
+        "anthropic",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pluginCount": 12,
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "creator-studio-pack",
+      "source": "./plugins/packages/creator-studio-pack",
+      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
+      "version": "1.16.0",
+      "category": "packages",
+      "keywords": [
+        "video",
+        "content-creation",
+        "youtube",
+        "filmmaking",
+        "creator",
+        "documentation",
+        "screencast",
+        "tutorial",
+        "video-editing",
+        "content-strategy",
+        "distribution",
+        "thumbnails",
+        "subtitles",
+        "repurposing",
+        "batch-recording",
+        "analytics",
+        "package",
+        "premium"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pricing": {
+        "model": "one-time",
+        "price": 149,
+        "currency": "USD"
+      },
+      "components": {
+        "agents": 10,
+        "commands": 10,
+        "total": 20
+      }
+    },
+    {
+      "name": "devops-automation-pack",
+      "source": "./plugins/packages/devops-automation-pack",
+      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "devops",
+        "ci-cd",
+        "docker",
+        "kubernetes",
+        "terraform",
+        "deployment",
+        "infrastructure",
+        "automation",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "fullstack-starter-pack",
+      "source": "./plugins/packages/fullstack-starter-pack",
+      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
+      "version": "1.21.0",
+      "category": "packages",
+      "keywords": [
+        "fullstack",
+        "react",
+        "express",
+        "fastapi",
+        "postgresql",
+        "prisma",
+        "typescript",
+        "mvp",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pluginCount": 15
+    },
+    {
+      "name": "security-pro-pack",
+      "source": "./plugins/packages/security-pro-pack",
+      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
+      "version": "1.31.0",
+      "category": "packages",
+      "keywords": [
+        "security",
+        "vulnerability-scanning",
+        "compliance",
+        "HIPAA",
+        "PCI-DSS",
+        "GDPR",
+        "SOC2",
+        "cryptography",
+        "devsecops",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "pluginCount": 10,
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "alerting-rule-creator",
+      "source": "./plugins/performance/alerting-rule-creator",
+      "description": "Create intelligent alerting rules for performance monitoring",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "alerting",
+        "monitoring",
+        "sre",
+        "observability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "apm-dashboard-creator",
+      "source": "./plugins/performance/apm-dashboard-creator",
+      "description": "Create Application Performance Monitoring dashboards",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "apm",
+        "monitoring",
+        "dashboard",
+        "grafana",
+        "datadog"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "application-profiler",
+      "source": "./plugins/performance/application-profiler",
+      "description": "Profile application performance with CPU, memory, and execution time analysis",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "performance",
+        "profiling",
+        "monitoring",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "bottleneck-detector",
+      "source": "./plugins/performance/bottleneck-detector",
+      "description": "Detect and resolve performance bottlenecks",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "bottleneck",
+        "performance",
+        "optimization",
+        "profiling"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cache-performance-optimizer",
+      "source": "./plugins/performance/cache-performance-optimizer",
+      "description": "Optimize caching strategies for improved performance",
+      "version": "1.19.0",
+      "category": "performance",
+      "keywords": [
+        "cache",
+        "performance",
+        "optimization",
+        "redis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "capacity-planning-analyzer",
+      "source": "./plugins/performance/capacity-planning-analyzer",
+      "description": "Analyze and plan for capacity requirements",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "capacity-planning",
+        "scaling",
+        "forecasting",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cpu-usage-monitor",
+      "source": "./plugins/performance/cpu-usage-monitor",
+      "description": "Monitor and analyze CPU usage patterns in applications",
+      "version": "1.23.0",
+      "category": "performance",
+      "keywords": [
+        "cpu",
+        "monitoring",
+        "performance",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-query-profiler",
+      "source": "./plugins/performance/database-query-profiler",
+      "description": "Profile and optimize database queries for performance",
+      "version": "1.9.0",
+      "category": "performance",
+      "keywords": [
+        "database",
+        "query",
+        "profiling",
+        "optimization",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "distributed-tracing-setup",
+      "source": "./plugins/performance/distributed-tracing-setup",
+      "description": "Set up distributed tracing for microservices",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "tracing",
+        "observability",
+        "microservices",
+        "opentelemetry"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "error-rate-monitor",
+      "source": "./plugins/performance/error-rate-monitor",
+      "description": "Monitor and analyze application error rates",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "errors",
+        "monitoring",
+        "reliability",
+        "sre"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "infrastructure-metrics-collector",
+      "source": "./plugins/performance/infrastructure-metrics-collector",
+      "description": "Collect comprehensive infrastructure performance metrics",
+      "version": "1.20.0",
+      "category": "performance",
+      "keywords": [
+        "infrastructure",
+        "metrics",
+        "monitoring",
+        "observability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "load-test-runner",
+      "source": "./plugins/performance/load-test-runner",
+      "description": "Create and execute load tests for performance validation",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "load-testing",
+        "performance",
+        "stress-test",
+        "k6"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "log-analysis-tool",
+      "source": "./plugins/performance/log-analysis-tool",
+      "description": "Analyze logs for performance insights and issues",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": [
+        "logs",
+        "analysis",
+        "performance",
+        "debugging"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "memory-leak-detector",
+      "source": "./plugins/performance/memory-leak-detector",
+      "description": "Detect memory leaks and analyze memory usage patterns",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": [
+        "memory",
+        "leak",
+        "detection",
+        "performance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "metrics-aggregator",
+      "source": "./plugins/performance/metrics-aggregator",
+      "description": "Aggregate and centralize performance metrics",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "metrics",
+        "aggregation",
+        "prometheus",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "network-latency-analyzer",
+      "source": "./plugins/performance/network-latency-analyzer",
+      "description": "Analyze network latency and optimize request patterns",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "network",
+        "latency",
+        "performance",
+        "api"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-budget-validator",
+      "source": "./plugins/performance/performance-budget-validator",
+      "description": "Validate application against performance budgets",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "performance-budget",
+        "validation",
+        "ci-cd",
+        "testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-optimization-advisor",
+      "source": "./plugins/performance/performance-optimization-advisor",
+      "description": "Get comprehensive performance optimization recommendations",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "optimization",
+        "performance",
+        "best-practices",
+        "advisor"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-regression-detector",
+      "source": "./plugins/performance/performance-regression-detector",
+      "description": "Detect performance regressions in CI/CD pipeline",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "regression",
+        "performance",
+        "ci-cd",
+        "testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "real-user-monitoring",
+      "source": "./plugins/performance/real-user-monitoring",
+      "description": "Implement Real User Monitoring for actual performance data",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "rum",
+        "monitoring",
+        "performance",
+        "user-experience"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "resource-usage-tracker",
+      "source": "./plugins/performance/resource-usage-tracker",
+      "description": "Track and optimize resource usage across the stack",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "resources",
+        "monitoring",
+        "optimization",
+        "metrics"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "response-time-tracker",
+      "source": "./plugins/performance/response-time-tracker",
+      "description": "Track and optimize application response times",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "response-time",
+        "latency",
+        "performance",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sla-sli-tracker",
+      "source": "./plugins/performance/sla-sli-tracker",
+      "description": "Track SLAs, SLIs, and SLOs for service reliability",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "sla",
+        "sli",
+        "slo",
+        "sre",
+        "reliability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "synthetic-monitoring-setup",
+      "source": "./plugins/performance/synthetic-monitoring-setup",
+      "description": "Set up synthetic monitoring for proactive performance tracking",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "synthetic-monitoring",
+        "uptime",
+        "performance",
+        "testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "throughput-analyzer",
+      "source": "./plugins/performance/throughput-analyzer",
+      "description": "Analyze and optimize system throughput",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": [
+        "throughput",
+        "performance",
+        "capacity",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "000-jeremy-content-consistency-validator",
+      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
+      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
+      "version": "3.29.0",
+      "category": "productivity",
+      "maintainer": "@jeremylongshore",
+      "keywords": [
+        "documentation",
+        "consistency",
+        "validation",
+        "drift-detection",
+        "source-of-truth",
+        "authority-registry",
+        "content-audit",
+        "quality-assurance",
+        "release-gate",
+        "standards"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "002-jeremy-yaml-master-agent",
+      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
+      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
+      "version": "2.21.0",
+      "category": "productivity",
+      "keywords": [
+        "yaml",
+        "validation",
+        "linting",
+        "schema",
+        "json",
+        "conversion",
+        "parsing",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 1
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "003-jeremy-vertex-ai-media-master",
+      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
+      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
+      "version": "2.25.0",
+      "category": "productivity",
+      "keywords": [
+        "vertex-ai",
+        "gemini",
+        "multimodal",
+        "video-processing",
+        "audio-generation",
+        "image-generation",
+        "marketing",
+        "campaigns",
+        "content-generation",
+        "imagen",
+        "media-production",
+        "google-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "004-jeremy-google-cloud-agent-sdk",
+      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
+      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
+      "version": "2.24.0",
+      "category": "productivity",
+      "keywords": [
+        "agent-development-kit",
+        "adk",
+        "agent-starter-pack",
+        "multi-agent",
+        "containerized-agents",
+        "cloud-run",
+        "gke",
+        "agent-engine",
+        "rag-agents",
+        "react-agents",
+        "google-cloud",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "agent-context-manager",
+      "source": "./plugins/productivity/agent-context-manager",
+      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
+      "version": "1.23.0",
+      "category": "productivity",
+      "keywords": [
+        "agents",
+        "context",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ai-commit-gen",
+      "source": "./plugins/productivity/ai-commit-gen",
+      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
+      "version": "1.10.0",
+      "category": "productivity",
+      "keywords": [
+        "git",
+        "commit",
+        "conventional-commits",
+        "ai",
+        "automation",
+        "productivity",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "commands": 1,
+        "total": 1
+      }
+    },
+    {
+      "name": "box-cloud-filesystem",
+      "source": "./plugins/productivity/box-cloud-filesystem",
+      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "box",
+        "cloud-storage",
+        "filesystem",
+        "file-sync",
+        "box-cli",
+        "upload",
+        "download",
+        "document-management",
+        "collaboration",
+        "ai-agent-storage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT",
+      "featured": true,
+      "pricing": "free",
+      "external_sync": true,
+      "components": {
+        "skills": 1,
+        "hooks": 2
+      },
+      "verification": {
+        "score": 0,
+        "grade": "N/A",
+        "badge": "none",
+        "lastValidated": "2026-03-17T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "claude-workflow-skills",
+      "source": "./plugins/productivity/claude-workflow-skills",
+      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
+      "version": "1.7.1",
+      "category": "productivity",
+      "keywords": [
+        "workflow",
+        "promote",
+        "release",
+        "audit",
+        "standards",
+        "improve",
+        "triage",
+        "git",
+        "review",
+        "pull-request"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
+      "repository": "https://github.com/ali5ter/claude-workflow-skills",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "cli-power-skills",
+      "source": "./plugins/productivity/cli-power-skills",
+      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "cli-tools",
+        "agentic-skills",
+        "data-processing",
+        "security",
+        "web-crawling",
+        "python",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Yuriy Kotik",
+        "url": "https://github.com/ykotik"
+      },
+      "repository": "https://github.com/ykotik/cli-power-skills",
+      "license": "MIT"
+    },
+    {
+      "name": "content-multiplier",
+      "source": "./plugins/productivity/content-multiplier",
+      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
+      "version": "0.2.1",
+      "category": "productivity",
+      "keywords": [
+        "marketing",
+        "content",
+        "repurposing",
+        "brand-voice",
+        "localization",
+        "social-media"
+      ],
+      "author": {
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
+      },
+      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
+    },
+    {
+      "name": "hyperfocus",
+      "source": "./plugins/productivity/hyperfocus",
+      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
+      "version": "0.2.0",
+      "category": "productivity",
+      "author": {
+        "name": "Nestor Magalhaes",
+        "email": "nestor.magalhaes@appex.world"
+      },
+      "keywords": [
+        "accessibility",
+        "adhd",
+        "neurodivergent",
+        "formatting",
+        "readability",
+        "productivity",
+        "cognitive-accessibility"
+      ],
+      "repository": "https://github.com/nextor2k/hyperfocus",
+      "homepage": "https://github.com/nextor2k/hyperfocus",
+      "license": "MIT",
+      "featured": false,
+      "pricing": "free",
+      "components": {
+        "skills": 1,
+        "agents": 0
+      }
+    },
+    {
+      "name": "intent-labs-pack",
+      "source": "./plugins/productivity/intent-labs-pack",
+      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "audit-tests",
+        "validate-skillmd",
+        "testing",
+        "skill-validation",
+        "intent-eval",
+        "dogfood"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 2,
+        "commands": 0,
+        "agents": 0,
+        "total": 2
+      }
+    },
+    {
+      "name": "j-rig",
+      "source": "./plugins/productivity/j-rig",
+      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "skill-refiner",
+        "eval-guided",
+        "skill-md",
+        "meta-tooling",
+        "hooks"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "navigating-github",
+      "source": "./plugins/productivity/navigating-github",
+      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
+      "version": "2.5.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "git",
+        "learning",
+        "onboarding",
+        "beginner-friendly",
+        "interactive-learning",
+        "version-control",
+        "vibe-coding",
+        "setup",
+        "collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/jeremylongshore/navigating-github",
+      "components": {
+        "skills": 1,
+        "commands": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "jeremylongshore/navigating-github",
+        "source_path": "."
+      },
+      "verification": {
+        "score": 98,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-16T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "neurodivergent-visual-org",
+      "source": "./plugins/productivity/neurodivergent-visual-org",
+      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
+      "version": "3.10.0",
+      "category": "productivity",
+      "keywords": [
+        "neurodivergent",
+        "adhd",
+        "autism",
+        "accessibility",
+        "mermaid-diagrams",
+        "visual-organization",
+        "task-breakdown",
+        "decision-trees"
+      ],
+      "author": {
+        "name": "Jack Reis",
+        "url": "https://github.com/JackReis"
+      },
+      "repository": "https://github.com/JackReis/neurodivergent-visual-org",
+      "components": {
+        "skills": 1
+      },
+      "verification": {
+        "score": 52,
+        "grade": "F",
+        "badge": null,
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "obsidian-project-documentation",
+      "source": "./plugins/productivity/obsidian-project-documentation",
+      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
+      "version": "3.2.5",
+      "category": "productivity",
+      "keywords": [
+        "obsidian",
+        "documentation",
+        "notes",
+        "projects"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
+      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
+      "license": "MIT"
+    },
+    {
+      "name": "over-50s-health",
+      "source": "./plugins/productivity/over-50s-health",
+      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
+      "version": "3.3.0",
+      "category": "productivity",
+      "keywords": [
+        "health",
+        "fitness",
+        "nutrition",
+        "longevity",
+        "50+"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
+      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
+      "license": "MIT"
+    },
+    {
+      "name": "overnight-dev",
+      "source": "./plugins/productivity/overnight-dev",
+      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
+      "version": "1.29.0",
+      "category": "productivity",
+      "keywords": [
+        "overnight",
+        "autonomous",
+        "tdd",
+        "testing",
+        "git-hooks",
+        "automation",
+        "continuous-integration",
+        "test-driven-development",
+        "productivity"
+      ],
+      "author": {
+        "name": "Intent Solutions IO",
+        "url": "https://intentsolutions.io",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "pair-programmer",
+      "source": "./plugins/productivity/pair-programmer",
+      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "pair-programming",
+        "coding",
+        "skill-development",
+        "graduated-assistance"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/pair-programmer",
+      "repository": "https://github.com/ali5ter/pair-programmer",
+      "license": "MIT"
+    },
+    {
+      "name": "plane",
+      "source": "./plugins/productivity/plane",
+      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+      "tagline": "Team behavior observatory for Plane workspaces",
+      "version": "0.3.0",
+      "category": "productivity",
+      "keywords": [
+        "plane",
+        "project-management",
+        "team-behavior",
+        "observability",
+        "productivity",
+        "agent-skills",
+        "forge-generated"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "agents": 2
+      },
+      "generated": true,
+      "author_type": "forge"
+    },
+    {
+      "name": "pm-ai-partner",
+      "source": "./plugins/productivity/pm-ai-partner",
+      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
+      "version": "1.8.0",
+      "category": "productivity",
+      "keywords": [
+        "product-management",
+        "pm",
+        "ai-partner",
+        "skills",
+        "commands",
+        "hooks"
+      ],
+      "author": {
+        "name": "Ahmed Khaled",
+        "email": "ahmd.khaled.a.mohamed@gmail.com"
+      },
+      "components": {
+        "skills": 12,
+        "commands": 6,
+        "hooks": 3,
+        "total": 21
+      }
+    },
+    {
+      "name": "prettier-markdown-hook",
+      "source": "./plugins/productivity/prettier-markdown-hook",
+      "description": "Automatically format markdown files with prettier when Claude stops responding, with configurable organization and path exclusions",
+      "version": "1.8.0",
+      "category": "productivity",
+      "keywords": [
+        "prettier",
+        "markdown",
+        "formatting",
+        "automation",
+        "hook",
+        "stop",
+        "git",
+        "conventional-commits"
+      ],
+      "author": {
+        "name": "Terry Li",
+        "email": "[email protected]",
+        "url": "https://github.com/terrylica"
+      },
+      "components": {
+        "hooks": 1,
+        "total": 1
+      }
+    },
+    {
+      "name": "publishing-skills",
+      "source": "./plugins/productivity/publishing-skills",
+      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "ghost",
+        "blogging",
+        "seo",
+        "content-creation",
+        "publishing",
+        "claude-code",
+        "ai-writing"
+      ],
+      "author": {
+        "name": "AutomateLab",
+        "url": "https://github.com/AutomateLab-tech",
+        "email": "hello@automatelab.tech"
+      },
+      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
+      "license": "MIT-0"
+    },
+    {
+      "name": "schedule-after-usage-reset",
+      "source": "./plugins/productivity/schedule-after-usage-reset",
+      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "schedule",
+        "usage-reset",
+        "rate-limit",
+        "claude-code",
+        "automation"
+      ],
+      "author": {
+        "name": "patricksong1993",
+        "url": "https://github.com/patricksong1993"
+      },
+      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "license": "MIT"
+    },
+    {
+      "name": "skyvern",
+      "source": "./plugins/productivity/skyvern",
+      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
+      "version": "0.1.0",
+      "category": "productivity",
+      "author": {
+        "name": "Skyvern-AI",
+        "url": "https://github.com/Skyvern-AI"
+      },
+      "license": "AGPL-3.0"
+    },
+    {
+      "name": "travel-assistant",
+      "source": "./plugins/productivity/travel-assistant",
+      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
+      "version": "1.15.0",
+      "category": "productivity",
+      "keywords": [
+        "travel",
+        "weather",
+        "currency",
+        "timezone",
+        "itinerary",
+        "vacation",
+        "trip-planning",
+        "ai-travel",
+        "real-time",
+        "api-integration",
+        "budget",
+        "packing-list"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "featured": true,
+      "components": {
+        "commands": 6,
+        "agents": 4,
+        "hooks": 2,
+        "scripts": 3,
+        "total": 15
+      }
+    },
+    {
+      "name": "vibe-guide",
+      "source": "./plugins/productivity/vibe-guide",
+      "description": "Non-technical progress summaries for Claude Code work (hides diffs/log noise).",
+      "version": "1.16.0",
+      "category": "productivity",
+      "keywords": [
+        "ux",
+        "accessibility",
+        "explain",
+        "pairing",
+        "non-technical",
+        "beginner-friendly",
+        "explanations",
+        "noise-filtering"
+      ],
+      "author": {
+        "name": "Intent Solutions",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "agents": 3,
+        "commands": 7,
+        "hooks": 1,
+        "total": 11
+      },
+      "tags": [
+        "beginner-friendly",
+        "explanations",
+        "noise-filtering"
+      ],
+      "strict": true
+    },
+    {
+      "name": "wondelai-design-sprint",
+      "source": "./plugins/productivity/wondelai-design-sprint",
+      "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "design-sprint",
+        "prototyping",
+        "user-testing",
+        "validation",
+        "gv",
+        "product-design",
+        "rapid-iteration",
+        "mvp"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "design-sprint"
+      },
+      "verification": {
+        "score": 58,
+        "grade": "F",
+        "badge": null,
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "wondelai-lean-startup",
+      "source": "./plugins/productivity/wondelai-lean-startup",
+      "description": "Lean Startup methodology for validated learning, MVPs, and innovation accounting. Design experiments, decide when to pivot vs. persevere, and reduce development waste.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "lean-startup",
+        "mvp",
+        "validated-learning",
+        "pivot",
+        "metrics",
+        "innovation-accounting",
+        "experimentation",
+        "build-measure-learn"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills",
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "wondelai/skills",
+        "source_path": "lean-startup"
+      },
+      "verification": {
+        "score": 63,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "youtube-strategy",
+      "source": "./plugins/productivity/youtube-strategy",
+      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
+      "version": "1.10.0",
+      "category": "productivity",
+      "keywords": [
+        "youtube",
+        "content-strategy",
+        "video-production",
+        "ideation",
+        "research",
+        "thumbnails",
+        "titles",
+        "outlining",
+        "content-creation"
+      ],
+      "author": {
+        "name": "Claude Code Plugins"
+      },
+      "components": {
+        "skills": 5,
+        "commands": 7,
+        "agents": 3
+      },
+      "verification": {
+        "score": 67,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "abridge-pack",
       "source": "./plugins/saas-packs/abridge-pack",
       "description": "Claude Code skill pack for Abridge (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["abridge", "saas", "sdk", "integration"],
+      "keywords": [
+        "abridge",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8171,7 +7890,12 @@
       "description": "Claude Code skill pack for Adobe (30 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["adobe", "saas", "sdk", "integration"],
+      "keywords": [
+        "adobe",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8193,7 +7917,12 @@
       "description": "Claude Code skill pack for Alchemy (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["alchemy", "saas", "sdk", "integration"],
+      "keywords": [
+        "alchemy",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8215,7 +7944,12 @@
       "description": "Claude Code skill pack for Algolia (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["algolia", "saas", "sdk", "integration"],
+      "keywords": [
+        "algolia",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8237,7 +7971,12 @@
       "description": "Claude Code skill pack for Anima (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["anima", "saas", "sdk", "integration"],
+      "keywords": [
+        "anima",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8259,7 +7998,12 @@
       "description": "Claude Code skill pack for Anthropic (30 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["anthropic", "saas", "sdk", "integration"],
+      "keywords": [
+        "anthropic",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8281,7 +8025,12 @@
       "description": "Claude Code skill pack for Apify (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["apify", "saas", "sdk", "integration"],
+      "keywords": [
+        "apify",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8298,12 +8047,48 @@
       }
     },
     {
+      "name": "apollo-pack",
+      "source": "./plugins/saas-packs/apollo-pack",
+      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "apollo",
+        "sales",
+        "prospecting",
+        "sequences",
+        "outbound",
+        "crm",
+        "sales-engagement",
+        "lead-generation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 65,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "appfolio-pack",
       "source": "./plugins/saas-packs/appfolio-pack",
       "description": "Claude Code skill pack for AppFolio (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["appfolio", "saas", "sdk", "integration"],
+      "keywords": [
+        "appfolio",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8325,7 +8110,13 @@
       "description": "Claude Code skill pack for Apple Notes (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["apple-notes", "apple notes", "saas", "sdk", "integration"],
+      "keywords": [
+        "apple-notes",
+        "apple notes",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8347,7 +8138,12 @@
       "description": "Claude Code skill pack for AssemblyAI (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["assemblyai", "saas", "sdk", "integration"],
+      "keywords": [
+        "assemblyai",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8369,7 +8165,12 @@
       "description": "Claude Code skill pack for Attio (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["attio", "saas", "sdk", "integration"],
+      "keywords": [
+        "attio",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8391,7 +8192,12 @@
       "description": "Claude Code skill pack for BambooHR (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["bamboohr", "saas", "sdk", "integration"],
+      "keywords": [
+        "bamboohr",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8413,7 +8219,13 @@
       "description": "Claude Code skill pack for Bright Data (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["brightdata", "bright data", "saas", "sdk", "integration"],
+      "keywords": [
+        "brightdata",
+        "bright data",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8435,7 +8247,12 @@
       "description": "Claude Code skill pack for Canva (30 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["canva", "saas", "sdk", "integration"],
+      "keywords": [
+        "canva",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8457,7 +8274,13 @@
       "description": "Claude Code skill pack for Cast AI (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["castai", "cast ai", "saas", "sdk", "integration"],
+      "keywords": [
+        "castai",
+        "cast ai",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8479,7 +8302,12 @@
       "description": "Claude Code skill pack for Clari (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["clari", "saas", "sdk", "integration"],
+      "keywords": [
+        "clari",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8496,12 +8324,78 @@
       }
     },
     {
+      "name": "clay-pack",
+      "source": "./plugins/saas-packs/clay-pack",
+      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clay",
+        "data-enrichment",
+        "waterfall",
+        "gtm",
+        "sales-ops",
+        "lead-enrichment",
+        "ai-agents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "clerk-pack",
+      "source": "./plugins/saas-packs/clerk-pack",
+      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clerk",
+        "authentication",
+        "auth",
+        "users",
+        "identity",
+        "sso",
+        "embeddable-ui",
+        "user-management"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "clickhouse-pack",
       "source": "./plugins/saas-packs/clickhouse-pack",
       "description": "Claude Code skill pack for ClickHouse (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["clickhouse", "saas", "sdk", "integration"],
+      "keywords": [
+        "clickhouse",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8523,7 +8417,12 @@
       "description": "Claude Code skill pack for ClickUp (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["clickup", "saas", "sdk", "integration"],
+      "keywords": [
+        "clickup",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8540,12 +8439,46 @@
       }
     },
     {
+      "name": "coderabbit-pack",
+      "source": "./plugins/saas-packs/coderabbit-pack",
+      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "coderabbit",
+        "code-review",
+        "pr-automation",
+        "ai-review",
+        "code-quality",
+        "github-integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "cohere-pack",
       "source": "./plugins/saas-packs/cohere-pack",
       "description": "Claude Code skill pack for Cohere (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["cohere", "saas", "sdk", "integration"],
+      "keywords": [
+        "cohere",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8567,7 +8500,12 @@
       "description": "Claude Code skill pack for CoreWeave (23 skills)",
       "version": "1.11.0",
       "category": "saas-packs",
-      "keywords": ["coreweave", "saas", "sdk", "integration"],
+      "keywords": [
+        "coreweave",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8584,12 +8522,170 @@
       }
     },
     {
+      "name": "cursor-pack",
+      "source": "./plugins/saas-packs/cursor-pack",
+      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "cursor",
+        "ai-editor",
+        "code-editor",
+        "composer",
+        "ai-coding",
+        "vscode-fork",
+        "copilot-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "customerio-pack",
+      "source": "./plugins/saas-packs/customerio-pack",
+      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "customerio",
+        "customer-io",
+        "marketing",
+        "email",
+        "automation",
+        "campaigns",
+        "sms",
+        "push-notifications"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 68,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "databricks-pack",
+      "source": "./plugins/saas-packs/databricks-pack",
+      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
+      "version": "2.27.0",
+      "category": "saas-packs",
+      "keywords": [
+        "databricks",
+        "delta-lake",
+        "mlflow",
+        "spark",
+        "notebooks",
+        "clusters",
+        "data-engineering",
+        "lakehouse"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "deepgram-pack",
+      "source": "./plugins/saas-packs/deepgram-pack",
+      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "deepgram",
+        "speech-to-text",
+        "transcription",
+        "voice",
+        "audio",
+        "asr",
+        "real-time",
+        "voice-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 65,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "documenso-pack",
+      "source": "./plugins/saas-packs/documenso-pack",
+      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "documenso",
+        "document-signing",
+        "e-signature",
+        "templates",
+        "workflows",
+        "contracts",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 66,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "elevenlabs-pack",
       "source": "./plugins/saas-packs/elevenlabs-pack",
       "description": "Claude Code skill pack for ElevenLabs (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["elevenlabs", "saas", "sdk", "integration"],
+      "keywords": [
+        "elevenlabs",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8606,12 +8702,77 @@
       }
     },
     {
+      "name": "evernote-pack",
+      "source": "./plugins/saas-packs/evernote-pack",
+      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "evernote",
+        "notes",
+        "notebooks",
+        "tags",
+        "search",
+        "productivity",
+        "organization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "exa-pack",
+      "source": "./plugins/saas-packs/exa-pack",
+      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "exa",
+        "neural-search",
+        "semantic-search",
+        "web-search",
+        "ai-search",
+        "retrieval",
+        "embeddings"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "fathom-pack",
       "source": "./plugins/saas-packs/fathom-pack",
       "description": "Claude Code skill pack for Fathom (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["fathom", "saas", "sdk", "integration"],
+      "keywords": [
+        "fathom",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8633,7 +8794,12 @@
       "description": "Claude Code skill pack for Figma (30 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["figma", "saas", "sdk", "integration"],
+      "keywords": [
+        "figma",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8655,7 +8821,12 @@
       "description": "Claude Code skill pack for Finta (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["finta", "saas", "sdk", "integration"],
+      "keywords": [
+        "finta",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8672,12 +8843,75 @@
       }
     },
     {
+      "name": "firecrawl-pack",
+      "source": "./plugins/saas-packs/firecrawl-pack",
+      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "firecrawl",
+        "web-scraping",
+        "crawling",
+        "markdown",
+        "llm-ready",
+        "data-extraction",
+        "scraper"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "fireflies-pack",
+      "source": "./plugins/saas-packs/fireflies-pack",
+      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "fireflies",
+        "meeting-transcription",
+        "ai-notes",
+        "conversation-intelligence",
+        "summaries"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "flexport-pack",
       "source": "./plugins/saas-packs/flexport-pack",
       "description": "Claude Code skill pack for Flexport (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["flexport", "saas", "sdk", "integration"],
+      "keywords": [
+        "flexport",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8699,7 +8933,13 @@
       "description": "Claude Code skill pack for Fly.io (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["flyio", "fly.io", "saas", "sdk", "integration"],
+      "keywords": [
+        "flyio",
+        "fly.io",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8721,7 +8961,12 @@
       "description": "Claude Code skill pack for Fondo (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["fondo", "saas", "sdk", "integration"],
+      "keywords": [
+        "fondo",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8743,7 +8988,12 @@
       "description": "Claude Code skill pack for Framer (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["framer", "saas", "sdk", "integration"],
+      "keywords": [
+        "framer",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8760,12 +9010,78 @@
       }
     },
     {
+      "name": "ga4-pack",
+      "source": "./plugins/saas-packs/ga4-pack",
+      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+      "version": "1.2.0",
+      "category": "saas-packs",
+      "keywords": [
+        "google-analytics",
+        "ga4",
+        "analytics",
+        "data-api",
+        "bigquery",
+        "reporting",
+        "dau-mau",
+        "cohort-retention"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 5
+      },
+      "verification": {
+        "score": 70,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gamma-pack",
+      "source": "./plugins/saas-packs/gamma-pack",
+      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "gamma",
+        "presentations",
+        "documents",
+        "ai-generation",
+        "templates",
+        "slides",
+        "visual-content"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 71,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "glean-pack",
       "source": "./plugins/saas-packs/glean-pack",
       "description": "Claude Code skill pack for Glean (24 skills)",
       "version": "1.8.0",
       "category": "saas-packs",
-      "keywords": ["glean", "saas", "sdk", "integration"],
+      "keywords": [
+        "glean",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8787,7 +9103,12 @@
       "description": "Claude Code skill pack for Grammarly (24 skills)",
       "version": "1.8.0",
       "category": "saas-packs",
-      "keywords": ["grammarly", "saas", "sdk", "integration"],
+      "keywords": [
+        "grammarly",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8804,12 +9125,107 @@
       }
     },
     {
+      "name": "granola-pack",
+      "source": "./plugins/saas-packs/granola-pack",
+      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "granola",
+        "meeting-notes",
+        "transcription",
+        "summaries",
+        "meetings",
+        "ai-notes",
+        "meeting-intelligence"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 72,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "groq-pack",
+      "source": "./plugins/saas-packs/groq-pack",
+      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "groq",
+        "lpu",
+        "fast-inference",
+        "llm",
+        "groq-cloud",
+        "low-latency",
+        "ai-acceleration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "guidewire-pack",
+      "source": "./plugins/saas-packs/guidewire-pack",
+      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
+      "version": "1.25.0",
+      "category": "saas-packs",
+      "keywords": [
+        "guidewire",
+        "insurance",
+        "policycenter",
+        "claimcenter",
+        "billingcenter",
+        "insurancesuite",
+        "enterprise"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 62,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "hex-pack",
       "source": "./plugins/saas-packs/hex-pack",
       "description": "Claude Code skill pack for Hex (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["hex", "saas", "sdk", "integration"],
+      "keywords": [
+        "hex",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8831,7 +9247,12 @@
       "description": "Claude Code skill pack for Hootsuite (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["hootsuite", "saas", "sdk", "integration"],
+      "keywords": [
+        "hootsuite",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8853,7 +9274,12 @@
       "description": "Claude Code skill pack for HubSpot (10 production-engineer skills)",
       "version": "2.9.0",
       "category": "saas-packs",
-      "keywords": ["hubspot", "saas", "sdk", "integration"],
+      "keywords": [
+        "hubspot",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8864,12 +9290,76 @@
       }
     },
     {
+      "name": "ideogram-pack",
+      "source": "./plugins/saas-packs/ideogram-pack",
+      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
+      "version": "1.10.0",
+      "category": "saas-packs",
+      "keywords": [
+        "ideogram",
+        "image-generation",
+        "text-to-image",
+        "ai-art",
+        "typography",
+        "creative",
+        "design"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "instantly-pack",
+      "source": "./plugins/saas-packs/instantly-pack",
+      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "instantly",
+        "cold-email",
+        "outreach",
+        "email-automation",
+        "lead-generation",
+        "sales"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "intercom-pack",
       "source": "./plugins/saas-packs/intercom-pack",
       "description": "Claude Code skill pack for Intercom (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["intercom", "saas", "sdk", "integration"],
+      "keywords": [
+        "intercom",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8883,6 +9373,36 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "juicebox-pack",
+      "source": "./plugins/saas-packs/juicebox-pack",
+      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
+      "version": "1.16.0",
+      "category": "saas-packs",
+      "keywords": [
+        "juicebox",
+        "people-data",
+        "enrichment",
+        "contacts",
+        "search",
+        "data-api",
+        "lead-enrichment"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 71,
+        "grade": "C",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -8891,7 +9411,12 @@
       "description": "Claude Code skill pack for Klaviyo (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["klaviyo", "saas", "sdk", "integration"],
+      "keywords": [
+        "klaviyo",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8908,12 +9433,163 @@
       }
     },
     {
+      "name": "klingai-pack",
+      "source": "./plugins/saas-packs/klingai-pack",
+      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "klingai",
+        "kling",
+        "video-generation",
+        "text-to-video",
+        "ai-video",
+        "generative-ai",
+        "creative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "langchain-py-pack",
+      "source": "./plugins/saas-packs/langchain-py-pack",
+      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
+      "version": "2.5.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langchain",
+        "langgraph",
+        "python",
+        "llm",
+        "agents",
+        "rag",
+        "checkpointing",
+        "streaming",
+        "middleware",
+        "langsmith"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 2
+      }
+    },
+    {
+      "name": "langfuse-pack",
+      "source": "./plugins/saas-packs/langfuse-pack",
+      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langfuse",
+        "observability",
+        "tracing",
+        "prompts",
+        "evaluation",
+        "llm-ops",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 67,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "lindy-pack",
+      "source": "./plugins/saas-packs/lindy-pack",
+      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
+      "version": "1.15.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lindy",
+        "ai-assistant",
+        "automation",
+        "workflows",
+        "tasks",
+        "intelligent-automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 75,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "linear-pack",
+      "source": "./plugins/saas-packs/linear-pack",
+      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "linear",
+        "issues",
+        "project-management",
+        "tracking",
+        "workflows",
+        "agile",
+        "team-collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 67,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "linktree-pack",
       "source": "./plugins/saas-packs/linktree-pack",
       "description": "Claude Code skill pack for Linktree (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["linktree", "saas", "sdk", "integration"],
+      "keywords": [
+        "linktree",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8927,6 +9603,36 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "lokalise-pack",
+      "source": "./plugins/saas-packs/lokalise-pack",
+      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lokalise",
+        "translation",
+        "localization",
+        "i18n",
+        "l10n",
+        "tms",
+        "internationalization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -8935,7 +9641,12 @@
       "description": "Claude Code skill pack for Lucidchart (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["lucidchart", "saas", "sdk", "integration"],
+      "keywords": [
+        "lucidchart",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8952,12 +9663,47 @@
       }
     },
     {
+      "name": "maintainx-pack",
+      "source": "./plugins/saas-packs/maintainx-pack",
+      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "maintainx",
+        "cmms",
+        "work-orders",
+        "maintenance",
+        "assets",
+        "facilities",
+        "operations"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 64,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "mindtickle-pack",
       "source": "./plugins/saas-packs/mindtickle-pack",
       "description": "Claude Code skill pack for Mindtickle (18 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["mindtickle", "saas", "sdk", "integration"],
+      "keywords": [
+        "mindtickle",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8979,7 +9725,12 @@
       "description": "Claude Code skill pack for Miro (24 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["miro", "saas", "sdk", "integration"],
+      "keywords": [
+        "miro",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -8996,12 +9747,47 @@
       }
     },
     {
+      "name": "mistral-pack",
+      "source": "./plugins/saas-packs/mistral-pack",
+      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "mistral",
+        "llm",
+        "inference",
+        "embeddings",
+        "fine-tuning",
+        "ai",
+        "machine-learning"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 68,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "navan-pack",
       "source": "./plugins/saas-packs/navan-pack",
       "description": "Claude Code skill pack for Navan (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["navan", "saas", "sdk", "integration"],
+      "keywords": [
+        "navan",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9023,7 +9809,12 @@
       "description": "Claude Code skill pack for Notion (30 skills)",
       "version": "1.38.0",
       "category": "saas-packs",
-      "keywords": ["notion", "saas", "sdk", "integration"],
+      "keywords": [
+        "notion",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9040,12 +9831,47 @@
       }
     },
     {
+      "name": "obsidian-pack",
+      "source": "./plugins/saas-packs/obsidian-pack",
+      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "obsidian",
+        "notes",
+        "vault",
+        "plugins",
+        "markdown",
+        "knowledge-management",
+        "pkm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 69,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "onenote-pack",
       "source": "./plugins/saas-packs/onenote-pack",
       "description": "Claude Code skill pack for OneNote (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["onenote", "saas", "sdk", "integration"],
+      "keywords": [
+        "onenote",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9062,12 +9888,77 @@
       }
     },
     {
+      "name": "openevidence-pack",
+      "source": "./plugins/saas-packs/openevidence-pack",
+      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openevidence",
+        "medical-ai",
+        "clinical",
+        "healthcare",
+        "evidence-based",
+        "decision-support",
+        "medicine"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 66,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "openrouter-pack",
+      "source": "./plugins/saas-packs/openrouter-pack",
+      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
+      "version": "1.20.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openrouter",
+        "llm-routing",
+        "model-selection",
+        "ai-gateway",
+        "multi-model",
+        "cost-optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "oraclecloud-pack",
       "source": "./plugins/saas-packs/oraclecloud-pack",
       "description": "Claude Code skill pack for Oracle Cloud (24 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["oraclecloud", "oracle cloud", "saas", "sdk", "integration"],
+      "keywords": [
+        "oraclecloud",
+        "oracle cloud",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9089,7 +9980,12 @@
       "description": "Claude Code skill pack for Palantir (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["palantir", "saas", "sdk", "integration"],
+      "keywords": [
+        "palantir",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9106,12 +10002,47 @@
       }
     },
     {
+      "name": "perplexity-pack",
+      "source": "./plugins/saas-packs/perplexity-pack",
+      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "perplexity",
+        "ai-search",
+        "research",
+        "citations",
+        "real-time",
+        "knowledge",
+        "answers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "persona-pack",
       "source": "./plugins/saas-packs/persona-pack",
       "description": "Claude Code skill pack for Persona (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["persona", "saas", "sdk", "integration"],
+      "keywords": [
+        "persona",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9160,12 +10091,46 @@
       }
     },
     {
+      "name": "posthog-pack",
+      "source": "./plugins/saas-packs/posthog-pack",
+      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "posthog",
+        "product-analytics",
+        "feature-flags",
+        "session-replay",
+        "ab-testing",
+        "experimentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "procore-pack",
       "source": "./plugins/saas-packs/procore-pack",
       "description": "Claude Code skill pack for Procore (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["procore", "saas", "sdk", "integration"],
+      "keywords": [
+        "procore",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9187,7 +10152,12 @@
       "description": "Claude Code skill pack for QuickNode (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["quicknode", "saas", "sdk", "integration"],
+      "keywords": [
+        "quicknode",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9209,7 +10179,12 @@
       "description": "Claude Code skill pack for Ramp (24 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["ramp", "saas", "sdk", "integration"],
+      "keywords": [
+        "ramp",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9231,7 +10206,12 @@
       "description": "Claude Code skill pack for RemoFirst (12 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["remofirst", "saas", "sdk", "integration"],
+      "keywords": [
+        "remofirst",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9248,12 +10228,77 @@
       }
     },
     {
+      "name": "replit-pack",
+      "source": "./plugins/saas-packs/replit-pack",
+      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "replit",
+        "cloud-ide",
+        "deployments",
+        "collaborative",
+        "ai-coding",
+        "browser-ide",
+        "hosting"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "retellai-pack",
+      "source": "./plugins/saas-packs/retellai-pack",
+      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
+      "version": "1.9.0",
+      "category": "saas-packs",
+      "keywords": [
+        "retellai",
+        "retell",
+        "voice-ai",
+        "phone-agents",
+        "conversational-ai",
+        "call-center",
+        "ivr"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "runway-pack",
       "source": "./plugins/saas-packs/runway-pack",
       "description": "Claude Code skill pack for Runway (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["runway", "saas", "sdk", "integration"],
+      "keywords": [
+        "runway",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9275,7 +10320,12 @@
       "description": "Claude Code skill pack for Salesforce (30 skills)",
       "version": "1.7.0",
       "category": "saas-packs",
-      "keywords": ["salesforce", "saas", "sdk", "integration"],
+      "keywords": [
+        "salesforce",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9297,7 +10347,12 @@
       "description": "Claude Code skill pack for Salesloft (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["salesloft", "saas", "sdk", "integration"],
+      "keywords": [
+        "salesloft",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9314,12 +10369,47 @@
       }
     },
     {
+      "name": "sentry-pack",
+      "source": "./plugins/saas-packs/sentry-pack",
+      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
+      "version": "1.51.0",
+      "category": "saas-packs",
+      "keywords": [
+        "sentry",
+        "error-monitoring",
+        "performance",
+        "observability",
+        "debugging",
+        "crash-reporting",
+        "apm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "serpapi-pack",
       "source": "./plugins/saas-packs/serpapi-pack",
       "description": "Claude Code skill pack for SerpApi (18 skills)",
       "version": "1.4.0",
       "category": "saas-packs",
-      "keywords": ["serpapi", "saas", "sdk", "integration"],
+      "keywords": [
+        "serpapi",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9370,7 +10460,12 @@
       "description": "Claude Code skill pack for Snowflake (30 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["snowflake", "saas", "sdk", "integration"],
+      "keywords": [
+        "snowflake",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9387,12 +10482,47 @@
       }
     },
     {
+      "name": "speak-pack",
+      "source": "./plugins/saas-packs/speak-pack",
+      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "speak",
+        "language-learning",
+        "speech",
+        "ai-tutor",
+        "education",
+        "conversation",
+        "edtech"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 68,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "stackblitz-pack",
       "source": "./plugins/saas-packs/stackblitz-pack",
       "description": "Claude Code skill pack for StackBlitz (18 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["stackblitz", "saas", "sdk", "integration"],
+      "keywords": [
+        "stackblitz",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9409,12 +10539,52 @@
       }
     },
     {
+      "name": "supabase-pack",
+      "source": "./plugins/saas-packs/supabase-pack",
+      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.53.0",
+      "category": "saas-packs",
+      "keywords": [
+        "supabase",
+        "postgres",
+        "database",
+        "authentication",
+        "realtime",
+        "storage",
+        "edge-functions",
+        "rls",
+        "row-level-security",
+        "baas",
+        "backend-as-a-service",
+        "firebase-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "techsmith-pack",
       "source": "./plugins/saas-packs/techsmith-pack",
       "description": "Claude Code skill pack for TechSmith (18 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": ["techsmith", "saas", "sdk", "integration"],
+      "keywords": [
+        "techsmith",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9436,7 +10606,13 @@
       "description": "Claude Code skill pack for Together AI (18 skills)",
       "version": "1.6.0",
       "category": "saas-packs",
-      "keywords": ["together", "together ai", "saas", "sdk", "integration"],
+      "keywords": [
+        "together",
+        "together ai",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9453,12 +10629,77 @@
       }
     },
     {
+      "name": "twinmind-pack",
+      "source": "./plugins/saas-packs/twinmind-pack",
+      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "twinmind",
+        "meetings",
+        "transcription",
+        "summaries",
+        "ai-assistant",
+        "productivity",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 66,
+        "grade": "D",
+        "badge": "bronze",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "vastai-pack",
+      "source": "./plugins/saas-packs/vastai-pack",
+      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vastai",
+        "vast-ai",
+        "gpu-marketplace",
+        "cloud-gpu",
+        "ml-infrastructure",
+        "compute",
+        "training"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 24
+      },
+      "verification": {
+        "score": 81,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "veeva-pack",
       "source": "./plugins/saas-packs/veeva-pack",
       "description": "Claude Code skill pack for Veeva (24 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": ["veeva", "saas", "sdk", "integration"],
+      "keywords": [
+        "veeva",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9472,6 +10713,39 @@
         "grade": "C",
         "badge": "silver",
         "lastValidated": "2026-03-21T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "vercel-pack",
+      "source": "./plugins/saas-packs/vercel-pack",
+      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vercel",
+        "deployment",
+        "edge-functions",
+        "serverless",
+        "preview",
+        "ci-cd",
+        "hosting",
+        "next-js",
+        "jamstack",
+        "frontend-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 87,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -9480,7 +10754,12 @@
       "description": "Claude Code skill pack for Webflow (24 skills)",
       "version": "1.5.0",
       "category": "saas-packs",
-      "keywords": ["webflow", "saas", "sdk", "integration"],
+      "keywords": [
+        "webflow",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9497,12 +10776,47 @@
       }
     },
     {
+      "name": "windsurf-pack",
+      "source": "./plugins/saas-packs/windsurf-pack",
+      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "windsurf",
+        "ai-editor",
+        "cascade",
+        "codeium",
+        "ai-coding",
+        "code-completion",
+        "refactoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "components": {
+        "skills": 30
+      },
+      "verification": {
+        "score": 79,
+        "grade": "C",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
       "name": "wispr-pack",
       "source": "./plugins/saas-packs/wispr-pack",
       "description": "Claude Code skill pack for Wispr (18 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": ["wispr", "saas", "sdk", "integration"],
+      "keywords": [
+        "wispr",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9524,7 +10838,12 @@
       "description": "Claude Code skill pack for Workhuman (18 skills)",
       "version": "1.3.0",
       "category": "saas-packs",
-      "keywords": ["workhuman", "saas", "sdk", "integration"],
+      "keywords": [
+        "workhuman",
+        "saas",
+        "sdk",
+        "integration"
+      ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io",
@@ -9541,1094 +10860,25 @@
       }
     },
     {
-      "name": "pm-ai-partner",
-      "source": "./plugins/productivity/pm-ai-partner",
-      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
-      "version": "1.8.0",
-      "category": "productivity",
-      "keywords": ["product-management", "pm", "ai-partner", "skills", "commands", "hooks"],
-      "author": {
-        "name": "Ahmed Khaled",
-        "email": "ahmd.khaled.a.mohamed@gmail.com"
-      },
-      "components": {
-        "skills": 12,
-        "commands": 6,
-        "hooks": 3,
-        "total": 21
-      }
-    },
-    {
-      "name": "validate-plugin",
-      "source": "./plugins/skill-enhancers/validate-plugin",
-      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
-      "version": "1.8.0",
-      "category": "skill-enhancers",
-      "keywords": ["validation", "plugin-development", "quality-assurance", "linting"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "zero-tech-debt",
-      "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only \u2014 surfaces refactor candidates and walks a 7-step workflow before any deletion.",
-      "version": "1.1.0",
-      "category": "skill-enhancers",
+      "name": "access-control-auditor",
+      "source": "./plugins/security/access-control-auditor",
+      "description": "Audit access control implementations",
+      "version": "1.24.0",
+      "category": "security",
       "keywords": [
-        "refactoring",
-        "tech-debt",
-        "architecture",
-        "cleanup",
-        "modernization",
-        "code-quality"
+        "security",
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "executive-assistant-skills",
-      "source": "./plugins/business-tools/executive-assistant-skills",
-      "version": "1.8.0",
-      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
-      "author": {
-        "name": "Martin Gontovnikas",
-        "email": "gonto@hypergrowthpartners.com",
-        "url": "https://github.com/mgonto"
-      },
-      "category": "business-tools",
-      "keywords": [
-        "executive-assistant",
-        "meeting-prep",
-        "email",
-        "productivity",
-        "automation",
-        "todoist"
-      ],
-      "license": "MIT",
-      "repository": "https://github.com/mgonto/executive-assistant-skills",
-      "featured": true,
-      "components": {
-        "skills": 5
-      }
-    },
-    {
-      "name": "box-cloud-filesystem",
-      "source": "./plugins/productivity/box-cloud-filesystem",
-      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "box",
-        "cloud-storage",
-        "filesystem",
-        "file-sync",
-        "box-cli",
-        "upload",
-        "download",
-        "document-management",
-        "collaboration",
-        "ai-agent-storage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT",
-      "featured": true,
-      "pricing": "free",
-      "external_sync": true,
-      "components": {
-        "skills": 1,
-        "hooks": 2
+        "email": "[email protected]"
       },
       "verification": {
-        "score": 0,
-        "grade": "N/A",
-        "badge": "none",
-        "lastValidated": "2026-03-17T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "pr-to-spec",
-      "source": "./plugins/mcp/pr-to-spec",
-      "description": "The flight envelope for agentic coding \u2014 convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
-      "version": "0.8.0",
-      "category": "mcp",
-      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "license": "MIT",
-      "featured": true,
-      "external_sync": true,
-      "mcpTools": 6,
-      "keywords": ["mcp", "pr-analysis", "intent-drift", "code-review", "agent-protocol"]
-    },
-    {
-      "name": "slack-channel",
-      "source": "./plugins/mcp/slack-channel",
-      "description": "Two-way Slack channel for Claude Code \u2014 chat from Slack DMs and channels via Socket Mode",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": ["slack", "channel", "mcp", "socket-mode", "chatops", "claude-code"],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT",
-      "featured": true,
-      "pricing": "free",
-      "external_sync": true,
-      "mcpTools": 5,
-      "components": {
-        "skills": 2
-      }
-    },
-    {
-      "name": "x-bug-triage-plugin",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage: X complaints \u2192 clusters \u2192 repo evidence \u2192 owner routing \u2192 Slack review \u2192 filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "keywords": ["bug-triage", "x-twitter", "slack", "devops", "mcp"],
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT",
-      "featured": false,
-      "pricing": "free",
-      "external_sync": true,
-      "mcpTools": 6,
-      "components": {
-        "skills": 5,
-        "agents": 4
-      }
-    },
-    {
-      "name": "framecraft",
-      "source": "./plugins/community/framecraft",
-      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
-      "version": "1.3.0",
-      "category": "community",
-      "keywords": ["demo-video", "video-generation", "playwright", "ffmpeg", "edge-tts", "mcp"],
-      "author": {
-        "name": "vaddisrinivas",
-        "url": "https://github.com/vaddisrinivas"
-      },
-      "components": {
-        "skills": 1
-      },
-      "featured": false
-    },
-    {
-      "name": "tweetclaw",
-      "source": "./plugins/devops/tweetclaw",
-      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
-      "version": "1.5.3",
-      "category": "devops",
-      "keywords": [
-        "twitter",
-        "x",
-        "automation",
-        "social-media",
-        "tweets",
-        "monitoring",
-        "giveaway",
-        "scraping"
-      ],
-      "author": {
-        "name": "Burak Bayir",
-        "email": "burak@xquik.com",
-        "url": "https://xquik.com"
-      },
-      "repository": "https://github.com/Xquik-dev/tweetclaw",
-      "homepage": "https://xquik.com",
-      "license": "MIT",
-      "pricing": "paid",
-      "components": {
-        "skills": 1,
-        "commands": 2
-      }
-    },
-    {
-      "name": "shipwright",
-      "source": "./plugins/ai-agency/shipwright",
-      "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
-      "version": "1.3.0",
-      "category": "ai-agency",
-      "author": {
-        "name": "Nate Nelson",
-        "url": "https://github.com/Wynelson94"
-      },
-      "keywords": [
-        "app-builder",
-        "code-generator",
-        "autonomous-agent",
-        "pipeline",
-        "nextjs",
-        "supabase",
-        "sveltekit",
-        "astro",
-        "ai-agency"
-      ],
-      "repository": "https://github.com/Wynelson94/shipwright",
-      "homepage": "https://github.com/Wynelson94/shipwright",
-      "license": "MIT",
-      "featured": false,
-      "pricing": "free",
-      "components": {
-        "skills": 1,
-        "commands": 4
-      }
-    },
-    {
-      "name": "hyperfocus",
-      "source": "./plugins/productivity/hyperfocus",
-      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
-      "version": "0.2.0",
-      "category": "productivity",
-      "author": {
-        "name": "Nestor Magalhaes",
-        "email": "nestor.magalhaes@appex.world"
-      },
-      "keywords": [
-        "accessibility",
-        "adhd",
-        "neurodivergent",
-        "formatting",
-        "readability",
-        "productivity",
-        "cognitive-accessibility"
-      ],
-      "repository": "https://github.com/nextor2k/hyperfocus",
-      "homepage": "https://github.com/nextor2k/hyperfocus",
-      "license": "MIT",
-      "featured": false,
-      "pricing": "free",
-      "components": {
-        "skills": 1,
-        "agents": 0
-      }
-    },
-    {
-      "name": "plane",
-      "source": "./plugins/productivity/plane",
-      "description": "Plane is a team behavior observatory \u2014 synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
-      "tagline": "Team behavior observatory for Plane workspaces",
-      "version": "0.3.0",
-      "category": "productivity",
-      "keywords": [
-        "plane",
-        "project-management",
-        "team-behavior",
-        "observability",
-        "productivity",
-        "agent-skills",
-        "forge-generated"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 2
-      },
-      "generated": true,
-      "author_type": "forge"
-    },
-    {
-      "name": "local-tts",
-      "source": "./plugins/ai-ml/local-tts",
-      "description": "Offline text-to-speech via VoxCPM2 \u2014 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
-      "version": "1.3.0",
-      "category": "ai-ml",
-      "keywords": [
-        "tts",
-        "text-to-speech",
-        "voice",
-        "voice-cloning",
-        "voice-design",
-        "offline",
-        "voxcpm",
-        "apple-silicon",
-        "audio",
-        "narration"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "Apache-2.0",
-      "repository": "https://github.com/vdk888/local-tts"
-    },
-    {
-      "name": "boycott-filter",
-      "source": "./plugins/community/boycott-filter",
-      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
-      "version": "1.2.0",
-      "category": "community",
-      "keywords": [
-        "boycott",
-        "consumer",
-        "shopping",
-        "brands",
-        "chrome-extension",
-        "conversational",
-        "privacy",
-        "ethical-consumption"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/vdk888/boycott-filter"
-    },
-    {
-      "name": "web-analytics",
-      "source": "./plugins/analytics/web-analytics",
-      "description": "Push-based web analytics intelligence team \u2014 self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
-      "version": "1.4.0",
-      "category": "analytics",
-      "keywords": [
-        "analytics",
-        "umami",
-        "ga4",
-        "traffic",
-        "mcp",
-        "self-hosted",
-        "multi-agent",
-        "push-based"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "components": {
-        "skills": 1,
-        "agents": 9
-      },
-      "verification": {
-        "score": 85,
+        "score": 96,
         "grade": "A",
         "badge": "gold",
-        "lastValidated": "2026-05-20T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "aomi",
-      "source": "./plugins/crypto/aomi",
-      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
-      "version": "0.10.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "defi",
-        "web3",
-        "evm",
-        "ethereum",
-        "wallet",
-        "account-abstraction",
-        "trading",
-        "agent",
-        "mcp"
-      ],
-      "author": {
-        "name": "aomi-labs",
-        "url": "https://aomi.dev",
-        "email": "info@aomi.dev"
-      },
-      "featured": false
-    },    {
-      "name": "cli-power-skills",
-      "source": "./plugins/productivity/cli-power-skills",
-      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "cli-tools",
-        "agentic-skills",
-        "data-processing",
-        "security",
-        "web-crawling",
-        "python",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Yuriy Kotik",
-        "url": "https://github.com/ykotik"
-      },
-      "repository": "https://github.com/ykotik/cli-power-skills",
-      "license": "MIT"
-    },    {
-      "name": "claude-workflow-skills",
-      "source": "./plugins/productivity/claude-workflow-skills",
-      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
-      "version": "1.7.1",
-      "category": "productivity",
-      "keywords": [
-        "workflow",
-        "promote",
-        "release",
-        "audit",
-        "standards",
-        "improve",
-        "triage",
-        "git",
-        "review",
-        "pull-request"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
-      "repository": "https://github.com/ali5ter/claude-workflow-skills",
-      "license": "MIT"
-    },    {
-      "name": "cli-ux-tester",
-      "source": "./plugins/testing/cli-ux-tester",
-      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
-      "version": "3.1.0",
-      "category": "testing",
-      "keywords": [
-        "CLI",
-        "UX",
-        "testing",
-        "developer-experience",
-        "terminal",
-        "usability"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
-      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
-      "license": "MIT"
-    },    {
-      "name": "skyvern",
-      "source": "./plugins/productivity/skyvern",
-      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
-      "version": "0.1.0",
-      "category": "productivity",
-      "author": {
-        "name": "Skyvern-AI",
-        "url": "https://github.com/Skyvern-AI"
-      },
-      "license": "AGPL-3.0"
-    },    {
-      "name": "tonone",
-      "source": "./plugins/ai-agency/tonone",
-      "description": "23-agent engineering + product team with 125 skills for Claude Code",
-      "version": "1.8.0",
-      "category": "ai-agency",
-      "keywords": [
-        "agents",
-        "engineering-team",
-        "infrastructure",
-        "devops",
-        "backend",
-        "security",
-        "observability",
-        "frontend",
-        "ml",
-        "mobile",
-        "embedded",
-        "analytics",
-        "testing",
-        "platform",
-        "sales",
-        "revenue",
-        "customer-success",
-        "content-marketing",
-        "pr",
-        "community",
-        "finance",
-        "people",
-        "operations",
-        "support"
-      ],
-      "author": {
-        "name": "tonone-ai",
-        "url": "https://tonone.ai"
-      },
-      "repository": "https://github.com/tonone-ai/tonone",
-      "license": "MIT"
-    },    {
-      "name": "x-bug-triage",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "triage",
-        "x-api",
-        "bug-tracking",
-        "clustering"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "license": "MIT"
-    },    {
-      "name": "hyperflow",
-      "source": "./plugins/ai-agency/hyperflow",
-      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
-      "version": "4.26.1",
-      "category": "ai-agency",
-      "keywords": [
-        "claude-code-plugin",
-        "multi-agent",
-        "dynamic-workflows",
-        "workflow-chain",
-        "triageflow",
-        "personas",
-        "flow-profiles",
-        "code-review",
-        "project-memory",
-        "multi-tool"
-      ],
-      "author": {
-        "name": "Mohammed Abdelhady",
-        "url": "https://github.com/Mohammed-Abdelhady"
-      },
-      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "license": "MIT"
-    },    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },    {
-      "name": "ejentum-anti-deception",
-      "source": "./plugins/community/ejentum-anti-deception",
-      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },    {
-      "name": "ejentum-code",
-      "source": "./plugins/community/ejentum-code",
-      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },    {
-      "name": "ejentum-memory",
-      "source": "./plugins/community/ejentum-memory",
-      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },    {
-      "name": "ejentum-reasoning",
-      "source": "./plugins/community/ejentum-reasoning",
-      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },    {
-      "name": "over-50s-health",
-      "source": "./plugins/productivity/over-50s-health",
-      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
-      "version": "3.3.0",
-      "category": "productivity",
-      "keywords": [
-        "health",
-        "fitness",
-        "nutrition",
-        "longevity",
-        "50+"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
-      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
-      "license": "MIT"
-    },    {
-      "name": "obsidian-project-documentation",
-      "source": "./plugins/productivity/obsidian-project-documentation",
-      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
-      "version": "3.2.5",
-      "category": "productivity",
-      "keywords": [
-        "obsidian",
-        "documentation",
-        "notes",
-        "projects"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
-      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
-      "license": "MIT"
-    },    {
-      "name": "pair-programmer",
-      "source": "./plugins/productivity/pair-programmer",
-      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "pair-programming",
-        "coding",
-        "skill-development",
-        "graduated-assistance"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/pair-programmer",
-      "repository": "https://github.com/ali5ter/pair-programmer",
-      "license": "MIT"
-    },    {
-      "name": "governed-second-brain",
-      "source": "./plugins/mcp/governed-second-brain",
-      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
-      "version": "1.1.2",
-      "category": "mcp",
-      "keywords": [
-        "memory",
-        "knowledge",
-        "governance",
-        "qmd",
-        "brain",
-        "citations",
-        "local-first",
-        "second-brain"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "license": "Apache-2.0"
-    },    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "databricks-workspace-mcp",
-      "source": "./plugins/mcp/databricks-workspace-mcp",
-      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "model-context-protocol",
-        "databricks",
-        "lakehouse",
-        "unity-catalog",
-        "clusters",
-        "dlt",
-        "finops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://tonsofskills.com/learn/databricks/",
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "license": "MIT",
-      "mcpTools": 8
-    },
-    {
-      "name": "beads-dolt",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "beads",
-        "bd",
-        "dolt",
-        "dolthub",
-        "task-tracking",
-        "mcp",
-        "version-control",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "publishing-skills",
-      "source": "./plugins/productivity/publishing-skills",
-      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "ghost",
-        "blogging",
-        "seo",
-        "content-creation",
-        "publishing",
-        "claude-code",
-        "ai-writing"
-      ],
-      "author": {
-        "name": "AutomateLab",
-        "url": "https://github.com/AutomateLab-tech",
-        "email": "hello@automatelab.tech"
-      },
-      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
-      "license": "MIT-0"
-    },
-    {
-      "name": "dolt-mcp-vcs",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "dolt-mcp-vcs",
-        "dolt",
-        "dolthub",
-        "dolt-mcp",
-        "version-control",
-        "vcs",
-        "mcp",
-        "sql",
-        "beads",
-        "bd"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "hermes-tweet",
-      "source": "./plugins/community/hermes-tweet",
-      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
-      "version": "0.1.6",
-      "category": "community",
-      "keywords": [
-        "hermes-agent",
-        "hermes-plugin",
-        "xquik",
-        "twitter",
-        "x",
-        "social-media",
-        "automation"
-      ],
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
-      "repository": "https://github.com/Xquik-dev/hermes-tweet",
-      "license": "MIT"
-    },
-    {
-      "name": "x-twitter-scraper",
-      "source": "./plugins/api-development/x-twitter-scraper",
-      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
-      "version": "0.1.0",
-      "category": "api-development",
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
-      "license": "MIT"
-    },
-    {
-      "name": "servicegraph",
-      "source": "./plugins/mcp/servicegraph",
-      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
-      "version": "0.2.0",
-      "category": "mcp",
-      "keywords": [
-        "servicegraph",
-        "service-providers",
-        "agencies",
-        "law-firms",
-        "consulting",
-        "accounting",
-        "marketing",
-        "lead-generation",
-        "professional-services",
-        "us-firms",
-        "product-directories",
-        "saas-directories",
-        "mcp-directories",
-        "ai-directories",
-        "product-launch",
-        "backlinks"
-      ],
-      "author": {
-        "name": "Artur Briugeman",
-        "url": "https://servicegraph.co",
-        "email": "artur@nostr.band"
-      },
-      "homepage": "https://servicegraph.co",
-      "repository": "https://github.com/nostrband/servicegraph",
-      "license": "MIT"
-    },
-    {
-      "name": "schedule-after-usage-reset",
-      "source": "./plugins/productivity/schedule-after-usage-reset",
-      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "schedule",
-        "usage-reset",
-        "rate-limit",
-        "claude-code",
-        "automation"
-      ],
-      "author": {
-        "name": "patricksong1993",
-        "url": "https://github.com/patricksong1993"
-      },
-      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "mnemos",
-      "source": "./plugins/community/mnemos",
-      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
-      "version": "0.9.0",
-      "category": "community",
-      "keywords": [
-        "memory",
-        "mcp",
-        "claude-code",
-        "persistent-memory",
-        "agent-memory",
-        "knowledge-graph",
-        "context",
-        "skill",
-        "observations",
-        "provenance",
-        "learning-loop",
-        "golang"
-      ],
-      "author": {
-        "name": "André Figueira",
-        "url": "https://polyxmedia.com",
-        "email": "andre@polyxmedia.com"
-      },
-      "homepage": "https://github.com/polyxmedia/mnemos",
-      "repository": "https://github.com/polyxmedia/mnemos",
-      "license": "MIT"
-    },
-    {
-      "name": "portaljs",
-      "source": "./plugins/community/portaljs",
-      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
-      "version": "0.1.0",
-      "category": "community",
-      "keywords": [
-        "portaljs",
-        "data-portal",
-        "ckan",
-        "nextjs",
-        "data-catalog"
-      ],
-      "author": {
-        "name": "Datopian",
-        "url": "https://www.datopian.com"
-      },
-      "homepage": "https://github.com/datopian/portaljs",
-      "repository": "https://github.com/datopian/portaljs",
-      "license": "MIT"
-    },
-    {
-      "name": "llm-box",
-      "source": "./plugins/community/llm-box",
-      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
-      "version": "0.3.0",
-      "category": "community",
-      "keywords": [
-        "workflow",
-        "automation",
-        "terminal",
-        "cli",
-        "yaml",
-        "llm",
-        "mcp"
-      ],
-      "author": {
-        "name": "alib8b8",
-        "url": "https://github.com/alib8b8"
-      },
-      "homepage": "https://github.com/alib8b8/llm-box",
-      "repository": "https://github.com/alib8b8/llm-box",
-      "license": "MIT"
-    },
-    {
-      "name": "j-rig",
-      "source": "./plugins/productivity/j-rig",
-      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "skill-refiner",
-        "eval-guided",
-        "skill-md",
-        "meta-tooling",
-        "hooks"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 1,
-        "commands": 0,
-        "agents": 0,
-        "total": 1
-      }
-    },
-    {
-      "name": "intent-labs-pack",
-      "source": "./plugins/productivity/intent-labs-pack",
-      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "audit-tests",
-        "validate-skillmd",
-        "testing",
-        "skill-validation",
-        "intent-eval",
-        "dogfood"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "components": {
-        "skills": 2,
-        "commands": 0,
-        "agents": 0,
-        "total": 2
+        "lastValidated": "2026-03-10T00:00:00.000Z"
       }
     },
     {
@@ -10656,119 +10906,1479 @@
       "license": "MIT"
     },
     {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
+      "name": "authentication-validator",
+      "source": "./plugins/security/authentication-validator",
+      "description": "Validate authentication implementations",
+      "version": "1.26.0",
+      "category": "security",
       "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "compliance-report-generator",
+      "source": "./plugins/security/compliance-report-generator",
+      "description": "Generate compliance reports",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cors-policy-validator",
+      "source": "./plugins/security/cors-policy-validator",
+      "description": "Validate CORS policies",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "csrf-protection-validator",
+      "source": "./plugins/security/csrf-protection-validator",
+      "description": "Validate CSRF protection",
+      "version": "1.26.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "data-privacy-scanner",
+      "source": "./plugins/security/data-privacy-scanner",
+      "description": "Scan for data privacy issues",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "dependency-checker",
+      "source": "./plugins/security/dependency-checker",
+      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "dependencies",
+        "npm",
+        "pip",
+        "composer",
+        "vulnerabilities"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "encryption-tool",
+      "source": "./plugins/security/encryption-tool",
+      "description": "Encrypt and decrypt data with various algorithms",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "gdpr-compliance-scanner",
+      "source": "./plugins/security/gdpr-compliance-scanner",
+      "description": "Scan for GDPR compliance issues",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "hipaa-compliance-checker",
+      "source": "./plugins/security/hipaa-compliance-checker",
+      "description": "Check HIPAA compliance",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "input-validation-scanner",
+      "source": "./plugins/security/input-validation-scanner",
+      "description": "Scan input validation practices",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "owasp-compliance-checker",
+      "source": "./plugins/security/owasp-compliance-checker",
+      "description": "Check OWASP Top 10 compliance",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "pci-dss-validator",
+      "source": "./plugins/security/pci-dss-validator",
+      "description": "Validate PCI DSS compliance",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "penetration-tester",
+      "source": "./plugins/security/penetration-tester",
+      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
+      "version": "3.30.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "penetration-testing",
+        "pentesting",
+        "owasp",
+        "owasp-top-10",
+        "vulnerability-scanning",
+        "dependency-audit",
+        "license-compliance",
+        "engagement-governance",
+        "chain-of-custody"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 84,
+        "grade": "B",
+        "badge": "silver",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "secret-scanner",
+      "source": "./plugins/security/secret-scanner",
+      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "secrets",
+        "api-keys",
+        "credentials",
+        "passwords"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-audit-reporter",
+      "source": "./plugins/security/security-audit-reporter",
+      "description": "Generate comprehensive security audit reports",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-headers-analyzer",
+      "source": "./plugins/security/security-headers-analyzer",
+      "description": "Analyze HTTP security headers",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-incident-responder",
+      "source": "./plugins/security/security-incident-responder",
+      "description": "Assist with security incident response",
+      "version": "1.32.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-misconfiguration-finder",
+      "source": "./plugins/security/security-misconfiguration-finder",
+      "description": "Find security misconfigurations",
+      "version": "1.29.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 94,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "session-security-checker",
+      "source": "./plugins/security/session-security-checker",
+      "description": "Check session security implementation",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "severity1-marketplace",
+      "source": "./plugins/security/severity1-marketplace",
+      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
+      "version": "1.6.0",
+      "category": "security",
+      "keywords": [
+        "severity",
+        "classification",
+        "prompt-improvement",
+        "marketplace",
+        "security",
+        "quality",
+        "triage",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "severity1",
+        "email": "severity1@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 2,
+        "agents": 1
+      }
+    },
+    {
+      "name": "soc2-audit-helper",
+      "source": "./plugins/security/soc2-audit-helper",
+      "description": "Assist with SOC2 audit preparation",
+      "version": "1.30.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 93,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "sql-injection-detector",
+      "source": "./plugins/security/sql-injection-detector",
+      "description": "Detect SQL injection vulnerabilities",
+      "version": "1.31.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "ssl-certificate-manager",
+      "source": "./plugins/security/ssl-certificate-manager",
+      "description": "Manage and monitor SSL/TLS certificates",
+      "version": "1.21.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 97,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "vulnerability-scanner",
+      "source": "./plugins/security/vulnerability-scanner",
+      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "vulnerability",
+        "scanning",
+        "cve",
+        "sast"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "xss-vulnerability-scanner",
+      "source": "./plugins/security/xss-vulnerability-scanner",
+      "description": "Scan for XSS vulnerabilities",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "axiom",
+      "source": "./plugins/skill-enhancers/axiom",
+      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
+      "version": "0.3.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "ios",
+        "debugging",
+        "swift",
+        "persistence",
+        "testing",
+        "performance",
+        "xcode",
+        "concurrency",
+        "database",
+        "swiftdata",
+        "grdb",
+        "liquid-glass",
+        "swiftui"
+      ],
+      "author": {
+        "name": "Charles Wiltgen",
+        "url": "https://github.com/CharlesWiltgen"
+      },
+      "components": {
+        "skills": 13,
+        "total": 13
+      }
+    },
+    {
+      "name": "calendar-to-workflow",
+      "source": "./plugins/skill-enhancers/calendar-to-workflow",
+      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "calendar",
+        "automation",
+        "meetings",
+        "productivity"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "file-to-code",
+      "source": "./plugins/skill-enhancers/file-to-code",
+      "description": "Converts file references into executable code implementations",
+      "version": "0.16.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "files",
+        "automation",
+        "code-generation"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "research-to-deploy",
+      "source": "./plugins/skill-enhancers/research-to-deploy",
+      "description": "Transforms research findings into deployed solutions automatically",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "research",
+        "automation",
+        "deployment"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "search-to-slack",
+      "source": "./plugins/skill-enhancers/search-to-slack",
+      "description": "Automatically posts search results to Slack channels",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "search",
+        "slack",
+        "automation",
+        "integration"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "skill-creator",
+      "source": "./plugins/skill-enhancers/skill-creator",
+      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
+      "version": "5.20.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "skill-creation",
+        "validation",
+        "meta-tooling",
+        "grading",
+        "anthropic-spec"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "featured": true,
+      "pluginCount": 1,
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "validate-plugin",
+      "source": "./plugins/skill-enhancers/validate-plugin",
+      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
+      "version": "1.8.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "validation",
+        "plugin-development",
+        "quality-assurance",
+        "linting"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
+    },
+    {
+      "name": "web-to-github-issue",
+      "source": "./plugins/skill-enhancers/web-to-github-issue",
+      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
+      "version": "1.27.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "web-search",
         "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
+        "automation",
+        "research",
+        "issue-tracking",
+        "skill-enhancer",
+        "productivity",
+        "workflow"
       ],
       "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
+        "name": "Claude Code Plugins Team",
+        "email": "[email protected]"
       },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
+      "featured": true,
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "verification": {
+        "score": 96,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
     },
     {
-      "name": "skills-janitor",
-      "source": "./plugins/community/skills-janitor",
-      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
-      "version": "0.1.0",
-      "category": "community",
+      "name": "zero-tech-debt",
+      "source": "./plugins/skill-enhancers/zero-tech-debt",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "version": "1.1.0",
+      "category": "skill-enhancers",
       "keywords": [
-        "skills",
+        "refactoring",
+        "tech-debt",
+        "architecture",
         "cleanup",
-        "context-window",
-        "token-budget",
-        "maintenance",
-        "tui"
+        "modernization",
+        "code-quality"
       ],
       "author": {
-        "name": "Krzysztof Hendzel",
-        "url": "https://github.com/khendzel",
-        "email": "krzysztoff.hendzel@gmail.com"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
       },
-      "repository": "https://github.com/khendzel/skills-janitor",
-      "license": "MIT"
+      "components": {
+        "skills": 1,
+        "commands": 0,
+        "agents": 0,
+        "total": 1
+      }
     },
     {
-      "name": "walkie-talkie",
-      "source": "./plugins/community/walkie-talkie",
-      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Walkie-Talkie Maintainers",
-        "url": "https://github.com/walkie-talkie-skill"
-      },
-      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
-      "license": "MIT"
-    },
-    {
-      "name": "brand-forge",
-      "source": "./plugins/design/brand-forge",
-      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
-      "version": "0.5.1",
-      "category": "design",
+      "name": "accessibility-test-scanner",
+      "source": "./plugins/testing/accessibility-test-scanner",
+      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
+      "version": "1.23.0",
+      "category": "testing",
       "keywords": [
-        "branding",
-        "logo",
-        "brand-identity",
-        "design",
-        "svg",
-        "templates",
-        "image-generation"
+        "testing",
+        "accessibility",
+        "a11y",
+        "wcag",
+        "aria",
+        "screen-reader",
+        "compliance"
       ],
       "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
       },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
-      "repository": "https://github.com/localplugins/plugins",
-      "license": "MIT"
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
     },
     {
-      "name": "content-multiplier",
-      "source": "./plugins/productivity/content-multiplier",
-      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
-      "version": "0.2.1",
-      "category": "productivity",
+      "name": "api-fuzzer",
+      "source": "./plugins/testing/api-fuzzer",
+      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
+      "version": "1.25.0",
+      "category": "testing",
       "keywords": [
-        "marketing",
-        "content",
-        "repurposing",
-        "brand-voice",
-        "localization",
-        "social-media"
+        "testing",
+        "fuzzing",
+        "api",
+        "security",
+        "edge-cases",
+        "input-validation"
       ],
       "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
       },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
-      "repository": "https://github.com/localplugins/plugins",
+      "verification": {
+        "score": 91,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "api-test-automation",
+      "source": "./plugins/testing/api-test-automation",
+      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "api",
+        "rest",
+        "graphql",
+        "automation",
+        "endpoints"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "browser-compatibility-tester",
+      "source": "./plugins/testing/browser-compatibility-tester",
+      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
+      "version": "2.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "cross-browser",
+        "browserstack",
+        "selenium",
+        "playwright",
+        "compatibility"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "chaos-engineering-toolkit",
+      "source": "./plugins/testing/chaos-engineering-toolkit",
+      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "chaos-engineering",
+        "resilience",
+        "failure-injection",
+        "fault-tolerance",
+        "reliability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "cli-ux-tester",
+      "source": "./plugins/testing/cli-ux-tester",
+      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
+      "version": "3.1.0",
+      "category": "testing",
+      "keywords": [
+        "CLI",
+        "UX",
+        "testing",
+        "developer-experience",
+        "terminal",
+        "usability"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
       "license": "MIT"
     },
     {
-      "name": "quit-sponsor",
-      "source": "./plugins/community/quit-sponsor",
-      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
-      "version": "0.1.0",
-      "category": "community",
+      "name": "code-cleanup",
+      "source": "./plugins/testing/code-cleanup",
+      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+      "version": "1.7.0",
+      "category": "testing",
+      "keywords": [
+        "code-quality",
+        "cleanup",
+        "refactoring",
+        "dead-code",
+        "deduplication",
+        "type-safety",
+        "security",
+        "performance",
+        "async",
+        "tech-debt",
+        "code-review"
+      ],
       "author": {
-        "name": "metr0x",
-        "url": "https://github.com/metrox-eth"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
       },
-      "repository": "https://github.com/metrox-eth/quit-sponsor",
-      "license": "MIT"
+      "components": {
+        "skills": 1,
+        "agents": 11
+      }
+    },
+    {
+      "name": "contract-test-validator",
+      "source": "./plugins/testing/contract-test-validator",
+      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "contract-testing",
+        "pact",
+        "openapi",
+        "api",
+        "microservices",
+        "consumer-driven"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "database-test-manager",
+      "source": "./plugins/testing/database-test-manager",
+      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "database",
+        "sql",
+        "test-data",
+        "fixtures",
+        "migrations",
+        "transactions"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "e2e-test-framework",
+      "source": "./plugins/testing/e2e-test-framework",
+      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "e2e",
+        "playwright",
+        "cypress",
+        "selenium",
+        "browser-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "integration-test-runner",
+      "source": "./plugins/testing/integration-test-runner",
+      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "integration-tests",
+        "test-runner",
+        "e2e",
+        "api-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "kobiton-automate",
+      "source": "./plugins/testing/kobiton-automate",
+      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
+      "version": "1.0.2",
+      "category": "testing",
+      "keywords": [
+        "mobile",
+        "testing",
+        "appium",
+        "automation",
+        "devices",
+        "ios",
+        "android",
+        "real-device",
+        "mcp",
+        "kobiton"
+      ],
+      "author": {
+        "name": "Kobiton Inc.",
+        "url": "https://github.com/kobiton"
+      },
+      "components": {
+        "skills": 1
+      },
+      "external_sync": {
+        "enabled": true,
+        "source_repo": "kobiton/automate",
+        "source_path": "."
+      },
+      "verification": {
+        "score": 95,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-05-20T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "load-balancer-tester",
+      "source": "./plugins/testing/load-balancer-tester",
+      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "load-balancer",
+        "traffic-distribution",
+        "failover",
+        "high-availability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mobile-app-tester",
+      "source": "./plugins/testing/mobile-app-tester",
+      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mobile",
+        "appium",
+        "detox",
+        "xcuitest",
+        "espresso",
+        "ios",
+        "android"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "mutation-test-runner",
+      "source": "./plugins/testing/mutation-test-runner",
+      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mutation-testing",
+        "test-quality",
+        "stryker",
+        "pitest"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "performance-test-suite",
+      "source": "./plugins/testing/performance-test-suite",
+      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
+      "version": "1.30.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "performance",
+        "load-testing",
+        "benchmarking",
+        "stress-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "regression-test-tracker",
+      "source": "./plugins/testing/regression-test-tracker",
+      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "regression-testing",
+        "test-tracking",
+        "ci-cd",
+        "quality-assurance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "security-test-scanner",
+      "source": "./plugins/testing/security-test-scanner",
+      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
+      "version": "1.29.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "security",
+        "vulnerabilities",
+        "owasp",
+        "penetration-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "smoke-test-runner",
+      "source": "./plugins/testing/smoke-test-runner",
+      "description": "Quick smoke test suites to verify critical functionality after deployments",
+      "version": "1.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "smoke-tests",
+        "deployment",
+        "sanity-check",
+        "critical-path"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "snapshot-test-manager",
+      "source": "./plugins/testing/snapshot-test-manager",
+      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "snapshot",
+        "jest",
+        "vitest",
+        "diff-analysis",
+        "test-management"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-coverage-analyzer",
+      "source": "./plugins/testing/test-coverage-analyzer",
+      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "coverage",
+        "code-coverage",
+        "metrics",
+        "analysis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-data-generator",
+      "source": "./plugins/testing/test-data-generator",
+      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "test-data",
+        "fake-data",
+        "fixtures",
+        "factory"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-doubles-generator",
+      "source": "./plugins/testing/test-doubles-generator",
+      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mocks",
+        "stubs",
+        "spies",
+        "fakes",
+        "test-doubles",
+        "jest",
+        "sinon"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-environment-manager",
+      "source": "./plugins/testing/test-environment-manager",
+      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "environment",
+        "docker",
+        "testcontainers",
+        "isolation",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-orchestrator",
+      "source": "./plugins/testing/test-orchestrator",
+      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "orchestration",
+        "workflow",
+        "parallel",
+        "test-selection",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "test-report-generator",
+      "source": "./plugins/testing/test-report-generator",
+      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
+      "version": "1.23.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "reporting",
+        "coverage",
+        "metrics",
+        "dashboard",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "unit-test-generator",
+      "source": "./plugins/testing/unit-test-generator",
+      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "unit-tests",
+        "test-generation",
+        "jest",
+        "pytest",
+        "mocha",
+        "junit"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "visual-regression-tester",
+      "source": "./plugins/testing/visual-regression-tester",
+      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "visual-regression",
+        "ui-testing",
+        "percy",
+        "chromatic",
+        "backstop",
+        "screenshot-testing"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      },
+      "verification": {
+        "score": 92,
+        "grade": "A",
+        "badge": "gold",
+        "lastValidated": "2026-03-10T00:00:00.000Z"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,151 +16,6 @@
   },
   "plugins": [
     {
-      "name": "000-jeremy-content-consistency-validator",
-      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
-      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
-      "version": "3.29.0",
-      "category": "productivity",
-      "keywords": [
-        "documentation",
-        "consistency",
-        "validation",
-        "drift-detection",
-        "source-of-truth",
-        "authority-registry",
-        "content-audit",
-        "quality-assurance",
-        "release-gate",
-        "standards"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "002-jeremy-yaml-master-agent",
-      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
-      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
-      "version": "2.21.0",
-      "category": "productivity",
-      "keywords": [
-        "yaml",
-        "validation",
-        "linting",
-        "schema",
-        "json",
-        "conversion",
-        "parsing",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "003-jeremy-vertex-ai-media-master",
-      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
-      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
-      "version": "2.25.0",
-      "category": "productivity",
-      "keywords": [
-        "vertex-ai",
-        "gemini",
-        "multimodal",
-        "video-processing",
-        "audio-generation",
-        "image-generation",
-        "marketing",
-        "campaigns",
-        "content-generation",
-        "imagen",
-        "media-production",
-        "google-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "004-jeremy-google-cloud-agent-sdk",
-      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
-      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
-      "version": "2.24.0",
-      "category": "productivity",
-      "keywords": [
-        "agent-development-kit",
-        "adk",
-        "agent-starter-pack",
-        "multi-agent",
-        "containerized-agents",
-        "cloud-run",
-        "gke",
-        "agent-engine",
-        "rag-agents",
-        "react-agents",
-        "google-cloud",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "access-control-auditor",
-      "source": "./plugins/security/access-control-auditor",
-      "description": "Audit access control implementations",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "accessibility-test-scanner",
-      "source": "./plugins/testing/accessibility-test-scanner",
-      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "accessibility",
-        "a11y",
-        "wcag",
-        "aria",
-        "screen-reader",
-        "compliance"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "agent-context-manager",
-      "source": "./plugins/productivity/agent-context-manager",
-      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
-      "version": "1.23.0",
-      "category": "productivity",
-      "keywords": [
-        "agents",
-        "context",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore"
-      }
-    },
-    {
       "name": "agency-os",
       "source": "./plugins/ai-agency/agency-os",
       "description": "Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel with dependency ordering and model routing.",
@@ -181,23 +36,202 @@
       }
     },
     {
-      "name": "ai-commit-gen",
-      "source": "./plugins/productivity/ai-commit-gen",
-      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
-      "version": "1.10.0",
-      "category": "productivity",
+      "name": "discovery-questionnaire",
+      "source": "./plugins/ai-agency/discovery-questionnaire",
+      "description": "Generate custom discovery questionnaires for AI agency prospects",
+      "version": "1.9.0",
+      "category": "ai-agency",
       "keywords": [
-        "git",
-        "commit",
-        "conventional-commits",
-        "ai",
-        "automation",
-        "productivity",
-        "devops"
+        "discovery",
+        "questionnaire",
+        "client",
+        "sales",
+        "agency",
+        "ai-agency"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "hyperflow",
+      "source": "./plugins/ai-agency/hyperflow",
+      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
+      "version": "4.26.1",
+      "category": "ai-agency",
+      "keywords": [
+        "claude-code-plugin",
+        "multi-agent",
+        "dynamic-workflows",
+        "workflow-chain",
+        "triageflow",
+        "personas",
+        "flow-profiles",
+        "code-review",
+        "project-memory",
+        "multi-tool"
+      ],
+      "author": {
+        "name": "Mohammed Abdelhady",
+        "url": "https://github.com/Mohammed-Abdelhady"
+      },
+      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "license": "MIT"
+    },
+    {
+      "name": "make-scenario-builder",
+      "source": "./plugins/ai-agency/make-scenario-builder",
+      "description": "Create Make.com (Integromat) scenarios with AI assistance",
+      "version": "1.15.0",
+      "category": "ai-agency",
+      "keywords": [
+        "make",
+        "integromat",
+        "automation",
+        "scenarios",
+        "workflow",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "n8n-workflow-designer",
+      "source": "./plugins/ai-agency/n8n-workflow-designer",
+      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
+      "version": "1.13.0",
+      "category": "ai-agency",
+      "keywords": [
+        "n8n",
+        "workflow",
+        "automation",
+        "self-hosted",
+        "open-source",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "url": "https://github.com/jeremylongshore/claude-code-plugins"
+      }
+    },
+    {
+      "name": "roi-calculator",
+      "source": "./plugins/ai-agency/roi-calculator",
+      "description": "Calculate and present ROI for AI automation projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "roi",
+        "return on investment",
+        "calculator",
+        "sales",
+        "value",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "shipwright",
+      "source": "./plugins/ai-agency/shipwright",
+      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+      "version": "1.3.0",
+      "category": "ai-agency",
+      "author": {
+        "name": "Nate Nelson",
+        "url": "https://github.com/Wynelson94"
+      },
+      "keywords": [
+        "app-builder",
+        "code-generator",
+        "autonomous-agent",
+        "pipeline",
+        "nextjs",
+        "supabase",
+        "sveltekit",
+        "astro",
+        "ai-agency"
+      ],
+      "repository": "https://github.com/Wynelson94/shipwright",
+      "homepage": "https://github.com/Wynelson94/shipwright",
+      "license": "MIT"
+    },
+    {
+      "name": "sow-generator",
+      "source": "./plugins/ai-agency/sow-generator",
+      "description": "Generate professional Statements of Work for AI projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "sow",
+        "statement of work",
+        "contract",
+        "proposal",
+        "agency",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "tonone",
+      "source": "./plugins/ai-agency/tonone",
+      "description": "23-agent engineering + product team with 125 skills for Claude Code",
+      "version": "1.8.0",
+      "category": "ai-agency",
+      "keywords": [
+        "agents",
+        "engineering-team",
+        "infrastructure",
+        "devops",
+        "backend",
+        "security",
+        "observability",
+        "frontend",
+        "ml",
+        "mobile",
+        "embedded",
+        "analytics",
+        "testing",
+        "platform",
+        "sales",
+        "revenue",
+        "customer-success",
+        "content-marketing",
+        "pr",
+        "community",
+        "finance",
+        "people",
+        "operations",
+        "support"
+      ],
+      "author": {
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
+      },
+      "repository": "https://github.com/tonone-ai/tonone",
+      "license": "MIT"
+    },
+    {
+      "name": "zapier-zap-builder",
+      "source": "./plugins/ai-agency/zapier-zap-builder",
+      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
+      "version": "1.10.0",
+      "category": "ai-agency",
+      "keywords": [
+        "zapier",
+        "zap",
+        "automation",
+        "integration",
+        "workflow",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
       }
     },
     {
@@ -212,45 +246,6 @@
         "bias",
         "responsible-ai",
         "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ai-experiment-logger",
-      "source": "./plugins/mcp/ai-experiment-logger",
-      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
-      "version": "1.12.0",
-      "category": "mcp",
-      "keywords": [
-        "ai",
-        "experiments",
-        "logging",
-        "mcp"
-      ],
-      "author": {
-        "name": "Claude Code Plugins"
-      }
-    },
-    {
-      "name": "ai-ml-engineering-pack",
-      "source": "./plugins/packages/ai-ml-engineering-pack",
-      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "ai",
-        "ml",
-        "llm",
-        "prompt-engineering",
-        "rag",
-        "vector-database",
-        "ai-safety",
-        "openai",
-        "anthropic",
-        "package"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -284,23 +279,6 @@
       }
     },
     {
-      "name": "alerting-rule-creator",
-      "source": "./plugins/performance/alerting-rule-creator",
-      "description": "Create intelligent alerting rules for performance monitoring",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "alerting",
-        "monitoring",
-        "sre",
-        "observability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "anomaly-detection-system",
       "source": "./plugins/ai-ml/anomaly-detection-system",
       "description": "Detect anomalies and outliers in data",
@@ -319,21 +297,642 @@
       }
     },
     {
-      "name": "ansible-playbook-creator",
-      "source": "./plugins/devops/ansible-playbook-creator",
-      "description": "Create Ansible playbooks for configuration management",
-      "version": "1.27.0",
-      "category": "devops",
+      "name": "automl-pipeline-builder",
+      "source": "./plugins/ai-ml/automl-pipeline-builder",
+      "description": "Build AutoML pipelines",
+      "version": "1.25.0",
+      "category": "ai-ml",
       "keywords": [
-        "ansible",
-        "automation",
-        "configuration",
-        "playbooks",
-        "devops"
+        "automl",
+        "automated",
+        "pipeline",
+        "h2o",
+        "ml"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
+      }
+    },
+    {
+      "name": "classification-model-builder",
+      "source": "./plugins/ai-ml/classification-model-builder",
+      "description": "Build classification models",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "classification",
+        "supervised",
+        "predictor",
+        "labels",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "clustering-algorithm-runner",
+      "source": "./plugins/ai-ml/clustering-algorithm-runner",
+      "description": "Run clustering algorithms on datasets",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "clustering",
+        "kmeans",
+        "dbscan",
+        "hierarchical",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "computer-vision-processor",
+      "source": "./plugins/ai-ml/computer-vision-processor",
+      "description": "Computer vision image processing and analysis",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "cv",
+        "vision",
+        "images",
+        "detection",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "data-preprocessing-pipeline",
+      "source": "./plugins/ai-ml/data-preprocessing-pipeline",
+      "description": "Automated data preprocessing and cleaning pipelines",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "preprocessing",
+        "cleaning",
+        "etl",
+        "pipeline",
+        "data"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "data-visualization-creator",
+      "source": "./plugins/ai-ml/data-visualization-creator",
+      "description": "Create data visualizations and plots",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "visualization",
+        "plots",
+        "charts",
+        "graphs",
+        "analytics"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "dataset-splitter",
+      "source": "./plugins/ai-ml/dataset-splitter",
+      "description": "Split datasets for training, validation, and testing",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "split",
+        "train-test",
+        "validation",
+        "stratify",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "deep-learning-optimizer",
+      "source": "./plugins/ai-ml/deep-learning-optimizer",
+      "description": "Deep learning optimization techniques",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "optimization",
+        "adam",
+        "sgd",
+        "learning-rate",
+        "deep-learning"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "experiment-tracking-setup",
+      "source": "./plugins/ai-ml/experiment-tracking-setup",
+      "description": "Set up ML experiment tracking",
+      "version": "1.19.0",
+      "category": "ai-ml",
+      "keywords": [
+        "experiments",
+        "mlflow",
+        "wandb",
+        "tracking",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "feature-engineering-toolkit",
+      "source": "./plugins/ai-ml/feature-engineering-toolkit",
+      "description": "Feature creation, selection, and transformation tools",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "features",
+        "engineering",
+        "selection",
+        "transformation",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "hyperparameter-tuner",
+      "source": "./plugins/ai-ml/hyperparameter-tuner",
+      "description": "Optimize hyperparameters using grid/random/bayesian search",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "hyperparameters",
+        "optimization",
+        "tuning",
+        "search",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "jeremy-adk-orchestrator",
+      "source": "./plugins/ai-ml/jeremy-adk-orchestrator",
+      "description": "Production ADK orchestrator for A2A protocol and multi-agent coordination on Vertex AI",
+      "version": "2.29.0",
+      "category": "ai-ml",
+      "keywords": [
+        "vertex-ai",
+        "adk",
+        "a2a-protocol",
+        "multi-agent",
+        "code-execution",
+        "memory-bank"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-adk-software-engineer",
+      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
+      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
+      "version": "2.19.0",
+      "category": "ai-ml",
+      "keywords": [
+        "adk",
+        "software-engineer",
+        "agent-development",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-gcp-starter-examples",
+      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
+      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
+      "version": "2.25.0",
+      "category": "ai-ml",
+      "keywords": [
+        "google-cloud",
+        "adk-samples",
+        "genkit-examples",
+        "vertex-ai",
+        "agent-starter-pack",
+        "code-examples",
+        "starter-kits",
+        "templates"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-genkit-pro",
+      "source": "./plugins/ai-ml/jeremy-genkit-pro",
+      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
+      "version": "2.26.0",
+      "category": "ai-ml",
+      "keywords": [
+        "firebase",
+        "genkit",
+        "ai-flows",
+        "rag",
+        "monitoring",
+        "gemini",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-google-adk",
+      "source": "./plugins/ai-ml/jeremy-google-adk",
+      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+      "version": "2.2.0",
+      "category": "ai-ml",
+      "keywords": [
+        "google",
+        "adk",
+        "agent-development-kit",
+        "ai-agents",
+        "react-pattern",
+        "multi-agent",
+        "vertex-ai",
+        "agent-engine"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-vertex-ai",
+      "source": "./plugins/ai-ml/jeremy-vertex-ai",
+      "description": "Build and deploy generative AI agents on Vertex AI: Gemini model selection, RAG with grounded retrieval, function calling, multimodal extraction, evaluation, and Agent Engine deployment with operational guardrails.",
+      "version": "2.2.0",
+      "category": "ai-ml",
+      "keywords": [
+        "vertex-ai",
+        "gemini",
+        "google-cloud",
+        "generative-ai",
+        "rag",
+        "agent-engine",
+        "function-calling",
+        "multimodal"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-vertex-engine",
+      "source": "./plugins/ai-ml/jeremy-vertex-engine",
+      "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
+      "version": "2.31.0",
+      "category": "ai-ml",
+      "keywords": [
+        "vertex-ai",
+        "agent-engine",
+        "runtime-inspector",
+        "agent-monitoring",
+        "compliance",
+        "production-validation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-vertex-validator",
+      "source": "./plugins/ai-ml/jeremy-vertex-validator",
+      "description": "Production readiness validator for Vertex AI deployments and configurations",
+      "version": "2.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "vertex-ai",
+        "validation",
+        "production-readiness",
+        "security",
+        "compliance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "local-tts",
+      "source": "./plugins/ai-ml/local-tts",
+      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+      "version": "1.3.0",
+      "category": "ai-ml",
+      "keywords": [
+        "tts",
+        "text-to-speech",
+        "voice",
+        "voice-cloning",
+        "voice-design",
+        "offline",
+        "voxcpm",
+        "apple-silicon",
+        "audio",
+        "narration"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "Apache-2.0",
+      "repository": "https://github.com/vdk888/local-tts"
+    },
+    {
+      "name": "ml-model-trainer",
+      "source": "./plugins/ai-ml/ml-model-trainer",
+      "description": "Train and optimize machine learning models with automated workflows",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "ml",
+        "machine-learning",
+        "training",
+        "models",
+        "ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-deployment-helper",
+      "source": "./plugins/ai-ml/model-deployment-helper",
+      "description": "Deploy ML models to production",
+      "version": "1.19.0",
+      "category": "ai-ml",
+      "keywords": [
+        "deployment",
+        "serving",
+        "production",
+        "api",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-evaluation-suite",
+      "source": "./plugins/ai-ml/model-evaluation-suite",
+      "description": "Comprehensive model evaluation with multiple metrics",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "evaluation",
+        "metrics",
+        "testing",
+        "validation",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-explainability-tool",
+      "source": "./plugins/ai-ml/model-explainability-tool",
+      "description": "Model interpretability and explainability",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "explainability",
+        "shap",
+        "lime",
+        "interpretability",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-versioning-tracker",
+      "source": "./plugins/ai-ml/model-versioning-tracker",
+      "description": "Track and manage model versions",
+      "version": "1.24.0",
+      "category": "ai-ml",
+      "keywords": [
+        "versioning",
+        "mlflow",
+        "tracking",
+        "registry",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "neural-network-builder",
+      "source": "./plugins/ai-ml/neural-network-builder",
+      "description": "Build and configure neural network architectures",
+      "version": "1.20.0",
+      "category": "ai-ml",
+      "keywords": [
+        "neural-networks",
+        "deep-learning",
+        "architecture",
+        "pytorch",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "nlp-text-analyzer",
+      "source": "./plugins/ai-ml/nlp-text-analyzer",
+      "description": "Natural language processing and text analysis",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "nlp",
+        "text",
+        "analysis",
+        "tokenization",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "ollama-local-ai",
+      "source": "./plugins/ai-ml/ollama-local-ai",
+      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
+      "version": "1.18.0",
+      "category": "ai-ml",
+      "keywords": [
+        "ollama",
+        "local-llm",
+        "free-ai",
+        "self-hosted",
+        "llama",
+        "mistral",
+        "privacy",
+        "zero-cost",
+        "openai-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "recommendation-engine",
+      "source": "./plugins/ai-ml/recommendation-engine",
+      "description": "Build recommendation systems and engines",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "recommendations",
+        "collaborative",
+        "content-based",
+        "ranking",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "regression-analysis-tool",
+      "source": "./plugins/ai-ml/regression-analysis-tool",
+      "description": "Regression analysis and modeling",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "regression",
+        "prediction",
+        "linear",
+        "polynomial",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "sentiment-analysis-tool",
+      "source": "./plugins/ai-ml/sentiment-analysis-tool",
+      "description": "Sentiment analysis on text data",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "sentiment",
+        "opinion",
+        "emotion",
+        "polarity",
+        "nlp"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "time-series-forecaster",
+      "source": "./plugins/ai-ml/time-series-forecaster",
+      "description": "Time series forecasting and analysis",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "time-series",
+        "forecasting",
+        "arima",
+        "prophet",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "transfer-learning-adapter",
+      "source": "./plugins/ai-ml/transfer-learning-adapter",
+      "description": "Transfer learning adaptation",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "transfer-learning",
+        "fine-tuning",
+        "pretrained",
+        "adapters",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "web-analytics",
+      "source": "./plugins/analytics/web-analytics",
+      "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
+      "version": "1.4.0",
+      "category": "analytics",
+      "keywords": [
+        "analytics",
+        "umami",
+        "ga4",
+        "traffic",
+        "mcp",
+        "self-hosted",
+        "multi-agent",
+        "push-based"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
       }
     },
     {
@@ -454,25 +1053,6 @@
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "api-fuzzer",
-      "source": "./plugins/testing/api-fuzzer",
-      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "fuzzing",
-        "api",
-        "security",
-        "edge-cases",
-        "input-validation"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
       }
     },
@@ -665,25 +1245,6 @@
       }
     },
     {
-      "name": "api-test-automation",
-      "source": "./plugins/testing/api-test-automation",
-      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "api",
-        "rest",
-        "graphql",
-        "automation",
-        "endpoints"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "api-throttling-manager",
       "source": "./plugins/api-development/api-throttling-manager",
       "description": "Manage API throttling with dynamic rate limits and quota management",
@@ -718,17 +1279,18 @@
       }
     },
     {
-      "name": "apm-dashboard-creator",
-      "source": "./plugins/performance/apm-dashboard-creator",
-      "description": "Create Application Performance Monitoring dashboards",
-      "version": "1.21.0",
-      "category": "performance",
+      "name": "graphql-server-builder",
+      "source": "./plugins/api-development/graphql-server-builder",
+      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
+      "version": "1.22.0",
+      "category": "api-development",
       "keywords": [
-        "apm",
-        "monitoring",
-        "dashboard",
-        "grafana",
-        "datadog"
+        "graphql",
+        "api",
+        "server",
+        "apollo",
+        "schema",
+        "resolvers"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -736,20 +1298,1117 @@
       }
     },
     {
-      "name": "application-profiler",
-      "source": "./plugins/performance/application-profiler",
-      "description": "Profile application performance with CPU, memory, and execution time analysis",
-      "version": "1.21.0",
-      "category": "performance",
+      "name": "grpc-service-generator",
+      "source": "./plugins/api-development/grpc-service-generator",
+      "description": "Generate gRPC services with Protocol Buffers and streaming support",
+      "version": "1.23.0",
+      "category": "api-development",
       "keywords": [
-        "performance",
-        "profiling",
-        "monitoring",
-        "optimization"
+        "grpc",
+        "protobuf",
+        "microservices",
+        "streaming"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
+      }
+    },
+    {
+      "name": "rest-api-generator",
+      "source": "./plugins/api-development/rest-api-generator",
+      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": [
+        "api",
+        "rest",
+        "generator",
+        "openapi",
+        "swagger",
+        "backend"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "webhook-handler-creator",
+      "source": "./plugins/api-development/webhook-handler-creator",
+      "description": "Create secure webhook endpoints with signature verification and retry logic",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "webhook",
+        "events",
+        "signature",
+        "security"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "websocket-server-builder",
+      "source": "./plugins/api-development/websocket-server-builder",
+      "description": "Build WebSocket servers for real-time bidirectional communication",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "websocket",
+        "real-time",
+        "socket.io",
+        "ws"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "x-twitter-scraper",
+      "source": "./plugins/api-development/x-twitter-scraper",
+      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
+      "version": "0.1.0",
+      "category": "api-development",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
+      "license": "MIT"
+    },
+    {
+      "name": "brand-strategy-framework",
+      "source": "./plugins/business-tools/brand-strategy-framework",
+      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
+      "version": "1.7.0",
+      "category": "business-tools",
+      "keywords": [
+        "brand-strategy",
+        "marketing",
+        "branding",
+        "positioning",
+        "messaging",
+        "brand-guidelines",
+        "audience-architecture",
+        "brand-identity"
+      ],
+      "author": {
+        "name": "Rowan Brooks",
+        "email": "rowanbrooks100@github.com"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills"
+    },
+    {
+      "name": "excel-analyst-pro",
+      "source": "./plugins/business-tools/excel-analyst-pro",
+      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
+      "version": "1.21.0",
+      "category": "business-tools",
+      "keywords": [
+        "excel",
+        "financial-modeling",
+        "dcf",
+        "lbo",
+        "valuation",
+        "variance-analysis",
+        "pivot-tables",
+        "investment-banking",
+        "private-equity",
+        "financial-analysis",
+        "skills",
+        "mcp"
+      ],
+      "author": {
+        "name": "ClaudeCodePlugins",
+        "email": "plugins@tonsofskills.com"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
+      "name": "executive-assistant-skills",
+      "source": "./plugins/business-tools/executive-assistant-skills",
+      "version": "1.8.0",
+      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
+      "author": {
+        "name": "Martin Gontovnikas",
+        "email": "gonto@hypergrowthpartners.com",
+        "url": "https://github.com/mgonto"
+      },
+      "category": "business-tools",
+      "keywords": [
+        "executive-assistant",
+        "meeting-prep",
+        "email",
+        "productivity",
+        "automation",
+        "todoist"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/mgonto/executive-assistant-skills"
+    },
+    {
+      "name": "openbb-terminal",
+      "source": "./plugins/business-tools/openbb-terminal",
+      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
+      "version": "1.6.0",
+      "category": "business-tools",
+      "keywords": [
+        "finance",
+        "investment",
+        "openbb",
+        "stocks",
+        "crypto",
+        "portfolio",
+        "trading",
+        "financial-analysis",
+        "market-data",
+        "equity-research",
+        "options",
+        "forex",
+        "macroeconomics",
+        "quant",
+        "ai-finance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "promptbook",
+      "source": "./plugins/business-tools/promptbook",
+      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
+      "version": "1.4.0",
+      "category": "business-tools",
+      "keywords": [
+        "analytics",
+        "telemetry",
+        "builds",
+        "portfolio",
+        "tracking",
+        "metrics",
+        "sessions"
+      ],
+      "author": {
+        "name": "Promptbook",
+        "email": "contact@promptbook.gg"
+      },
+      "homepage": "https://promptbook.gg",
+      "repository": "https://github.com/promptbookgg/claude-code-plugin",
+      "license": "MIT"
+    },
+    {
+      "name": "wondelai-blue-ocean-strategy",
+      "source": "./plugins/business-tools/wondelai-blue-ocean-strategy",
+      "description": "Blue Ocean Strategy framework for creating uncontested market space. Use the Strategy Canvas, Four Actions Framework (ERRC), and value innovation to break the value-cost trade-off.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "strategy",
+        "blue-ocean",
+        "value-innovation",
+        "market-creation",
+        "errc",
+        "strategy-canvas",
+        "competition",
+        "positioning"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-contagious",
+      "source": "./plugins/business-tools/wondelai-contagious",
+      "description": "Word-of-mouth and virality framework using the STEPPS model (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Engineer products and content that people naturally share.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "virality",
+        "word-of-mouth",
+        "stepps",
+        "social-currency",
+        "marketing",
+        "content-strategy",
+        "sharing",
+        "growth"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-cro-methodology",
+      "source": "./plugins/business-tools/wondelai-cro-methodology",
+      "description": "Customer-centric conversion rate optimization methodology. Audit landing pages, identify conversion blockers, write persuasive copy, design A/B tests, and optimize funnels.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "cro",
+        "conversion",
+        "optimization",
+        "landing-pages",
+        "ab-testing",
+        "copywriting",
+        "persuasion",
+        "funnels"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-crossing-the-chasm",
+      "source": "./plugins/business-tools/wondelai-crossing-the-chasm",
+      "description": "Technology adoption and go-to-market strategy for crossing from early adopters to mainstream market. Choose beachhead segments, build whole products, and position against incumbents.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "go-to-market",
+        "technology-adoption",
+        "chasm",
+        "beachhead",
+        "b2b",
+        "saas",
+        "market-strategy",
+        "positioning"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-drive-motivation",
+      "source": "./plugins/business-tools/wondelai-drive-motivation",
+      "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "motivation",
+        "autonomy",
+        "mastery",
+        "purpose",
+        "engagement",
+        "gamification",
+        "intrinsic-motivation",
+        "team-management"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-hundred-million-offers",
+      "source": "./plugins/business-tools/wondelai-hundred-million-offers",
+      "description": "Grand Slam Offer creation framework. Create irresistible offers using the Value Equation, stack bonuses, design risk-reversing guarantees, and apply ethical scarcity.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "offers",
+        "pricing",
+        "value-equation",
+        "guarantees",
+        "bonuses",
+        "scarcity",
+        "sales",
+        "hormozi"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-influence-psychology",
+      "source": "./plugins/business-tools/wondelai-influence-psychology",
+      "description": "Persuasion science framework based on Cialdini's six principles (Reciprocity, Commitment, Social Proof, Authority, Liking, Scarcity). Apply ethical persuasion to product design and marketing.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "persuasion",
+        "influence",
+        "cialdini",
+        "social-proof",
+        "reciprocity",
+        "scarcity",
+        "psychology",
+        "marketing"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-jobs-to-be-done",
+      "source": "./plugins/business-tools/wondelai-jobs-to-be-done",
+      "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "jtbd",
+        "jobs-to-be-done",
+        "product-strategy",
+        "customer-discovery",
+        "innovation",
+        "christensen",
+        "product-market-fit",
+        "interviews"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-made-to-stick",
+      "source": "./plugins/business-tools/wondelai-made-to-stick",
+      "description": "Sticky messaging framework using the SUCCESs model (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Make product messaging memorable and create compelling presentations.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "messaging",
+        "storytelling",
+        "success",
+        "sticky",
+        "communication",
+        "presentations",
+        "copywriting",
+        "branding"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-negotiation",
+      "source": "./plugins/business-tools/wondelai-negotiation",
+      "description": "Tactical negotiation framework based on Chris Voss's techniques. Use mirroring, labeling, calibrated questions, the Ackerman method, and accusation audits for business and salary negotiations.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "negotiation",
+        "chris-voss",
+        "mirroring",
+        "labeling",
+        "ackerman",
+        "salary",
+        "deals",
+        "conflict-resolution"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-obviously-awesome",
+      "source": "./plugins/business-tools/wondelai-obviously-awesome",
+      "description": "Product positioning framework for competitive differentiation. Define competitive alternatives, identify unique attributes, map value themes, and choose the right market category.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "positioning",
+        "differentiation",
+        "competitive-analysis",
+        "market-category",
+        "value-proposition",
+        "april-dunford",
+        "go-to-market",
+        "branding"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-one-page-marketing",
+      "source": "./plugins/business-tools/wondelai-one-page-marketing",
+      "description": "End-to-end marketing plan framework. Define target market, craft USP, choose channels, design lead capture and nurture sequences, optimize conversion, and build referral systems.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "marketing-plan",
+        "usp",
+        "lead-generation",
+        "nurture",
+        "referral",
+        "advertising",
+        "customer-lifetime-value",
+        "marketing-strategy"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-predictable-revenue",
+      "source": "./plugins/business-tools/wondelai-predictable-revenue",
+      "description": "Outbound sales methodology for scalable B2B pipeline. Implement Cold Calling 2.0, structure SDR/AE/CSM roles, design prospecting sequences, and build predictable revenue engines.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "sales",
+        "outbound",
+        "sdr",
+        "pipeline",
+        "b2b",
+        "saas",
+        "prospecting",
+        "cold-calling",
+        "revenue"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-scorecard-marketing",
+      "source": "./plugins/business-tools/wondelai-scorecard-marketing",
+      "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "lead-generation",
+        "quiz-funnel",
+        "assessment",
+        "scorecard",
+        "conversion",
+        "segmentation",
+        "lead-magnet",
+        "marketing-automation"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-storybrand-messaging",
+      "source": "./plugins/business-tools/wondelai-storybrand-messaging",
+      "description": "StoryBrand messaging framework that positions customer as hero. Create brand scripts, write website copy that converts, craft one-liners, and build narrative-driven landing pages.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "storybrand",
+        "messaging",
+        "brand-script",
+        "copywriting",
+        "narrative",
+        "website-copy",
+        "one-liner",
+        "donald-miller"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-traction-eos",
+      "source": "./plugins/business-tools/wondelai-traction-eos",
+      "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "eos",
+        "traction",
+        "operating-system",
+        "rocks",
+        "l10-meetings",
+        "accountability",
+        "vision",
+        "execution"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "b12-claude-plugin",
+      "source": "./plugins/community/b12-claude-plugin",
+      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+      "version": "1.9.0",
+      "category": "community",
+      "keywords": [
+        "website",
+        "b12",
+        "hosting",
+        "web-design",
+        "ai-website",
+        "website-generator",
+        "saas"
+      ],
+      "author": {
+        "name": "B12.io",
+        "url": "https://github.com/b12io"
+      }
+    },
+    {
+      "name": "boycott-filter",
+      "source": "./plugins/community/boycott-filter",
+      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
+      "version": "1.2.0",
+      "category": "community",
+      "keywords": [
+        "boycott",
+        "consumer",
+        "shopping",
+        "brands",
+        "chrome-extension",
+        "conversational",
+        "privacy",
+        "ethical-consumption"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "claude-never-forgets",
+      "source": "./plugins/community/claude-never-forgets",
+      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "version": "1.21.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "context",
+        "persistent",
+        "preferences",
+        "sessions",
+        "recall"
+      ],
+      "author": {
+        "name": "yldrmahmet",
+        "url": "https://github.com/yldrmahmet"
+      }
+    },
+    {
+      "name": "claude-reflect",
+      "source": "./plugins/community/claude-reflect",
+      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": [
+        "claude-code",
+        "self-learning",
+        "corrections",
+        "CLAUDE.md",
+        "memory",
+        "learnings",
+        "hooks",
+        "automation"
+      ],
+      "author": {
+        "name": "Bayram Annakov",
+        "url": "https://github.com/bayramannakov"
+      },
+      "repository": "https://github.com/bayramannakov/claude-reflect"
+    },
+    {
+      "name": "contributing-clanker",
+      "source": "./plugins/community/contributing-clanker",
+      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
+      "version": "0.8.0",
+      "category": "community",
+      "keywords": [
+        "oss",
+        "contributions",
+        "github",
+        "ai-slop-prevention",
+        "code-review",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
+      "repository": "https://github.com/jeremylongshore/contributing-clanker",
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-anti-deception",
+      "source": "./plugins/community/ejentum-anti-deception",
+      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-code",
+      "source": "./plugins/community/ejentum-code",
+      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-memory",
+      "source": "./plugins/community/ejentum-memory",
+      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-reasoning",
+      "source": "./plugins/community/ejentum-reasoning",
+      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "fairdb-ops-manager",
+      "source": "./plugins/community/fairdb-ops-manager",
+      "description": "Database operations management for FairDB PostgreSQL clusters",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": [
+        "database",
+        "postgresql",
+        "operations"
+      ],
+      "author": {
+        "name": "Community"
+      }
+    },
+    {
+      "name": "framecraft",
+      "source": "./plugins/community/framecraft",
+      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
+      "version": "1.3.0",
+      "category": "community",
+      "keywords": [
+        "demo-video",
+        "video-generation",
+        "playwright",
+        "ffmpeg",
+        "edge-tts",
+        "mcp"
+      ],
+      "author": {
+        "name": "vaddisrinivas",
+        "url": "https://github.com/vaddisrinivas"
+      }
+    },
+    {
+      "name": "gastown",
+      "source": "./plugins/community/gastown",
+      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "multi-agent",
+        "orchestration",
+        "automation",
+        "polecats",
+        "convoys",
+        "beads",
+        "work-tracking",
+        "ai-factory",
+        "gastown",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "research",
+        "games",
+        "accessibility",
+        "performance",
+        "flask",
+        "react",
+        "godot",
+        "corpus-linguistics",
+        "mcp"
+      ],
+      "author": {
+        "name": "Luke Steuber",
+        "url": "https://github.com/lukeslp"
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "mcp",
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "geepers",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Luke Steuber"
+      },
+      "homepage": "https://dr.eamer.dev/geepers/",
+      "repository": "https://github.com/lukeslp/geepers"
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./plugins/community/hermes-tweet",
+      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
+      "version": "0.1.6",
+      "category": "community",
+      "keywords": [
+        "hermes-agent",
+        "hermes-plugin",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
+      ],
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
+      "repository": "https://github.com/Xquik-dev/hermes-tweet",
+      "license": "MIT"
+    },
+    {
+      "name": "jeremy-firebase",
+      "source": "./plugins/community/jeremy-firebase",
+      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
+      "version": "2.23.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "vertex-ai",
+        "gemini",
+        "authentication",
+        "storage",
+        "hosting",
+        "cloud-functions",
+        "analytics",
+        "ai-integration",
+        "google-cloud",
+        "embeddings",
+        "model-deployment",
+        "ai-powered",
+        "production-ready"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-firestore",
+      "source": "./plugins/community/jeremy-firestore",
+      "description": "Firestore database specialist for schema design, queries, and real-time sync",
+      "version": "2.20.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "firestore",
+        "database",
+        "crud",
+        "security-rules",
+        "cloud-functions",
+        "batch-operations",
+        "data-migration",
+        "performance",
+        "cost-optimization",
+        "nosql",
+        "google-cloud",
+        "a2a",
+        "agent-to-agent",
+        "mcp",
+        "cloud-run",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]",
+        "url": "https://intentsolutions.io"
+      }
+    },
+    {
+      "name": "llm-box",
+      "source": "./plugins/community/llm-box",
+      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
+      "version": "0.3.0",
+      "category": "community",
+      "keywords": [
+        "workflow",
+        "automation",
+        "terminal",
+        "cli",
+        "yaml",
+        "llm",
+        "mcp"
+      ],
+      "author": {
+        "name": "alib8b8",
+        "url": "https://github.com/alib8b8"
+      },
+      "homepage": "https://github.com/alib8b8/llm-box",
+      "repository": "https://github.com/alib8b8/llm-box",
+      "license": "MIT"
+    },
+    {
+      "name": "mnemos",
+      "source": "./plugins/community/mnemos",
+      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
+      "version": "0.9.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "mcp",
+        "claude-code",
+        "persistent-memory",
+        "agent-memory",
+        "knowledge-graph",
+        "context",
+        "skill",
+        "observations",
+        "provenance",
+        "learning-loop",
+        "golang"
+      ],
+      "author": {
+        "name": "André Figueira",
+        "url": "https://polyxmedia.com",
+        "email": "andre@polyxmedia.com"
+      },
+      "homepage": "https://github.com/polyxmedia/mnemos",
+      "repository": "https://github.com/polyxmedia/mnemos",
+      "license": "MIT"
+    },
+    {
+      "name": "portaljs",
+      "source": "./plugins/community/portaljs",
+      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
+      "version": "0.1.0",
+      "category": "community",
+      "keywords": [
+        "portaljs",
+        "data-portal",
+        "ckan",
+        "nextjs",
+        "data-catalog"
+      ],
+      "author": {
+        "name": "Datopian",
+        "url": "https://www.datopian.com"
+      },
+      "homepage": "https://github.com/datopian/portaljs",
+      "repository": "https://github.com/datopian/portaljs",
+      "license": "MIT"
+    },
+    {
+      "name": "quit-sponsor",
+      "source": "./plugins/community/quit-sponsor",
+      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "metr0x",
+        "url": "https://github.com/metrox-eth"
+      },
+      "repository": "https://github.com/metrox-eth/quit-sponsor",
+      "license": "MIT"
+    },
+    {
+      "name": "skills-janitor",
+      "source": "./plugins/community/skills-janitor",
+      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
+      "version": "0.1.0",
+      "category": "community",
+      "keywords": [
+        "skills",
+        "cleanup",
+        "context-window",
+        "token-budget",
+        "maintenance",
+        "tui"
+      ],
+      "author": {
+        "name": "Krzysztof Hendzel",
+        "url": "https://github.com/khendzel",
+        "email": "krzysztoff.hendzel@gmail.com"
+      },
+      "repository": "https://github.com/khendzel/skills-janitor",
+      "license": "MIT"
+    },
+    {
+      "name": "sprint",
+      "source": "./plugins/community/sprint",
+      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
+      "version": "1.20.0",
+      "category": "community",
+      "keywords": [
+        "autonomous",
+        "agentic",
+        "yolo",
+        "self-iterating",
+        "multi-agent",
+        "hands-off",
+        "auto-pilot",
+        "orchestration",
+        "sprint",
+        "testing",
+        "qa",
+        "mcp"
+      ],
+      "author": {
+        "name": "Damien Laine",
+        "email": "damien.laine@gmail.com",
+        "url": "https://github.com/damienlaine"
+      }
+    },
+    {
+      "name": "walkie-talkie",
+      "source": "./plugins/community/walkie-talkie",
+      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Walkie-Talkie Maintainers",
+        "url": "https://github.com/walkie-talkie-skill"
+      },
+      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
+      "license": "MIT"
+    },
+    {
+      "name": "zai-cli",
+      "source": "./plugins/community/zai-cli",
+      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "vision",
+        "image-analysis",
+        "ocr",
+        "web-search",
+        "web-reader",
+        "github",
+        "mcp",
+        "z-ai",
+        "glm-4",
+        "multimodal"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      }
+    },
+    {
+      "name": "aomi",
+      "source": "./plugins/crypto/aomi",
+      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
+      "version": "0.10.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "defi",
+        "web3",
+        "evm",
+        "ethereum",
+        "wallet",
+        "account-abstraction",
+        "trading",
+        "agent",
+        "mcp"
+      ],
+      "author": {
+        "name": "aomi-labs",
+        "url": "https://aomi.dev",
+        "email": "info@aomi.dev"
       }
     },
     {
@@ -771,75 +2430,6 @@
       }
     },
     {
-      "name": "authentication-validator",
-      "source": "./plugins/security/authentication-validator",
-      "description": "Validate authentication implementations",
-      "version": "1.26.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "auto-scaling-configurator",
-      "source": "./plugins/devops/auto-scaling-configurator",
-      "description": "Configure auto-scaling policies for applications and infrastructure",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "autoscaling",
-        "scaling",
-        "hpa",
-        "kubernetes",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "automl-pipeline-builder",
-      "source": "./plugins/ai-ml/automl-pipeline-builder",
-      "description": "Build AutoML pipelines",
-      "version": "1.25.0",
-      "category": "ai-ml",
-      "keywords": [
-        "automl",
-        "automated",
-        "pipeline",
-        "h2o",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "backup-strategy-implementor",
-      "source": "./plugins/devops/backup-strategy-implementor",
-      "description": "Implement backup strategies for databases and applications",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "backup",
-        "disaster-recovery",
-        "restoration",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "blockchain-explorer-cli",
       "source": "./plugins/crypto/blockchain-explorer-cli",
       "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
@@ -852,381 +2442,6 @@
         "transactions",
         "addresses",
         "contracts"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "bottleneck-detector",
-      "source": "./plugins/performance/bottleneck-detector",
-      "description": "Detect and resolve performance bottlenecks",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "bottleneck",
-        "performance",
-        "optimization",
-        "profiling"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "browser-compatibility-tester",
-      "source": "./plugins/testing/browser-compatibility-tester",
-      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-      "version": "2.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "cross-browser",
-        "browserstack",
-        "selenium",
-        "playwright",
-        "compatibility"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cache-performance-optimizer",
-      "source": "./plugins/performance/cache-performance-optimizer",
-      "description": "Optimize caching strategies for improved performance",
-      "version": "1.19.0",
-      "category": "performance",
-      "keywords": [
-        "cache",
-        "performance",
-        "optimization",
-        "redis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "calendar-to-workflow",
-      "source": "./plugins/skill-enhancers/calendar-to-workflow",
-      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "calendar",
-        "automation",
-        "meetings",
-        "productivity"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "capacity-planning-analyzer",
-      "source": "./plugins/performance/capacity-planning-analyzer",
-      "description": "Analyze and plan for capacity requirements",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "capacity-planning",
-        "scaling",
-        "forecasting",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "chaos-engineering-toolkit",
-      "source": "./plugins/testing/chaos-engineering-toolkit",
-      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "chaos-engineering",
-        "resilience",
-        "failure-injection",
-        "fault-tolerance",
-        "reliability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ci-cd-pipeline-builder",
-      "source": "./plugins/devops/ci-cd-pipeline-builder",
-      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "ci-cd",
-        "github-actions",
-        "gitlab-ci",
-        "jenkins",
-        "devops",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "classification-model-builder",
-      "source": "./plugins/ai-ml/classification-model-builder",
-      "description": "Build classification models",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "classification",
-        "supervised",
-        "predictor",
-        "labels",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cloud-cost-optimizer",
-      "source": "./plugins/devops/cloud-cost-optimizer",
-      "description": "Optimize cloud costs and generate cost reports",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "cost",
-        "optimization",
-        "finops",
-        "cloud",
-        "aws",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "clustering-algorithm-runner",
-      "source": "./plugins/ai-ml/clustering-algorithm-runner",
-      "description": "Run clustering algorithms on datasets",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "clustering",
-        "kmeans",
-        "dbscan",
-        "hierarchical",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "compliance-checker",
-      "source": "./plugins/devops/compliance-checker",
-      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "compliance",
-        "security",
-        "audit",
-        "soc2",
-        "hipaa",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "compliance-report-generator",
-      "source": "./plugins/security/compliance-report-generator",
-      "description": "Generate compliance reports",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "computer-vision-processor",
-      "source": "./plugins/ai-ml/computer-vision-processor",
-      "description": "Computer vision image processing and analysis",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "cv",
-        "vision",
-        "images",
-        "detection",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "container-registry-manager",
-      "source": "./plugins/devops/container-registry-manager",
-      "description": "Manage container registries (ECR, GCR, Harbor)",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "registry",
-        "containers",
-        "docker",
-        "ecr",
-        "gcr",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "container-security-scanner",
-      "source": "./plugins/devops/container-security-scanner",
-      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "security",
-        "containers",
-        "scanning",
-        "vulnerabilities",
-        "trivy",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "contract-test-validator",
-      "source": "./plugins/testing/contract-test-validator",
-      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "contract-testing",
-        "pact",
-        "openapi",
-        "api",
-        "microservices",
-        "consumer-driven"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "conversational-api-debugger",
-      "source": "./plugins/mcp/conversational-api-debugger",
-      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "api",
-        "debugging",
-        "openapi",
-        "har",
-        "rest",
-        "curl",
-        "http"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cors-policy-validator",
-      "source": "./plugins/security/cors-policy-validator",
-      "description": "Validate CORS policies",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cpu-usage-monitor",
-      "source": "./plugins/performance/cpu-usage-monitor",
-      "description": "Monitor and analyze CPU usage patterns in applications",
-      "version": "1.23.0",
-      "category": "performance",
-      "keywords": [
-        "cpu",
-        "monitoring",
-        "performance",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "creator-studio-pack",
-      "source": "./plugins/packages/creator-studio-pack",
-      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
-      "version": "1.16.0",
-      "category": "packages",
-      "keywords": [
-        "video",
-        "content-creation",
-        "youtube",
-        "filmmaking",
-        "creator",
-        "documentation",
-        "screencast",
-        "tutorial",
-        "video-editing",
-        "content-strategy",
-        "distribution",
-        "thumbnails",
-        "subtitles",
-        "repurposing",
-        "batch-recording",
-        "analytics",
-        "package",
-        "premium"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1351,15 +2566,252 @@
       }
     },
     {
-      "name": "csrf-protection-validator",
-      "source": "./plugins/security/csrf-protection-validator",
-      "description": "Validate CSRF protection",
+      "name": "defi-yield-optimizer",
+      "source": "./plugins/crypto/defi-yield-optimizer",
+      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "defi",
+        "yield",
+        "farming",
+        "liquidity",
+        "apy",
+        "optimization",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "dex-aggregator-router",
+      "source": "./plugins/crypto/dex-aggregator-router",
+      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": [
+        "dex",
+        "swap",
+        "trading",
+        "defi",
+        "aggregator",
+        "routing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "flash-loan-simulator",
+      "source": "./plugins/crypto/flash-loan-simulator",
+      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "flash-loans",
+        "defi",
+        "aave",
+        "arbitrage",
+        "liquidation",
+        "ethereum",
+        "simulation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "gas-fee-optimizer",
+      "source": "./plugins/crypto/gas-fee-optimizer",
+      "description": "Optimize transaction gas fees with timing and routing recommendations",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "gas",
+        "fees",
+        "ethereum",
+        "optimization",
+        "transaction",
+        "l2"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "liquidity-pool-analyzer",
+      "source": "./plugins/crypto/liquidity-pool-analyzer",
+      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
+      "version": "1.23.0",
+      "category": "crypto",
+      "keywords": [
+        "liquidity",
+        "pool",
+        "defi",
+        "impermanent",
+        "loss",
+        "apy"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "market-movers-scanner",
+      "source": "./plugins/crypto/market-movers-scanner",
+      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "market",
+        "scanner",
+        "movers",
+        "gainers",
+        "losers",
+        "volume",
+        "trading"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "market-price-tracker",
+      "source": "./plugins/crypto/market-price-tracker",
+      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "market",
+        "price",
+        "tracking",
+        "trading",
+        "crypto",
+        "stocks",
+        "forex"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "market-sentiment-analyzer",
+      "source": "./plugins/crypto/market-sentiment-analyzer",
+      "description": "Analyze market sentiment from social media, news, and on-chain data",
+      "version": "1.24.0",
+      "category": "crypto",
+      "keywords": [
+        "sentiment",
+        "analysis",
+        "social",
+        "news",
+        "market",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "mempool-analyzer",
+      "source": "./plugins/crypto/mempool-analyzer",
+      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
+      "version": "1.32.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "mempool",
+        "mev",
+        "ethereum",
+        "blockchain",
+        "gas",
+        "pending-transactions",
+        "arbitrage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "nft-rarity-analyzer",
+      "source": "./plugins/crypto/nft-rarity-analyzer",
+      "description": "Analyze NFT rarity scores and valuations across collections",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": [
+        "nft",
+        "rarity",
+        "valuation",
+        "traits",
+        "opensea",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "on-chain-analytics",
+      "source": "./plugins/crypto/on-chain-analytics",
+      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "on-chain",
+        "analytics",
+        "whale",
+        "metrics",
+        "blockchain"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "options-flow-analyzer",
+      "source": "./plugins/crypto/options-flow-analyzer",
+      "description": "Track institutional options flow, unusual activity, and smart money movements",
+      "version": "1.29.0",
+      "category": "crypto",
+      "keywords": [
+        "options",
+        "flow",
+        "institutional",
+        "trading",
+        "derivatives",
+        "smart money"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "staking-rewards-optimizer",
+      "source": "./plugins/crypto/staking-rewards-optimizer",
+      "description": "Optimize staking rewards across multiple protocols and chains",
       "version": "1.26.0",
-      "category": "security",
+      "category": "crypto",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
+        "crypto",
+        "staking",
+        "defi",
+        "yield",
+        "optimization",
+        "rewards"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1367,17 +2819,20 @@
       }
     },
     {
-      "name": "data-preprocessing-pipeline",
-      "source": "./plugins/ai-ml/data-preprocessing-pipeline",
-      "description": "Automated data preprocessing and cleaning pipelines",
-      "version": "1.23.0",
-      "category": "ai-ml",
+      "name": "token-launch-tracker",
+      "source": "./plugins/crypto/token-launch-tracker",
+      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
+      "version": "1.30.0",
+      "category": "crypto",
       "keywords": [
-        "preprocessing",
-        "cleaning",
-        "etl",
-        "pipeline",
-        "data"
+        "crypto",
+        "token-launch",
+        "rugpull",
+        "security",
+        "scam-detection",
+        "contract-analysis",
+        "defi",
+        "new-tokens"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1385,15 +2840,73 @@
       }
     },
     {
-      "name": "data-privacy-scanner",
-      "source": "./plugins/security/data-privacy-scanner",
-      "description": "Scan for data privacy issues",
-      "version": "1.23.0",
-      "category": "security",
+      "name": "trading-strategy-backtester",
+      "source": "./plugins/crypto/trading-strategy-backtester",
+      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
+      "version": "1.28.0",
+      "category": "crypto",
       "keywords": [
+        "trading",
+        "backtesting",
+        "strategy",
+        "historical",
+        "performance",
+        "risk"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "wallet-portfolio-tracker",
+      "source": "./plugins/crypto/wallet-portfolio-tracker",
+      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
+      "version": "1.12.0",
+      "category": "crypto",
+      "keywords": [
+        "wallet",
+        "portfolio",
+        "tracking",
+        "blockchain",
+        "defi",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "wallet-security-auditor",
+      "source": "./plugins/crypto/wallet-security-auditor",
+      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
+      "version": "1.17.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "wallet",
         "security",
-        "compliance",
-        "auditing"
+        "audit",
+        "web3"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "whale-alert-monitor",
+      "source": "./plugins/crypto/whale-alert-monitor",
+      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": [
+        "whale",
+        "alert",
+        "monitor",
+        "large",
+        "transactions"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1428,24 +2941,6 @@
         "database",
         "backend",
         "validation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "data-visualization-creator",
-      "source": "./plugins/ai-ml/data-visualization-creator",
-      "description": "Create data visualizations and plots",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "visualization",
-        "plots",
-        "charts",
-        "graphs",
-        "analytics"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1652,24 +3147,6 @@
       }
     },
     {
-      "name": "database-query-profiler",
-      "source": "./plugins/performance/database-query-profiler",
-      "description": "Profile and optimize database queries for performance",
-      "version": "1.9.0",
-      "category": "performance",
-      "keywords": [
-        "database",
-        "query",
-        "profiling",
-        "optimization",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "database-recovery-manager",
       "source": "./plugins/database/database-recovery-manager",
       "description": "Database plugin for database-recovery-manager",
@@ -1754,26 +3231,6 @@
       }
     },
     {
-      "name": "database-test-manager",
-      "source": "./plugins/testing/database-test-manager",
-      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
-      "version": "1.26.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "database",
-        "sql",
-        "test-data",
-        "fixtures",
-        "migrations",
-        "transactions"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "database-transaction-monitor",
       "source": "./plugins/database/database-transaction-monitor",
       "description": "Database plugin for database-transaction-monitor",
@@ -1790,17 +3247,36 @@
       }
     },
     {
-      "name": "dataset-splitter",
-      "source": "./plugins/ai-ml/dataset-splitter",
-      "description": "Split datasets for training, validation, and testing",
-      "version": "1.22.0",
-      "category": "ai-ml",
+      "name": "freshie-inventory-manager",
+      "source": "./plugins/database/freshie-inventory-manager",
+      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+      "version": "1.5.0",
+      "category": "database",
       "keywords": [
-        "split",
-        "train-test",
-        "validation",
-        "stratify",
-        "ml"
+        "database",
+        "inventory",
+        "freshie",
+        "compliance",
+        "sqlite",
+        "ecosystem",
+        "audit",
+        "subagents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "nosql-data-modeler",
+      "source": "./plugins/database/nosql-data-modeler",
+      "description": "Database plugin for nosql-data-modeler",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "data"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1808,37 +3284,17 @@
       }
     },
     {
-      "name": "deep-learning-optimizer",
-      "source": "./plugins/ai-ml/deep-learning-optimizer",
-      "description": "Deep learning optimization techniques",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "optimization",
-        "adam",
-        "sgd",
-        "learning-rate",
-        "deep-learning"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "defi-yield-optimizer",
-      "source": "./plugins/crypto/defi-yield-optimizer",
-      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
+      "name": "orm-code-generator",
+      "source": "./plugins/database/orm-code-generator",
+      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
       "version": "1.28.0",
-      "category": "crypto",
+      "category": "database",
       "keywords": [
-        "defi",
-        "yield",
-        "farming",
-        "liquidity",
-        "apy",
-        "optimization",
-        "crypto"
+        "orm",
+        "models",
+        "code-generation",
+        "database",
+        "backend"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1846,18 +3302,383 @@
       }
     },
     {
-      "name": "dependency-checker",
-      "source": "./plugins/security/dependency-checker",
-      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
+      "name": "query-performance-analyzer",
+      "source": "./plugins/database/query-performance-analyzer",
+      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
       "version": "1.27.0",
-      "category": "security",
+      "category": "database",
+      "keywords": [
+        "performance",
+        "query",
+        "optimization",
+        "explain",
+        "database"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "sql-query-optimizer",
+      "source": "./plugins/database/sql-query-optimizer",
+      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "sql",
+        "optimization",
+        "performance",
+        "database",
+        "query"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "stored-procedure-generator",
+      "source": "./plugins/database/stored-procedure-generator",
+      "description": "Database plugin for stored-procedure-generator",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "procedure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "brand-forge",
+      "source": "./plugins/design/brand-forge",
+      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
+      "version": "0.5.1",
+      "category": "design",
+      "keywords": [
+        "branding",
+        "logo",
+        "brand-identity",
+        "design",
+        "svg",
+        "templates",
+        "image-generation"
+      ],
+      "author": {
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
+      },
+      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
+    },
+    {
+      "name": "wondelai-design-everyday-things",
+      "source": "./plugins/design/wondelai-design-everyday-things",
+      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "design",
+        "ux",
+        "affordances",
+        "signifiers",
+        "human-centered-design",
+        "usability",
+        "don-norman",
+        "hcd"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-hooked-ux",
+      "source": "./plugins/design/wondelai-hooked-ux",
+      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "habits",
+        "engagement",
+        "retention",
+        "hook-model",
+        "triggers",
+        "rewards",
+        "onboarding",
+        "ux"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-ios-hig-design",
+      "source": "./plugins/design/wondelai-ios-hig-design",
+      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ios",
+        "apple",
+        "hig",
+        "swiftui",
+        "uikit",
+        "mobile-design",
+        "accessibility",
+        "interface-guidelines"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-refactoring-ui",
+      "source": "./plugins/design/wondelai-refactoring-ui",
+      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ui-design",
+        "visual-hierarchy",
+        "typography",
+        "color-palette",
+        "tailwind",
+        "shadows",
+        "spacing",
+        "refactoring-ui"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-top-design",
+      "source": "./plugins/design/wondelai-top-design",
+      "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "web-design",
+        "awwwards",
+        "animations",
+        "typography",
+        "scroll-effects",
+        "brand-website",
+        "premium-design",
+        "motion"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-ux-heuristics",
+      "source": "./plugins/design/wondelai-ux-heuristics",
+      "description": "Usability heuristics and UX audit framework based on Nielsen and Krug. Conduct heuristic evaluations, identify usability problems, and prioritize fixes by severity.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ux",
+        "usability",
+        "heuristics",
+        "nielsen",
+        "krug",
+        "ux-audit",
+        "evaluation",
+        "accessibility"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-web-typography",
+      "source": "./plugins/design/wondelai-web-typography",
+      "description": "Web typography framework for readable, beautiful type. Select and pair typefaces, set optimal line length and height, implement responsive typography, and optimize web font loading.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "typography",
+        "web-fonts",
+        "typeface",
+        "font-pairing",
+        "readability",
+        "responsive-typography",
+        "css",
+        "type-hierarchy"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "ansible-playbook-creator",
+      "source": "./plugins/devops/ansible-playbook-creator",
+      "description": "Create Ansible playbooks for configuration management",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "ansible",
+        "automation",
+        "configuration",
+        "playbooks",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "auto-scaling-configurator",
+      "source": "./plugins/devops/auto-scaling-configurator",
+      "description": "Configure auto-scaling policies for applications and infrastructure",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "autoscaling",
+        "scaling",
+        "hpa",
+        "kubernetes",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "backup-strategy-implementor",
+      "source": "./plugins/devops/backup-strategy-implementor",
+      "description": "Implement backup strategies for databases and applications",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "backup",
+        "disaster-recovery",
+        "restoration",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "ci-cd-pipeline-builder",
+      "source": "./plugins/devops/ci-cd-pipeline-builder",
+      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "ci-cd",
+        "github-actions",
+        "gitlab-ci",
+        "jenkins",
+        "devops",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cloud-cost-optimizer",
+      "source": "./plugins/devops/cloud-cost-optimizer",
+      "description": "Optimize cloud costs and generate cost reports",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "cost",
+        "optimization",
+        "finops",
+        "cloud",
+        "aws",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "compliance-checker",
+      "source": "./plugins/devops/compliance-checker",
+      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "compliance",
+        "security",
+        "audit",
+        "soc2",
+        "hipaa",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "container-registry-manager",
+      "source": "./plugins/devops/container-registry-manager",
+      "description": "Manage container registries (ECR, GCR, Harbor)",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "registry",
+        "containers",
+        "docker",
+        "ecr",
+        "gcr",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "container-security-scanner",
+      "source": "./plugins/devops/container-security-scanner",
+      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
+      "version": "1.27.0",
+      "category": "devops",
       "keywords": [
         "security",
-        "dependencies",
-        "npm",
-        "pip",
-        "composer",
-        "vulnerabilities"
+        "containers",
+        "scanning",
+        "vulnerabilities",
+        "trivy",
+        "devops"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1901,68 +3722,6 @@
       }
     },
     {
-      "name": "design-to-code",
-      "source": "./plugins/mcp/design-to-code",
-      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "design",
-        "figma",
-        "react",
-        "svelte",
-        "vue",
-        "accessibility",
-        "component-generation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "devops-automation-pack",
-      "source": "./plugins/packages/devops-automation-pack",
-      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "devops",
-        "ci-cd",
-        "docker",
-        "kubernetes",
-        "terraform",
-        "deployment",
-        "infrastructure",
-        "automation",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "dex-aggregator-router",
-      "source": "./plugins/crypto/dex-aggregator-router",
-      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": [
-        "dex",
-        "swap",
-        "trading",
-        "defi",
-        "aggregator",
-        "routing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "disaster-recovery-planner",
       "source": "./plugins/devops/disaster-recovery-planner",
       "description": "Plan and implement disaster recovery procedures",
@@ -1973,41 +3732,6 @@
         "dr",
         "business-continuity",
         "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "discovery-questionnaire",
-      "source": "./plugins/ai-agency/discovery-questionnaire",
-      "description": "Generate custom discovery questionnaires for AI agency prospects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "discovery",
-        "questionnaire",
-        "client",
-        "sales",
-        "agency",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "distributed-tracing-setup",
-      "source": "./plugins/performance/distributed-tracing-setup",
-      "description": "Set up distributed tracing for microservices",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "tracing",
-        "observability",
-        "microservices",
-        "opentelemetry"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2026,82 +3750,6 @@
         "containers",
         "orchestration",
         "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "domain-memory-agent",
-      "source": "./plugins/mcp/domain-memory-agent",
-      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
-      "version": "1.17.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "knowledge-base",
-        "semantic-search",
-        "tfidf",
-        "summarization",
-        "rag",
-        "documentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "lumera-agent-memory",
-      "source": "./plugins/mcp/lumera-agent-memory",
-      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
-      "version": "1.7.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "memory",
-        "cascade",
-        "storage",
-        "encryption",
-        "search",
-        "fts",
-        "agent"
-      ],
-      "author": {
-        "name": "Intent Solutions IO",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "e2e-test-framework",
-      "source": "./plugins/testing/e2e-test-framework",
-      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "e2e",
-        "playwright",
-        "cypress",
-        "selenium",
-        "browser-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "encryption-tool",
-      "source": "./plugins/security/encryption-tool",
-      "description": "Encrypt and decrypt data with various algorithms",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2151,89 +3799,6 @@
       }
     },
     {
-      "name": "error-rate-monitor",
-      "source": "./plugins/performance/error-rate-monitor",
-      "description": "Monitor and analyze application error rates",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "errors",
-        "monitoring",
-        "reliability",
-        "sre"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "excel-analyst-pro",
-      "source": "./plugins/business-tools/excel-analyst-pro",
-      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
-      "version": "1.21.0",
-      "category": "business-tools",
-      "keywords": [
-        "excel",
-        "financial-modeling",
-        "dcf",
-        "lbo",
-        "valuation",
-        "variance-analysis",
-        "pivot-tables",
-        "investment-banking",
-        "private-equity",
-        "financial-analysis",
-        "skills",
-        "mcp"
-      ],
-      "author": {
-        "name": "ClaudeCodePlugins",
-        "email": "plugins@tonsofskills.com"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "brand-strategy-framework",
-      "source": "./plugins/business-tools/brand-strategy-framework",
-      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
-      "version": "1.7.0",
-      "category": "business-tools",
-      "keywords": [
-        "brand-strategy",
-        "marketing",
-        "branding",
-        "positioning",
-        "messaging",
-        "brand-guidelines",
-        "audience-architecture",
-        "brand-identity"
-      ],
-      "author": {
-        "name": "Rowan Brooks",
-        "email": "rowanbrooks100@github.com"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills"
-    },
-    {
-      "name": "experiment-tracking-setup",
-      "source": "./plugins/ai-ml/experiment-tracking-setup",
-      "description": "Set up ML experiment tracking",
-      "version": "1.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "experiments",
-        "mlflow",
-        "wandb",
-        "tracking",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "fairdb-operations-kit",
       "source": "./plugins/devops/fairdb-operations-kit",
       "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
@@ -2262,162 +3827,23 @@
       "repository": "https://github.com/jeremylongshore/claude-code-plugins"
     },
     {
-      "name": "fairdb-ops-manager",
-      "source": "./plugins/community/fairdb-ops-manager",
-      "description": "Database operations management for FairDB PostgreSQL clusters",
-      "version": "1.12.0",
-      "category": "community",
+      "name": "gh-dash",
+      "source": "./plugins/devops/gh-dash",
+      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
+      "version": "1.6.0",
+      "category": "devops",
       "keywords": [
-        "database",
-        "postgresql",
-        "operations"
+        "github",
+        "pull-request",
+        "ci-cd",
+        "dashboard",
+        "devops",
+        "merge",
+        "code-review"
       ],
       "author": {
-        "name": "Community"
-      }
-    },
-    {
-      "name": "feature-engineering-toolkit",
-      "source": "./plugins/ai-ml/feature-engineering-toolkit",
-      "description": "Feature creation, selection, and transformation tools",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "features",
-        "engineering",
-        "selection",
-        "transformation",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "file-to-code",
-      "source": "./plugins/skill-enhancers/file-to-code",
-      "description": "Converts file references into executable code implementations",
-      "version": "0.16.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "files",
-        "automation",
-        "code-generation"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "flash-loan-simulator",
-      "source": "./plugins/crypto/flash-loan-simulator",
-      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "flash-loans",
-        "defi",
-        "aave",
-        "arbitrage",
-        "liquidation",
-        "ethereum",
-        "simulation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "formatter",
-      "source": "./plugins/examples/formatter",
-      "description": "Code formatting plugin using hooks to auto-format on save",
-      "version": "2.26.0",
-      "category": "examples",
-      "keywords": [
-        "formatting",
-        "hooks",
-        "automation"
-      ]
-    },
-    {
-      "name": "freshie-inventory-manager",
-      "source": "./plugins/database/freshie-inventory-manager",
-      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
-      "version": "1.5.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "inventory",
-        "freshie",
-        "compliance",
-        "sqlite",
-        "ecosystem",
-        "audit",
-        "subagents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "fullstack-starter-pack",
-      "source": "./plugins/packages/fullstack-starter-pack",
-      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
-      "version": "1.21.0",
-      "category": "packages",
-      "keywords": [
-        "fullstack",
-        "react",
-        "express",
-        "fastapi",
-        "postgresql",
-        "prisma",
-        "typescript",
-        "mvp",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "gas-fee-optimizer",
-      "source": "./plugins/crypto/gas-fee-optimizer",
-      "description": "Optimize transaction gas fees with timing and routing recommendations",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "gas",
-        "fees",
-        "ethereum",
-        "optimization",
-        "transaction",
-        "l2"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "gdpr-compliance-scanner",
-      "source": "./plugins/security/gdpr-compliance-scanner",
-      "description": "Scan for GDPR compliance issues",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "Jake Kozloski",
+        "email": "jakozloski@gmail.com"
       }
     },
     {
@@ -2459,57 +3885,6 @@
       }
     },
     {
-      "name": "graphql-server-builder",
-      "source": "./plugins/api-development/graphql-server-builder",
-      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
-      "version": "1.22.0",
-      "category": "api-development",
-      "keywords": [
-        "graphql",
-        "api",
-        "server",
-        "apollo",
-        "schema",
-        "resolvers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "grpc-service-generator",
-      "source": "./plugins/api-development/grpc-service-generator",
-      "description": "Generate gRPC services with Protocol Buffers and streaming support",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "grpc",
-        "protobuf",
-        "microservices",
-        "streaming"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "hello-world",
-      "source": "./plugins/examples/hello-world",
-      "description": "Simple example plugin demonstrating basic slash commands",
-      "version": "1.12.0",
-      "category": "examples",
-      "keywords": [
-        "example",
-        "tutorial",
-        "beginner"
-      ],
-      "author": {
-        "name": "Jeremy Longshore"
-      }
-    },
-    {
       "name": "helm-chart-generator",
       "source": "./plugins/devops/helm-chart-generator",
       "description": "Generate Helm charts for Kubernetes applications",
@@ -2521,40 +3896,6 @@
         "packaging",
         "charts",
         "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "hipaa-compliance-checker",
-      "source": "./plugins/security/hipaa-compliance-checker",
-      "description": "Check HIPAA compliance",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "hyperparameter-tuner",
-      "source": "./plugins/ai-ml/hyperparameter-tuner",
-      "description": "Optimize hyperparameters using grid/random/bayesian search",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "hyperparameters",
-        "optimization",
-        "tuning",
-        "search",
-        "ml"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2599,77 +3940,83 @@
       }
     },
     {
-      "name": "infrastructure-metrics-collector",
-      "source": "./plugins/performance/infrastructure-metrics-collector",
-      "description": "Collect comprehensive infrastructure performance metrics",
-      "version": "1.20.0",
-      "category": "performance",
+      "name": "jeremy-adk-terraform",
+      "source": "./plugins/devops/jeremy-adk-terraform",
+      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
+      "version": "2.22.0",
+      "category": "devops",
       "keywords": [
+        "terraform",
+        "adk",
+        "agent-engine",
+        "vertex-ai",
         "infrastructure",
-        "metrics",
-        "monitoring",
-        "observability"
+        "vpc-sc"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
-      "name": "input-validation-scanner",
-      "source": "./plugins/security/input-validation-scanner",
-      "description": "Scan input validation practices",
-      "version": "1.25.0",
-      "category": "security",
+      "name": "jeremy-genkit-terraform",
+      "source": "./plugins/devops/jeremy-genkit-terraform",
+      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
+      "version": "2.21.0",
+      "category": "devops",
       "keywords": [
+        "terraform",
+        "genkit",
+        "firebase",
+        "cloud-run",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-github-actions-gcp",
+      "source": "./plugins/devops/jeremy-github-actions-gcp",
+      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
+      "version": "2.27.0",
+      "category": "devops",
+      "keywords": [
+        "github-actions",
+        "google-cloud",
+        "workload-identity-federation",
+        "wif",
+        "vertex-ai",
+        "agent-engine",
+        "deployment",
+        "ci-cd",
         "security",
-        "compliance",
-        "auditing"
+        "best-practices",
+        "oidc",
+        "iam"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
-      "name": "integration-test-runner",
-      "source": "./plugins/testing/integration-test-runner",
-      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
-      "version": "1.22.0",
-      "category": "testing",
+      "name": "jeremy-vertex-terraform",
+      "source": "./plugins/devops/jeremy-vertex-terraform",
+      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
+      "version": "2.22.0",
+      "category": "devops",
       "keywords": [
-        "testing",
-        "integration-tests",
-        "test-runner",
-        "e2e",
-        "api-testing"
+        "terraform",
+        "vertex-ai",
+        "gemini",
+        "model-garden",
+        "infrastructure"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "kobiton-automate",
-      "source": "./plugins/testing/kobiton-automate",
-      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
-      "version": "1.0.2",
-      "category": "testing",
-      "keywords": [
-        "mobile",
-        "testing",
-        "appium",
-        "automation",
-        "devices",
-        "ios",
-        "android",
-        "real-device",
-        "mcp",
-        "kobiton"
-      ],
-      "author": {
-        "name": "Kobiton Inc.",
-        "url": "https://github.com/kobiton"
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
@@ -2684,25 +4031,6 @@
         "deployment",
         "orchestration",
         "containers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "liquidity-pool-analyzer",
-      "source": "./plugins/crypto/liquidity-pool-analyzer",
-      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
-      "version": "1.23.0",
-      "category": "crypto",
-      "keywords": [
-        "liquidity",
-        "pool",
-        "defi",
-        "impermanent",
-        "loss",
-        "apy"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2729,41 +4057,6 @@
       }
     },
     {
-      "name": "load-balancer-tester",
-      "source": "./plugins/testing/load-balancer-tester",
-      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "load-balancer",
-        "traffic-distribution",
-        "failover",
-        "high-availability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "load-test-runner",
-      "source": "./plugins/performance/load-test-runner",
-      "description": "Create and execute load tests for performance validation",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "load-testing",
-        "performance",
-        "stress-test",
-        "k6"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "log-aggregation-setup",
       "source": "./plugins/devops/log-aggregation-setup",
       "description": "Set up log aggregation (ELK, Loki, Splunk)",
@@ -2783,263 +4076,23 @@
       }
     },
     {
-      "name": "log-analysis-tool",
-      "source": "./plugins/performance/log-analysis-tool",
-      "description": "Analyze logs for performance insights and issues",
-      "version": "1.24.0",
-      "category": "performance",
+      "name": "mattyp-changelog",
+      "source": "./plugins/devops/mattyp-changelog",
+      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
+      "version": "0.3.0",
+      "category": "devops",
       "keywords": [
-        "logs",
-        "analysis",
-        "performance",
-        "debugging"
+        "changelog",
+        "release-notes",
+        "weekly-update",
+        "git",
+        "github",
+        "automation"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "make-scenario-builder",
-      "source": "./plugins/ai-agency/make-scenario-builder",
-      "description": "Create Make.com (Integromat) scenarios with AI assistance",
-      "version": "1.15.0",
-      "category": "ai-agency",
-      "keywords": [
-        "make",
-        "integromat",
-        "automation",
-        "scenarios",
-        "workflow",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "market-movers-scanner",
-      "source": "./plugins/crypto/market-movers-scanner",
-      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "market",
-        "scanner",
-        "movers",
-        "gainers",
-        "losers",
-        "volume",
-        "trading"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "market-price-tracker",
-      "source": "./plugins/crypto/market-price-tracker",
-      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "market",
-        "price",
-        "tracking",
-        "trading",
-        "crypto",
-        "stocks",
-        "forex"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "market-sentiment-analyzer",
-      "source": "./plugins/crypto/market-sentiment-analyzer",
-      "description": "Analyze market sentiment from social media, news, and on-chain data",
-      "version": "1.24.0",
-      "category": "crypto",
-      "keywords": [
-        "sentiment",
-        "analysis",
-        "social",
-        "news",
-        "market",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "memory-leak-detector",
-      "source": "./plugins/performance/memory-leak-detector",
-      "description": "Detect memory leaks and analyze memory usage patterns",
-      "version": "1.24.0",
-      "category": "performance",
-      "keywords": [
-        "memory",
-        "leak",
-        "detection",
-        "performance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "mempool-analyzer",
-      "source": "./plugins/crypto/mempool-analyzer",
-      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
-      "version": "1.32.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "mempool",
-        "mev",
-        "ethereum",
-        "blockchain",
-        "gas",
-        "pending-transactions",
-        "arbitrage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "metrics-aggregator",
-      "source": "./plugins/performance/metrics-aggregator",
-      "description": "Aggregate and centralize performance metrics",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "metrics",
-        "aggregation",
-        "prometheus",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ml-model-trainer",
-      "source": "./plugins/ai-ml/ml-model-trainer",
-      "description": "Train and optimize machine learning models with automated workflows",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "ml",
-        "machine-learning",
-        "training",
-        "models",
-        "ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "mobile-app-tester",
-      "source": "./plugins/testing/mobile-app-tester",
-      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mobile",
-        "appium",
-        "detox",
-        "xcuitest",
-        "espresso",
-        "ios",
-        "android"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-deployment-helper",
-      "source": "./plugins/ai-ml/model-deployment-helper",
-      "description": "Deploy ML models to production",
-      "version": "1.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "deployment",
-        "serving",
-        "production",
-        "api",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-evaluation-suite",
-      "source": "./plugins/ai-ml/model-evaluation-suite",
-      "description": "Comprehensive model evaluation with multiple metrics",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "evaluation",
-        "metrics",
-        "testing",
-        "validation",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-explainability-tool",
-      "source": "./plugins/ai-ml/model-explainability-tool",
-      "description": "Model interpretability and explainability",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "explainability",
-        "shap",
-        "lime",
-        "interpretability",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-versioning-tracker",
-      "source": "./plugins/ai-ml/model-versioning-tracker",
-      "description": "Track and manage model versions",
-      "version": "1.24.0",
-      "category": "ai-ml",
-      "keywords": [
-        "versioning",
-        "mlflow",
-        "tracking",
-        "registry",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "name": "Mattyp",
+        "email": "mattyp@tonsofskills.com",
+        "url": "https://tonsofskills.com"
       }
     },
     {
@@ -3054,60 +4107,6 @@
         "grafana",
         "observability",
         "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "mutation-test-runner",
-      "source": "./plugins/testing/mutation-test-runner",
-      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mutation-testing",
-        "test-quality",
-        "stryker",
-        "pitest"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "n8n-workflow-designer",
-      "source": "./plugins/ai-agency/n8n-workflow-designer",
-      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
-      "version": "1.13.0",
-      "category": "ai-agency",
-      "keywords": [
-        "n8n",
-        "workflow",
-        "automation",
-        "self-hosted",
-        "open-source",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "url": "https://github.com/jeremylongshore/claude-code-plugins"
-      }
-    },
-    {
-      "name": "network-latency-analyzer",
-      "source": "./plugins/performance/network-latency-analyzer",
-      "description": "Analyze network latency and optimize request patterns",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "network",
-        "latency",
-        "performance",
-        "api"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3133,36 +4132,18 @@
       }
     },
     {
-      "name": "neural-network-builder",
-      "source": "./plugins/ai-ml/neural-network-builder",
-      "description": "Build and configure neural network architectures",
-      "version": "1.20.0",
-      "category": "ai-ml",
-      "keywords": [
-        "neural-networks",
-        "deep-learning",
-        "architecture",
-        "pytorch",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "nft-rarity-analyzer",
-      "source": "./plugins/crypto/nft-rarity-analyzer",
-      "description": "Analyze NFT rarity scores and valuations across collections",
+      "name": "secrets-manager-integrator",
+      "source": "./plugins/devops/secrets-manager-integrator",
+      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
       "version": "1.25.0",
-      "category": "crypto",
+      "category": "devops",
       "keywords": [
-        "nft",
-        "rarity",
-        "valuation",
-        "traits",
-        "opensea",
-        "crypto"
+        "secrets",
+        "vault",
+        "aws",
+        "security",
+        "credentials",
+        "devops"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3170,17 +4151,17 @@
       }
     },
     {
-      "name": "nlp-text-analyzer",
-      "source": "./plugins/ai-ml/nlp-text-analyzer",
-      "description": "Natural language processing and text analysis",
-      "version": "1.22.0",
-      "category": "ai-ml",
+      "name": "service-mesh-configurator",
+      "source": "./plugins/devops/service-mesh-configurator",
+      "description": "Configure service mesh (Istio, Linkerd) for microservices",
+      "version": "1.24.0",
+      "category": "devops",
       "keywords": [
-        "nlp",
-        "text",
-        "analysis",
-        "tokenization",
-        "ml"
+        "service-mesh",
+        "istio",
+        "linkerd",
+        "microservices",
+        "devops"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3188,21 +4169,171 @@
       }
     },
     {
-      "name": "ollama-local-ai",
-      "source": "./plugins/ai-ml/ollama-local-ai",
-      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
-      "version": "1.18.0",
-      "category": "ai-ml",
+      "name": "sugar",
+      "source": "./plugins/devops/sugar",
+      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
+      "version": "2.0.0",
+      "category": "devops",
       "keywords": [
-        "ollama",
-        "local-llm",
-        "free-ai",
-        "self-hosted",
-        "llama",
-        "mistral",
-        "privacy",
-        "zero-cost",
-        "openai-alternative"
+        "autonomous",
+        "development",
+        "ai",
+        "task-management",
+        "automation",
+        "agents",
+        "enterprise",
+        "workflow",
+        "productivity",
+        "mcp"
+      ],
+      "author": {
+        "name": "Steven Leggett",
+        "email": "contact@roboticforce.io"
+      },
+      "repository": "https://github.com/cdnsteve/sugar"
+    },
+    {
+      "name": "terraform-module-builder",
+      "source": "./plugins/devops/terraform-module-builder",
+      "description": "Build reusable Terraform modules",
+      "version": "1.23.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "iac",
+        "modules",
+        "infrastructure",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "tweetclaw",
+      "source": "./plugins/devops/tweetclaw",
+      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
+      "version": "1.5.3",
+      "category": "devops",
+      "keywords": [
+        "twitter",
+        "x",
+        "automation",
+        "social-media",
+        "tweets",
+        "monitoring",
+        "giveaway",
+        "scraping"
+      ],
+      "author": {
+        "name": "Burak Bayir",
+        "email": "burak@xquik.com",
+        "url": "https://xquik.com"
+      },
+      "repository": "https://github.com/Xquik-dev/tweetclaw",
+      "homepage": "https://xquik.com",
+      "license": "MIT"
+    },
+    {
+      "name": "formatter",
+      "source": "./plugins/examples/formatter",
+      "description": "Code formatting plugin using hooks to auto-format on save",
+      "version": "2.26.0",
+      "category": "examples",
+      "keywords": [
+        "formatting",
+        "hooks",
+        "automation"
+      ]
+    },
+    {
+      "name": "hello-world",
+      "source": "./plugins/examples/hello-world",
+      "description": "Simple example plugin demonstrating basic slash commands",
+      "version": "1.12.0",
+      "category": "examples",
+      "keywords": [
+        "example",
+        "tutorial",
+        "beginner"
+      ],
+      "author": {
+        "name": "Jeremy Longshore"
+      }
+    },
+    {
+      "name": "jeremy-plugin-tool",
+      "source": "./plugins/examples/jeremy-plugin-tool",
+      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
+      "version": "2.19.0",
+      "category": "examples",
+      "keywords": [
+        "skills",
+        "agent-skills",
+        "plugin-management",
+        "marketplace",
+        "validation",
+        "audit",
+        "versioning",
+        "meta-plugin",
+        "repository-tools"
+      ],
+      "author": {
+        "name": "Claude Code Plugins",
+        "email": "[email protected]"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
+      "name": "pi-pathfinder",
+      "source": "./plugins/examples/pi-pathfinder",
+      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
+      "version": "1.24.0",
+      "category": "examples",
+      "keywords": [
+        "agent-skills",
+        "pi",
+        "pathfinder",
+        "plugin-intelligence",
+        "task-router",
+        "auto-selector",
+        "skill-extraction",
+        "easy-mode",
+        "automatic",
+        "no-thinking-required"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
+      "name": "security-agent",
+      "source": "./plugins/examples/security-agent",
+      "description": "Security review subagent for code analysis",
+      "version": "1.28.0",
+      "category": "examples",
+      "keywords": [
+        "security",
+        "agent",
+        "code-review"
+      ]
+    },
+    {
+      "name": "a2a-client",
+      "source": "./plugins/mcp/a2a-client",
+      "description": "Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "a2a",
+        "agent2agent",
+        "agent-card",
+        "multi-agent",
+        "interoperability"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3210,15 +4341,60 @@
       }
     },
     {
-      "name": "nosql-data-modeler",
-      "source": "./plugins/database/nosql-data-modeler",
-      "description": "Database plugin for nosql-data-modeler",
-      "version": "1.29.0",
-      "category": "database",
+      "name": "ai-experiment-logger",
+      "source": "./plugins/mcp/ai-experiment-logger",
+      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
+      "version": "1.12.0",
+      "category": "mcp",
       "keywords": [
-        "database",
-        "backend",
-        "data"
+        "ai",
+        "experiments",
+        "logging",
+        "mcp"
+      ],
+      "author": {
+        "name": "Claude Code Plugins"
+      }
+    },
+    {
+      "name": "beads-dolt",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "beads",
+        "bd",
+        "dolt",
+        "dolthub",
+        "task-tracking",
+        "mcp",
+        "version-control",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "conversational-api-debugger",
+      "source": "./plugins/mcp/conversational-api-debugger",
+      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "api",
+        "debugging",
+        "openapi",
+        "har",
+        "rest",
+        "curl",
+        "http"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3226,17 +4402,44 @@
       }
     },
     {
-      "name": "on-chain-analytics",
-      "source": "./plugins/crypto/on-chain-analytics",
-      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
-      "version": "1.28.0",
-      "category": "crypto",
+      "name": "databricks-workspace-mcp",
+      "source": "./plugins/mcp/databricks-workspace-mcp",
+      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+      "version": "0.1.0",
+      "category": "mcp",
       "keywords": [
-        "on-chain",
-        "analytics",
-        "whale",
-        "metrics",
-        "blockchain"
+        "mcp",
+        "model-context-protocol",
+        "databricks",
+        "lakehouse",
+        "unity-catalog",
+        "clusters",
+        "dlt",
+        "finops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://tonsofskills.com/learn/databricks/",
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "license": "MIT"
+    },
+    {
+      "name": "design-to-code",
+      "source": "./plugins/mcp/design-to-code",
+      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "design",
+        "figma",
+        "react",
+        "svelte",
+        "vue",
+        "accessibility",
+        "component-generation"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3244,27 +4447,46 @@
       }
     },
     {
-      "name": "openbb-terminal",
-      "source": "./plugins/business-tools/openbb-terminal",
-      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
-      "version": "1.6.0",
-      "category": "business-tools",
+      "name": "dolt-mcp-vcs",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
+      "version": "0.1.0",
+      "category": "mcp",
       "keywords": [
-        "finance",
-        "investment",
-        "openbb",
-        "stocks",
-        "crypto",
-        "portfolio",
-        "trading",
-        "financial-analysis",
-        "market-data",
-        "equity-research",
-        "options",
-        "forex",
-        "macroeconomics",
-        "quant",
-        "ai-finance"
+        "dolt-mcp-vcs",
+        "dolt",
+        "dolthub",
+        "dolt-mcp",
+        "version-control",
+        "vcs",
+        "mcp",
+        "sql",
+        "beads",
+        "bd"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "domain-memory-agent",
+      "source": "./plugins/mcp/domain-memory-agent",
+      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
+      "version": "1.17.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "knowledge-base",
+        "semantic-search",
+        "tfidf",
+        "summarization",
+        "rag",
+        "documentation"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3272,75 +4494,84 @@
       }
     },
     {
-      "name": "options-flow-analyzer",
-      "source": "./plugins/crypto/options-flow-analyzer",
-      "description": "Track institutional options flow, unusual activity, and smart money movements",
-      "version": "1.29.0",
-      "category": "crypto",
+      "name": "governed-second-brain",
+      "source": "./plugins/mcp/governed-second-brain",
+      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
+      "version": "1.1.2",
+      "category": "mcp",
       "keywords": [
-        "options",
-        "flow",
-        "institutional",
-        "trading",
-        "derivatives",
-        "smart money"
+        "memory",
+        "knowledge",
+        "governance",
+        "qmd",
+        "brain",
+        "citations",
+        "local-first",
+        "second-brain"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "license": "Apache-2.0"
     },
     {
-      "name": "orm-code-generator",
-      "source": "./plugins/database/orm-code-generator",
-      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
-      "version": "1.28.0",
-      "category": "database",
+      "name": "lumera-agent-memory",
+      "source": "./plugins/mcp/lumera-agent-memory",
+      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
+      "version": "1.7.0",
+      "category": "mcp",
       "keywords": [
-        "orm",
-        "models",
-        "code-generation",
-        "database",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "overnight-dev",
-      "source": "./plugins/productivity/overnight-dev",
-      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
-      "version": "1.29.0",
-      "category": "productivity",
-      "keywords": [
-        "overnight",
-        "autonomous",
-        "tdd",
-        "testing",
-        "git-hooks",
-        "automation",
-        "continuous-integration",
-        "test-driven-development",
-        "productivity"
+        "mcp",
+        "memory",
+        "cascade",
+        "storage",
+        "encryption",
+        "search",
+        "fts",
+        "agent"
       ],
       "author": {
         "name": "Intent Solutions IO",
-        "url": "https://intentsolutions.io",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
-      "name": "owasp-compliance-checker",
-      "source": "./plugins/security/owasp-compliance-checker",
-      "description": "Check OWASP Top 10 compliance",
-      "version": "1.28.0",
-      "category": "security",
+      "name": "pr-to-spec",
+      "source": "./plugins/mcp/pr-to-spec",
+      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+      "version": "0.8.0",
+      "category": "mcp",
+      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "license": "MIT",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
+        "mcp",
+        "pr-analysis",
+        "intent-drift",
+        "code-review",
+        "agent-protocol"
+      ]
+    },
+    {
+      "name": "project-health-auditor",
+      "source": "./plugins/mcp/project-health-auditor",
+      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
+      "version": "1.18.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "code-quality",
+        "technical-debt",
+        "complexity",
+        "git-churn",
+        "test-coverage",
+        "analytics"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3348,15 +4579,74 @@
       }
     },
     {
-      "name": "pci-dss-validator",
-      "source": "./plugins/security/pci-dss-validator",
-      "description": "Validate PCI DSS compliance",
-      "version": "1.24.0",
-      "category": "security",
+      "name": "servicegraph",
+      "source": "./plugins/mcp/servicegraph",
+      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
+      "version": "0.2.0",
+      "category": "mcp",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
+        "servicegraph",
+        "service-providers",
+        "agencies",
+        "law-firms",
+        "consulting",
+        "accounting",
+        "marketing",
+        "lead-generation",
+        "professional-services",
+        "us-firms",
+        "product-directories",
+        "saas-directories",
+        "mcp-directories",
+        "ai-directories",
+        "product-launch",
+        "backlinks"
+      ],
+      "author": {
+        "name": "Artur Briugeman",
+        "url": "https://servicegraph.co",
+        "email": "artur@nostr.band"
+      },
+      "homepage": "https://servicegraph.co",
+      "repository": "https://github.com/nostrband/servicegraph",
+      "license": "MIT"
+    },
+    {
+      "name": "slack-channel",
+      "source": "./plugins/mcp/slack-channel",
+      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "slack",
+        "channel",
+        "mcp",
+        "socket-mode",
+        "chatops",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT"
+    },
+    {
+      "name": "workflow-orchestrator",
+      "source": "./plugins/mcp/workflow-orchestrator",
+      "description": "DAG-based workflow automation with parallel task execution and dependency management",
+      "version": "1.15.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "workflow",
+        "dag",
+        "automation",
+        "orchestration",
+        "cicd",
+        "parallel-execution"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3364,22 +4654,436 @@
       }
     },
     {
-      "name": "penetration-tester",
-      "source": "./plugins/security/penetration-tester",
-      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
-      "version": "3.30.0",
-      "category": "security",
+      "name": "x-bug-triage",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "triage",
+        "x-api",
+        "bug-tracking",
+        "clustering"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "license": "MIT"
+    },
+    {
+      "name": "x-bug-triage-plugin",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "keywords": [
+        "bug-triage",
+        "x-twitter",
+        "slack",
+        "devops",
+        "mcp"
+      ],
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT"
+    },
+    {
+      "name": "ai-ml-engineering-pack",
+      "source": "./plugins/packages/ai-ml-engineering-pack",
+      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "ai",
+        "ml",
+        "llm",
+        "prompt-engineering",
+        "rag",
+        "vector-database",
+        "ai-safety",
+        "openai",
+        "anthropic",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "creator-studio-pack",
+      "source": "./plugins/packages/creator-studio-pack",
+      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
+      "version": "1.16.0",
+      "category": "packages",
+      "keywords": [
+        "video",
+        "content-creation",
+        "youtube",
+        "filmmaking",
+        "creator",
+        "documentation",
+        "screencast",
+        "tutorial",
+        "video-editing",
+        "content-strategy",
+        "distribution",
+        "thumbnails",
+        "subtitles",
+        "repurposing",
+        "batch-recording",
+        "analytics",
+        "package",
+        "premium"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "devops-automation-pack",
+      "source": "./plugins/packages/devops-automation-pack",
+      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "devops",
+        "ci-cd",
+        "docker",
+        "kubernetes",
+        "terraform",
+        "deployment",
+        "infrastructure",
+        "automation",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "fullstack-starter-pack",
+      "source": "./plugins/packages/fullstack-starter-pack",
+      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
+      "version": "1.21.0",
+      "category": "packages",
+      "keywords": [
+        "fullstack",
+        "react",
+        "express",
+        "fastapi",
+        "postgresql",
+        "prisma",
+        "typescript",
+        "mvp",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-pro-pack",
+      "source": "./plugins/packages/security-pro-pack",
+      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
+      "version": "1.31.0",
+      "category": "packages",
       "keywords": [
         "security",
-        "penetration-testing",
-        "pentesting",
-        "owasp",
-        "owasp-top-10",
         "vulnerability-scanning",
-        "dependency-audit",
-        "license-compliance",
-        "engagement-governance",
-        "chain-of-custody"
+        "compliance",
+        "HIPAA",
+        "PCI-DSS",
+        "GDPR",
+        "SOC2",
+        "cryptography",
+        "devsecops",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "alerting-rule-creator",
+      "source": "./plugins/performance/alerting-rule-creator",
+      "description": "Create intelligent alerting rules for performance monitoring",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "alerting",
+        "monitoring",
+        "sre",
+        "observability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "apm-dashboard-creator",
+      "source": "./plugins/performance/apm-dashboard-creator",
+      "description": "Create Application Performance Monitoring dashboards",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "apm",
+        "monitoring",
+        "dashboard",
+        "grafana",
+        "datadog"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "application-profiler",
+      "source": "./plugins/performance/application-profiler",
+      "description": "Profile application performance with CPU, memory, and execution time analysis",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "performance",
+        "profiling",
+        "monitoring",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "bottleneck-detector",
+      "source": "./plugins/performance/bottleneck-detector",
+      "description": "Detect and resolve performance bottlenecks",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "bottleneck",
+        "performance",
+        "optimization",
+        "profiling"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cache-performance-optimizer",
+      "source": "./plugins/performance/cache-performance-optimizer",
+      "description": "Optimize caching strategies for improved performance",
+      "version": "1.19.0",
+      "category": "performance",
+      "keywords": [
+        "cache",
+        "performance",
+        "optimization",
+        "redis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "capacity-planning-analyzer",
+      "source": "./plugins/performance/capacity-planning-analyzer",
+      "description": "Analyze and plan for capacity requirements",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "capacity-planning",
+        "scaling",
+        "forecasting",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cpu-usage-monitor",
+      "source": "./plugins/performance/cpu-usage-monitor",
+      "description": "Monitor and analyze CPU usage patterns in applications",
+      "version": "1.23.0",
+      "category": "performance",
+      "keywords": [
+        "cpu",
+        "monitoring",
+        "performance",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "database-query-profiler",
+      "source": "./plugins/performance/database-query-profiler",
+      "description": "Profile and optimize database queries for performance",
+      "version": "1.9.0",
+      "category": "performance",
+      "keywords": [
+        "database",
+        "query",
+        "profiling",
+        "optimization",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "distributed-tracing-setup",
+      "source": "./plugins/performance/distributed-tracing-setup",
+      "description": "Set up distributed tracing for microservices",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "tracing",
+        "observability",
+        "microservices",
+        "opentelemetry"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "error-rate-monitor",
+      "source": "./plugins/performance/error-rate-monitor",
+      "description": "Monitor and analyze application error rates",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "errors",
+        "monitoring",
+        "reliability",
+        "sre"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "infrastructure-metrics-collector",
+      "source": "./plugins/performance/infrastructure-metrics-collector",
+      "description": "Collect comprehensive infrastructure performance metrics",
+      "version": "1.20.0",
+      "category": "performance",
+      "keywords": [
+        "infrastructure",
+        "metrics",
+        "monitoring",
+        "observability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "load-test-runner",
+      "source": "./plugins/performance/load-test-runner",
+      "description": "Create and execute load tests for performance validation",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "load-testing",
+        "performance",
+        "stress-test",
+        "k6"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "log-analysis-tool",
+      "source": "./plugins/performance/log-analysis-tool",
+      "description": "Analyze logs for performance insights and issues",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": [
+        "logs",
+        "analysis",
+        "performance",
+        "debugging"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "memory-leak-detector",
+      "source": "./plugins/performance/memory-leak-detector",
+      "description": "Detect memory leaks and analyze memory usage patterns",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": [
+        "memory",
+        "leak",
+        "detection",
+        "performance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "metrics-aggregator",
+      "source": "./plugins/performance/metrics-aggregator",
+      "description": "Aggregate and centralize performance metrics",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "metrics",
+        "aggregation",
+        "prometheus",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "network-latency-analyzer",
+      "source": "./plugins/performance/network-latency-analyzer",
+      "description": "Analyze network latency and optimize request patterns",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "network",
+        "latency",
+        "performance",
+        "api"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3438,133 +5142,6 @@
       }
     },
     {
-      "name": "performance-test-suite",
-      "source": "./plugins/testing/performance-test-suite",
-      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
-      "version": "1.30.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "performance",
-        "load-testing",
-        "benchmarking",
-        "stress-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "pi-pathfinder",
-      "source": "./plugins/examples/pi-pathfinder",
-      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
-      "version": "1.24.0",
-      "category": "examples",
-      "keywords": [
-        "agent-skills",
-        "pi",
-        "pathfinder",
-        "plugin-intelligence",
-        "task-router",
-        "auto-selector",
-        "skill-extraction",
-        "easy-mode",
-        "automatic",
-        "no-thinking-required"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "code-cleanup",
-      "source": "./plugins/testing/code-cleanup",
-      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
-      "version": "1.7.0",
-      "category": "testing",
-      "keywords": [
-        "code-quality",
-        "cleanup",
-        "refactoring",
-        "dead-code",
-        "deduplication",
-        "type-safety",
-        "security",
-        "performance",
-        "async",
-        "tech-debt",
-        "code-review"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "project-health-auditor",
-      "source": "./plugins/mcp/project-health-auditor",
-      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
-      "version": "1.18.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "code-quality",
-        "technical-debt",
-        "complexity",
-        "git-churn",
-        "test-coverage",
-        "analytics"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "promptbook",
-      "source": "./plugins/business-tools/promptbook",
-      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
-      "version": "1.4.0",
-      "category": "business-tools",
-      "keywords": [
-        "analytics",
-        "telemetry",
-        "builds",
-        "portfolio",
-        "tracking",
-        "metrics",
-        "sessions"
-      ],
-      "author": {
-        "name": "Promptbook",
-        "email": "contact@promptbook.gg"
-      },
-      "homepage": "https://promptbook.gg",
-      "repository": "https://github.com/promptbookgg/claude-code-plugin",
-      "license": "MIT"
-    },
-    {
-      "name": "query-performance-analyzer",
-      "source": "./plugins/database/query-performance-analyzer",
-      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "performance",
-        "query",
-        "optimization",
-        "explain",
-        "database"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
       "name": "real-user-monitoring",
       "source": "./plugins/performance/real-user-monitoring",
       "description": "Implement Real User Monitoring for actual performance data",
@@ -3579,75 +5156,6 @@
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
-      }
-    },
-    {
-      "name": "recommendation-engine",
-      "source": "./plugins/ai-ml/recommendation-engine",
-      "description": "Build recommendation systems and engines",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "recommendations",
-        "collaborative",
-        "content-based",
-        "ranking",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "regression-analysis-tool",
-      "source": "./plugins/ai-ml/regression-analysis-tool",
-      "description": "Regression analysis and modeling",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "regression",
-        "prediction",
-        "linear",
-        "polynomial",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "regression-test-tracker",
-      "source": "./plugins/testing/regression-test-tracker",
-      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
-      "version": "1.26.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "regression-testing",
-        "test-tracking",
-        "ci-cd",
-        "quality-assurance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "research-to-deploy",
-      "source": "./plugins/skill-enhancers/research-to-deploy",
-      "description": "Transforms research findings into deployed solutions automatically",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "research",
-        "automation",
-        "deployment"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
       }
     },
     {
@@ -3685,309 +5193,6 @@
       }
     },
     {
-      "name": "rest-api-generator",
-      "source": "./plugins/api-development/rest-api-generator",
-      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "api",
-        "rest",
-        "generator",
-        "openapi",
-        "swagger",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "roi-calculator",
-      "source": "./plugins/ai-agency/roi-calculator",
-      "description": "Calculate and present ROI for AI automation projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "roi",
-        "return on investment",
-        "calculator",
-        "sales",
-        "value",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "search-to-slack",
-      "source": "./plugins/skill-enhancers/search-to-slack",
-      "description": "Automatically posts search results to Slack channels",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "search",
-        "slack",
-        "automation",
-        "integration"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "secret-scanner",
-      "source": "./plugins/security/secret-scanner",
-      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "secrets",
-        "api-keys",
-        "credentials",
-        "passwords"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "severity1-marketplace",
-      "source": "./plugins/security/severity1-marketplace",
-      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
-      "version": "1.6.0",
-      "category": "security",
-      "keywords": [
-        "severity",
-        "classification",
-        "prompt-improvement",
-        "marketplace",
-        "security",
-        "quality",
-        "triage",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "severity1",
-        "email": "severity1@intentsolutions.io"
-      }
-    },
-    {
-      "name": "secrets-manager-integrator",
-      "source": "./plugins/devops/secrets-manager-integrator",
-      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "secrets",
-        "vault",
-        "aws",
-        "security",
-        "credentials",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-agent",
-      "source": "./plugins/examples/security-agent",
-      "description": "Security review subagent for code analysis",
-      "version": "1.28.0",
-      "category": "examples",
-      "keywords": [
-        "security",
-        "agent",
-        "code-review"
-      ]
-    },
-    {
-      "name": "security-audit-reporter",
-      "source": "./plugins/security/security-audit-reporter",
-      "description": "Generate comprehensive security audit reports",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-headers-analyzer",
-      "source": "./plugins/security/security-headers-analyzer",
-      "description": "Analyze HTTP security headers",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-incident-responder",
-      "source": "./plugins/security/security-incident-responder",
-      "description": "Assist with security incident response",
-      "version": "1.32.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-misconfiguration-finder",
-      "source": "./plugins/security/security-misconfiguration-finder",
-      "description": "Find security misconfigurations",
-      "version": "1.29.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-pro-pack",
-      "source": "./plugins/packages/security-pro-pack",
-      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
-      "version": "1.31.0",
-      "category": "packages",
-      "keywords": [
-        "security",
-        "vulnerability-scanning",
-        "compliance",
-        "HIPAA",
-        "PCI-DSS",
-        "GDPR",
-        "SOC2",
-        "cryptography",
-        "devsecops",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-test-scanner",
-      "source": "./plugins/testing/security-test-scanner",
-      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
-      "version": "1.29.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "security",
-        "vulnerabilities",
-        "owasp",
-        "penetration-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "sentiment-analysis-tool",
-      "source": "./plugins/ai-ml/sentiment-analysis-tool",
-      "description": "Sentiment analysis on text data",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "sentiment",
-        "opinion",
-        "emotion",
-        "polarity",
-        "nlp"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "service-mesh-configurator",
-      "source": "./plugins/devops/service-mesh-configurator",
-      "description": "Configure service mesh (Istio, Linkerd) for microservices",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "service-mesh",
-        "istio",
-        "linkerd",
-        "microservices",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "session-security-checker",
-      "source": "./plugins/security/session-security-checker",
-      "description": "Check session security implementation",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "jeremy-plugin-tool",
-      "source": "./plugins/examples/jeremy-plugin-tool",
-      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
-      "version": "2.19.0",
-      "category": "examples",
-      "keywords": [
-        "skills",
-        "agent-skills",
-        "plugin-management",
-        "marketplace",
-        "validation",
-        "audit",
-        "versioning",
-        "meta-plugin",
-        "repository-tools"
-      ],
-      "author": {
-        "name": "Claude Code Plugins",
-        "email": "[email protected]"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
       "name": "sla-sli-tracker",
       "source": "./plugins/performance/sla-sli-tracker",
       "description": "Track SLAs, SLIs, and SLOs for service reliability",
@@ -4006,217 +5211,6 @@
       }
     },
     {
-      "name": "smoke-test-runner",
-      "source": "./plugins/testing/smoke-test-runner",
-      "description": "Quick smoke test suites to verify critical functionality after deployments",
-      "version": "1.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "smoke-tests",
-        "deployment",
-        "sanity-check",
-        "critical-path"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "snapshot-test-manager",
-      "source": "./plugins/testing/snapshot-test-manager",
-      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "snapshot",
-        "jest",
-        "vitest",
-        "diff-analysis",
-        "test-management"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "soc2-audit-helper",
-      "source": "./plugins/security/soc2-audit-helper",
-      "description": "Assist with SOC2 audit preparation",
-      "version": "1.30.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "sow-generator",
-      "source": "./plugins/ai-agency/sow-generator",
-      "description": "Generate professional Statements of Work for AI projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "sow",
-        "statement of work",
-        "contract",
-        "proposal",
-        "agency",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "sql-injection-detector",
-      "source": "./plugins/security/sql-injection-detector",
-      "description": "Detect SQL injection vulnerabilities",
-      "version": "1.31.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "sql-query-optimizer",
-      "source": "./plugins/database/sql-query-optimizer",
-      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "sql",
-        "optimization",
-        "performance",
-        "database",
-        "query"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ssl-certificate-manager",
-      "source": "./plugins/security/ssl-certificate-manager",
-      "description": "Manage and monitor SSL/TLS certificates",
-      "version": "1.21.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "staking-rewards-optimizer",
-      "source": "./plugins/crypto/staking-rewards-optimizer",
-      "description": "Optimize staking rewards across multiple protocols and chains",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "staking",
-        "defi",
-        "yield",
-        "optimization",
-        "rewards"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "stored-procedure-generator",
-      "source": "./plugins/database/stored-procedure-generator",
-      "description": "Database plugin for stored-procedure-generator",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "procedure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "jeremy-firestore",
-      "source": "./plugins/community/jeremy-firestore",
-      "description": "Firestore database specialist for schema design, queries, and real-time sync",
-      "version": "2.20.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "firestore",
-        "database",
-        "crud",
-        "security-rules",
-        "cloud-functions",
-        "batch-operations",
-        "data-migration",
-        "performance",
-        "cost-optimization",
-        "nosql",
-        "google-cloud",
-        "a2a",
-        "agent-to-agent",
-        "mcp",
-        "cloud-run",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]",
-        "url": "https://intentsolutions.io"
-      }
-    },
-    {
-      "name": "sugar",
-      "source": "./plugins/devops/sugar",
-      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
-      "version": "2.0.0",
-      "category": "devops",
-      "keywords": [
-        "autonomous",
-        "development",
-        "ai",
-        "task-management",
-        "automation",
-        "agents",
-        "enterprise",
-        "workflow",
-        "productivity",
-        "mcp"
-      ],
-      "author": {
-        "name": "Steven Leggett",
-        "email": "contact@roboticforce.io"
-      },
-      "repository": "https://github.com/cdnsteve/sugar"
-    },
-    {
       "name": "synthetic-monitoring-setup",
       "source": "./plugins/performance/synthetic-monitoring-setup",
       "description": "Set up synthetic monitoring for proactive performance tracking",
@@ -4230,138 +5224,6 @@
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "terraform-module-builder",
-      "source": "./plugins/devops/terraform-module-builder",
-      "description": "Build reusable Terraform modules",
-      "version": "1.23.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "iac",
-        "modules",
-        "infrastructure",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-coverage-analyzer",
-      "source": "./plugins/testing/test-coverage-analyzer",
-      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "coverage",
-        "code-coverage",
-        "metrics",
-        "analysis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-data-generator",
-      "source": "./plugins/testing/test-data-generator",
-      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "test-data",
-        "fake-data",
-        "fixtures",
-        "factory"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-doubles-generator",
-      "source": "./plugins/testing/test-doubles-generator",
-      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mocks",
-        "stubs",
-        "spies",
-        "fakes",
-        "test-doubles",
-        "jest",
-        "sinon"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-environment-manager",
-      "source": "./plugins/testing/test-environment-manager",
-      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "environment",
-        "docker",
-        "testcontainers",
-        "isolation",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-orchestrator",
-      "source": "./plugins/testing/test-orchestrator",
-      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "orchestration",
-        "workflow",
-        "parallel",
-        "test-selection",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-report-generator",
-      "source": "./plugins/testing/test-report-generator",
-      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "reporting",
-        "coverage",
-        "metrics",
-        "dashboard",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
       }
     },
@@ -4383,324 +5245,92 @@
       }
     },
     {
-      "name": "time-series-forecaster",
-      "source": "./plugins/ai-ml/time-series-forecaster",
-      "description": "Time series forecasting and analysis",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "time-series",
-        "forecasting",
-        "arima",
-        "prophet",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "token-launch-tracker",
-      "source": "./plugins/crypto/token-launch-tracker",
-      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "token-launch",
-        "rugpull",
-        "security",
-        "scam-detection",
-        "contract-analysis",
-        "defi",
-        "new-tokens"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "trading-strategy-backtester",
-      "source": "./plugins/crypto/trading-strategy-backtester",
-      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "trading",
-        "backtesting",
-        "strategy",
-        "historical",
-        "performance",
-        "risk"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "transfer-learning-adapter",
-      "source": "./plugins/ai-ml/transfer-learning-adapter",
-      "description": "Transfer learning adaptation",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "transfer-learning",
-        "fine-tuning",
-        "pretrained",
-        "adapters",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "travel-assistant",
-      "source": "./plugins/productivity/travel-assistant",
-      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
-      "version": "1.15.0",
+      "name": "000-jeremy-content-consistency-validator",
+      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
+      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
+      "version": "3.29.0",
       "category": "productivity",
       "keywords": [
-        "travel",
-        "weather",
-        "currency",
-        "timezone",
-        "itinerary",
-        "vacation",
-        "trip-planning",
-        "ai-travel",
-        "real-time",
-        "api-integration",
-        "budget",
-        "packing-list"
+        "documentation",
+        "consistency",
+        "validation",
+        "drift-detection",
+        "source-of-truth",
+        "authority-registry",
+        "content-audit",
+        "quality-assurance",
+        "release-gate",
+        "standards"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
-      "name": "unit-test-generator",
-      "source": "./plugins/testing/unit-test-generator",
-      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
-      "version": "1.21.0",
-      "category": "testing",
+      "name": "002-jeremy-yaml-master-agent",
+      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
+      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
+      "version": "2.21.0",
+      "category": "productivity",
       "keywords": [
-        "testing",
-        "unit-tests",
-        "test-generation",
-        "jest",
-        "pytest",
-        "mocha",
-        "junit"
+        "yaml",
+        "validation",
+        "linting",
+        "schema",
+        "json",
+        "conversion",
+        "parsing",
+        "agent-skills"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
-      "name": "visual-regression-tester",
-      "source": "./plugins/testing/visual-regression-tester",
-      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
-      "version": "1.25.0",
-      "category": "testing",
+      "name": "003-jeremy-vertex-ai-media-master",
+      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
+      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
+      "version": "2.25.0",
+      "category": "productivity",
       "keywords": [
-        "testing",
-        "visual-regression",
-        "ui-testing",
-        "percy",
-        "chromatic",
-        "backstop",
-        "screenshot-testing"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "vulnerability-scanner",
-      "source": "./plugins/security/vulnerability-scanner",
-      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "vulnerability",
-        "scanning",
-        "cve",
-        "sast"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "wallet-portfolio-tracker",
-      "source": "./plugins/crypto/wallet-portfolio-tracker",
-      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
-      "version": "1.12.0",
-      "category": "crypto",
-      "keywords": [
-        "wallet",
-        "portfolio",
-        "tracking",
-        "blockchain",
-        "defi",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "web-to-github-issue",
-      "source": "./plugins/skill-enhancers/web-to-github-issue",
-      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
-      "version": "1.27.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "web-search",
-        "github",
-        "automation",
-        "research",
-        "issue-tracking",
-        "skill-enhancer",
-        "productivity",
-        "workflow"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team",
-        "email": "[email protected]"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "webhook-handler-creator",
-      "source": "./plugins/api-development/webhook-handler-creator",
-      "description": "Create secure webhook endpoints with signature verification and retry logic",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "webhook",
-        "events",
-        "signature",
-        "security"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "websocket-server-builder",
-      "source": "./plugins/api-development/websocket-server-builder",
-      "description": "Build WebSocket servers for real-time bidirectional communication",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "websocket",
-        "real-time",
-        "socket.io",
-        "ws"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "whale-alert-monitor",
-      "source": "./plugins/crypto/whale-alert-monitor",
-      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "whale",
-        "alert",
-        "monitor",
-        "large",
-        "transactions"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "workflow-orchestrator",
-      "source": "./plugins/mcp/workflow-orchestrator",
-      "description": "DAG-based workflow automation with parallel task execution and dependency management",
-      "version": "1.15.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "workflow",
-        "dag",
-        "automation",
-        "orchestration",
-        "cicd",
-        "parallel-execution"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "xss-vulnerability-scanner",
-      "source": "./plugins/security/xss-vulnerability-scanner",
-      "description": "Scan for XSS vulnerabilities",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "zapier-zap-builder",
-      "source": "./plugins/ai-agency/zapier-zap-builder",
-      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
-      "version": "1.10.0",
-      "category": "ai-agency",
-      "keywords": [
-        "zapier",
-        "zap",
-        "automation",
-        "integration",
-        "workflow",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "jeremy-genkit-pro",
-      "source": "./plugins/ai-ml/jeremy-genkit-pro",
-      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
-      "version": "2.26.0",
-      "category": "ai-ml",
-      "keywords": [
-        "firebase",
-        "genkit",
-        "ai-flows",
-        "rag",
-        "monitoring",
+        "vertex-ai",
         "gemini",
+        "multimodal",
+        "video-processing",
+        "audio-generation",
+        "image-generation",
+        "marketing",
+        "campaigns",
+        "content-generation",
+        "imagen",
+        "media-production",
+        "google-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "004-jeremy-google-cloud-agent-sdk",
+      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
+      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
+      "version": "2.24.0",
+      "category": "productivity",
+      "keywords": [
+        "agent-development-kit",
+        "adk",
+        "agent-starter-pack",
+        "multi-agent",
+        "containerized-agents",
+        "cloud-run",
+        "gke",
+        "agent-engine",
+        "rag-agents",
+        "react-agents",
+        "google-cloud",
         "vertex-ai"
       ],
       "author": {
@@ -4709,36 +5339,260 @@
       }
     },
     {
-      "name": "jeremy-adk-orchestrator",
-      "source": "./plugins/ai-ml/jeremy-adk-orchestrator",
-      "description": "Production ADK orchestrator for A2A protocol and multi-agent coordination on Vertex AI",
-      "version": "2.29.0",
-      "category": "ai-ml",
+      "name": "agent-context-manager",
+      "source": "./plugins/productivity/agent-context-manager",
+      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
+      "version": "1.23.0",
+      "category": "productivity",
       "keywords": [
-        "vertex-ai",
-        "adk",
-        "a2a-protocol",
-        "multi-agent",
-        "code-execution",
-        "memory-bank"
+        "agents",
+        "context",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore"
+      }
+    },
+    {
+      "name": "ai-commit-gen",
+      "source": "./plugins/productivity/ai-commit-gen",
+      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
+      "version": "1.10.0",
+      "category": "productivity",
+      "keywords": [
+        "git",
+        "commit",
+        "conventional-commits",
+        "ai",
+        "automation",
+        "productivity",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "box-cloud-filesystem",
+      "source": "./plugins/productivity/box-cloud-filesystem",
+      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "box",
+        "cloud-storage",
+        "filesystem",
+        "file-sync",
+        "box-cli",
+        "upload",
+        "download",
+        "document-management",
+        "collaboration",
+        "ai-agent-storage"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
-      }
+      },
+      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT"
     },
     {
-      "name": "jeremy-vertex-validator",
-      "source": "./plugins/ai-ml/jeremy-vertex-validator",
-      "description": "Production readiness validator for Vertex AI deployments and configurations",
-      "version": "2.22.0",
-      "category": "ai-ml",
+      "name": "claude-workflow-skills",
+      "source": "./plugins/productivity/claude-workflow-skills",
+      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
+      "version": "1.7.1",
+      "category": "productivity",
       "keywords": [
-        "vertex-ai",
-        "validation",
-        "production-readiness",
+        "workflow",
+        "promote",
+        "release",
+        "audit",
+        "standards",
+        "improve",
+        "triage",
+        "git",
+        "review",
+        "pull-request"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
+      "repository": "https://github.com/ali5ter/claude-workflow-skills",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "cli-power-skills",
+      "source": "./plugins/productivity/cli-power-skills",
+      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "cli-tools",
+        "agentic-skills",
+        "data-processing",
         "security",
-        "compliance"
+        "web-crawling",
+        "python",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Yuriy Kotik",
+        "url": "https://github.com/ykotik"
+      },
+      "repository": "https://github.com/ykotik/cli-power-skills",
+      "license": "MIT"
+    },
+    {
+      "name": "content-multiplier",
+      "source": "./plugins/productivity/content-multiplier",
+      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
+      "version": "0.2.1",
+      "category": "productivity",
+      "keywords": [
+        "marketing",
+        "content",
+        "repurposing",
+        "brand-voice",
+        "localization",
+        "social-media"
+      ],
+      "author": {
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
+      },
+      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
+    },
+    {
+      "name": "hyperfocus",
+      "source": "./plugins/productivity/hyperfocus",
+      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
+      "version": "0.2.0",
+      "category": "productivity",
+      "author": {
+        "name": "Nestor Magalhaes",
+        "email": "nestor.magalhaes@appex.world"
+      },
+      "keywords": [
+        "accessibility",
+        "adhd",
+        "neurodivergent",
+        "formatting",
+        "readability",
+        "productivity",
+        "cognitive-accessibility"
+      ],
+      "repository": "https://github.com/nextor2k/hyperfocus",
+      "homepage": "https://github.com/nextor2k/hyperfocus",
+      "license": "MIT"
+    },
+    {
+      "name": "intent-labs-pack",
+      "source": "./plugins/productivity/intent-labs-pack",
+      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "audit-tests",
+        "validate-skillmd",
+        "testing",
+        "skill-validation",
+        "intent-eval",
+        "dogfood"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4746,20 +5600,17 @@
       }
     },
     {
-      "name": "jeremy-google-adk",
-      "source": "./plugins/ai-ml/jeremy-google-adk",
-      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
-      "version": "2.2.0",
-      "category": "ai-ml",
+      "name": "j-rig",
+      "source": "./plugins/productivity/j-rig",
+      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
+      "version": "0.1.0",
+      "category": "productivity",
       "keywords": [
-        "google",
-        "adk",
-        "agent-development-kit",
-        "ai-agents",
-        "react-pattern",
-        "multi-agent",
-        "vertex-ai",
-        "agent-engine"
+        "skill-refiner",
+        "eval-guided",
+        "skill-md",
+        "meta-tooling",
+        "hooks"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4767,20 +5618,151 @@
       }
     },
     {
-      "name": "jeremy-vertex-ai",
-      "source": "./plugins/ai-ml/jeremy-vertex-ai",
-      "description": "Build and deploy generative AI agents on Vertex AI: Gemini model selection, RAG with grounded retrieval, function calling, multimodal extraction, evaluation, and Agent Engine deployment with operational guardrails.",
-      "version": "2.2.0",
-      "category": "ai-ml",
+      "name": "navigating-github",
+      "source": "./plugins/productivity/navigating-github",
+      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
+      "version": "2.5.0",
+      "category": "productivity",
       "keywords": [
-        "vertex-ai",
-        "gemini",
-        "google-cloud",
-        "generative-ai",
-        "rag",
-        "agent-engine",
-        "function-calling",
-        "multimodal"
+        "github",
+        "git",
+        "learning",
+        "onboarding",
+        "beginner-friendly",
+        "interactive-learning",
+        "version-control",
+        "vibe-coding",
+        "setup",
+        "collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/jeremylongshore/navigating-github"
+    },
+    {
+      "name": "neurodivergent-visual-org",
+      "source": "./plugins/productivity/neurodivergent-visual-org",
+      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
+      "version": "3.10.0",
+      "category": "productivity",
+      "keywords": [
+        "neurodivergent",
+        "adhd",
+        "autism",
+        "accessibility",
+        "mermaid-diagrams",
+        "visual-organization",
+        "task-breakdown",
+        "decision-trees"
+      ],
+      "author": {
+        "name": "Jack Reis",
+        "url": "https://github.com/JackReis"
+      },
+      "repository": "https://github.com/JackReis/neurodivergent-visual-org"
+    },
+    {
+      "name": "obsidian-project-documentation",
+      "source": "./plugins/productivity/obsidian-project-documentation",
+      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
+      "version": "3.2.5",
+      "category": "productivity",
+      "keywords": [
+        "obsidian",
+        "documentation",
+        "notes",
+        "projects"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
+      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
+      "license": "MIT"
+    },
+    {
+      "name": "over-50s-health",
+      "source": "./plugins/productivity/over-50s-health",
+      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
+      "version": "3.3.0",
+      "category": "productivity",
+      "keywords": [
+        "health",
+        "fitness",
+        "nutrition",
+        "longevity",
+        "50+"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
+      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
+      "license": "MIT"
+    },
+    {
+      "name": "overnight-dev",
+      "source": "./plugins/productivity/overnight-dev",
+      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
+      "version": "1.29.0",
+      "category": "productivity",
+      "keywords": [
+        "overnight",
+        "autonomous",
+        "tdd",
+        "testing",
+        "git-hooks",
+        "automation",
+        "continuous-integration",
+        "test-driven-development",
+        "productivity"
+      ],
+      "author": {
+        "name": "Intent Solutions IO",
+        "url": "https://intentsolutions.io",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "pair-programmer",
+      "source": "./plugins/productivity/pair-programmer",
+      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "pair-programming",
+        "coding",
+        "skill-development",
+        "graduated-assistance"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/pair-programmer",
+      "repository": "https://github.com/ali5ter/pair-programmer",
+      "license": "MIT"
+    },
+    {
+      "name": "plane",
+      "source": "./plugins/productivity/plane",
+      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+      "version": "0.3.0",
+      "category": "productivity",
+      "keywords": [
+        "plane",
+        "project-management",
+        "team-behavior",
+        "observability",
+        "productivity",
+        "agent-skills",
+        "forge-generated"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4788,123 +5770,22 @@
       }
     },
     {
-      "name": "jeremy-genkit-terraform",
-      "source": "./plugins/devops/jeremy-genkit-terraform",
-      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
-      "version": "2.21.0",
-      "category": "devops",
+      "name": "pm-ai-partner",
+      "source": "./plugins/productivity/pm-ai-partner",
+      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
+      "version": "1.8.0",
+      "category": "productivity",
       "keywords": [
-        "terraform",
-        "genkit",
-        "firebase",
-        "cloud-run",
-        "infrastructure"
+        "product-management",
+        "pm",
+        "ai-partner",
+        "skills",
+        "commands",
+        "hooks"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-adk-terraform",
-      "source": "./plugins/devops/jeremy-adk-terraform",
-      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
-      "version": "2.22.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "adk",
-        "agent-engine",
-        "vertex-ai",
-        "infrastructure",
-        "vpc-sc"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-vertex-terraform",
-      "source": "./plugins/devops/jeremy-vertex-terraform",
-      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
-      "version": "2.22.0",
-      "category": "devops",
-      "keywords": [
-        "terraform",
-        "vertex-ai",
-        "gemini",
-        "model-garden",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-vertex-engine",
-      "source": "./plugins/ai-ml/jeremy-vertex-engine",
-      "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
-      "version": "2.31.0",
-      "category": "ai-ml",
-      "keywords": [
-        "vertex-ai",
-        "agent-engine",
-        "runtime-inspector",
-        "agent-monitoring",
-        "compliance",
-        "production-validation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-gcp-starter-examples",
-      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
-      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
-      "version": "2.25.0",
-      "category": "ai-ml",
-      "keywords": [
-        "google-cloud",
-        "adk-samples",
-        "genkit-examples",
-        "vertex-ai",
-        "agent-starter-pack",
-        "code-examples",
-        "starter-kits",
-        "templates"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-github-actions-gcp",
-      "source": "./plugins/devops/jeremy-github-actions-gcp",
-      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
-      "version": "2.27.0",
-      "category": "devops",
-      "keywords": [
-        "github-actions",
-        "google-cloud",
-        "workload-identity-federation",
-        "wif",
-        "vertex-ai",
-        "agent-engine",
-        "deployment",
-        "ci-cd",
-        "security",
-        "best-practices",
-        "oidc",
-        "iam"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "name": "Ahmed Khaled",
+        "email": "ahmd.khaled.a.mohamed@gmail.com"
       }
     },
     {
@@ -4930,119 +5811,84 @@
       }
     },
     {
-      "name": "axiom",
-      "source": "./plugins/skill-enhancers/axiom",
-      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
-      "version": "0.3.0",
-      "category": "skill-enhancers",
+      "name": "publishing-skills",
+      "source": "./plugins/productivity/publishing-skills",
+      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
+      "version": "0.1.0",
+      "category": "productivity",
       "keywords": [
-        "ios",
-        "debugging",
-        "swift",
-        "persistence",
-        "testing",
-        "performance",
-        "xcode",
-        "concurrency",
-        "database",
-        "swiftdata",
-        "grdb",
-        "liquid-glass",
-        "swiftui"
+        "ghost",
+        "blogging",
+        "seo",
+        "content-creation",
+        "publishing",
+        "claude-code",
+        "ai-writing"
       ],
       "author": {
-        "name": "Charles Wiltgen",
-        "url": "https://github.com/CharlesWiltgen"
-      }
+        "name": "AutomateLab",
+        "url": "https://github.com/AutomateLab-tech",
+        "email": "hello@automatelab.tech"
+      },
+      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
+      "license": "MIT-0"
     },
     {
-      "name": "skill-creator",
-      "source": "./plugins/skill-enhancers/skill-creator",
-      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.20.0",
-      "category": "skill-enhancers",
+      "name": "schedule-after-usage-reset",
+      "source": "./plugins/productivity/schedule-after-usage-reset",
+      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
+      "version": "1.0.0",
+      "category": "productivity",
       "keywords": [
-        "skill-creation",
-        "validation",
-        "meta-tooling",
-        "grading",
-        "anthropic-spec"
+        "schedule",
+        "usage-reset",
+        "rate-limit",
+        "claude-code",
+        "automation"
+      ],
+      "author": {
+        "name": "patricksong1993",
+        "url": "https://github.com/patricksong1993"
+      },
+      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "license": "MIT"
+    },
+    {
+      "name": "skyvern",
+      "source": "./plugins/productivity/skyvern",
+      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
+      "version": "0.1.0",
+      "category": "productivity",
+      "author": {
+        "name": "Skyvern-AI",
+        "url": "https://github.com/Skyvern-AI"
+      },
+      "license": "AGPL-3.0"
+    },
+    {
+      "name": "travel-assistant",
+      "source": "./plugins/productivity/travel-assistant",
+      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
+      "version": "1.15.0",
+      "category": "productivity",
+      "keywords": [
+        "travel",
+        "weather",
+        "currency",
+        "timezone",
+        "itinerary",
+        "vacation",
+        "trip-planning",
+        "ai-travel",
+        "real-time",
+        "api-integration",
+        "budget",
+        "packing-list"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "claude-never-forgets",
-      "source": "./plugins/community/claude-never-forgets",
-      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
-      "version": "1.21.0",
-      "category": "community",
-      "keywords": [
-        "memory",
-        "context",
-        "persistent",
-        "preferences",
-        "sessions",
-        "recall"
-      ],
-      "author": {
-        "name": "yldrmahmet",
-        "url": "https://github.com/yldrmahmet"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "research",
-        "games",
-        "accessibility",
-        "performance",
-        "flask",
-        "react",
-        "godot",
-        "corpus-linguistics",
-        "mcp"
-      ],
-      "author": {
-        "name": "Luke Steuber",
-        "url": "https://github.com/lukeslp"
-      }
-    },
-    {
-      "name": "sprint",
-      "source": "./plugins/community/sprint",
-      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
-      "version": "1.20.0",
-      "category": "community",
-      "keywords": [
-        "autonomous",
-        "agentic",
-        "yolo",
-        "self-iterating",
-        "multi-agent",
-        "hands-off",
-        "auto-pilot",
-        "orchestration",
-        "sprint",
-        "testing",
-        "qa",
-        "mcp"
-      ],
-      "author": {
-        "name": "Damien Laine",
-        "email": "damien.laine@gmail.com",
-        "url": "https://github.com/damienlaine"
+        "email": "[email protected]"
       }
     },
     {
@@ -5073,1313 +5919,6 @@
       "strict": true
     },
     {
-      "name": "jeremy-adk-software-engineer",
-      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
-      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
-      "version": "2.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "adk",
-        "software-engineer",
-        "agent-development",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "mcp",
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "geepers",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Luke Steuber"
-      },
-      "homepage": "https://dr.eamer.dev/geepers/",
-      "repository": "https://github.com/lukeslp/geepers"
-    },
-    {
-      "name": "jeremy-firebase",
-      "source": "./plugins/community/jeremy-firebase",
-      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
-      "version": "2.23.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "vertex-ai",
-        "gemini",
-        "authentication",
-        "storage",
-        "hosting",
-        "cloud-functions",
-        "analytics",
-        "ai-integration",
-        "google-cloud",
-        "embeddings",
-        "model-deployment",
-        "ai-powered",
-        "production-ready"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "wallet-security-auditor",
-      "source": "./plugins/crypto/wallet-security-auditor",
-      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
-      "version": "1.17.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "wallet",
-        "security",
-        "audit",
-        "web3"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "mattyp-changelog",
-      "source": "./plugins/devops/mattyp-changelog",
-      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
-      "version": "0.3.0",
-      "category": "devops",
-      "keywords": [
-        "changelog",
-        "release-notes",
-        "weekly-update",
-        "git",
-        "github",
-        "automation"
-      ],
-      "author": {
-        "name": "Mattyp",
-        "email": "mattyp@tonsofskills.com",
-        "url": "https://tonsofskills.com"
-      }
-    },
-    {
-      "name": "supabase-pack",
-      "source": "./plugins/saas-packs/supabase-pack",
-      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.53.0",
-      "category": "saas-packs",
-      "keywords": [
-        "supabase",
-        "postgres",
-        "database",
-        "authentication",
-        "realtime",
-        "storage",
-        "edge-functions",
-        "rls",
-        "row-level-security",
-        "baas",
-        "backend-as-a-service",
-        "firebase-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "vercel-pack",
-      "source": "./plugins/saas-packs/vercel-pack",
-      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vercel",
-        "deployment",
-        "edge-functions",
-        "serverless",
-        "preview",
-        "ci-cd",
-        "hosting",
-        "next-js",
-        "jamstack",
-        "frontend-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "clay-pack",
-      "source": "./plugins/saas-packs/clay-pack",
-      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clay",
-        "data-enrichment",
-        "waterfall",
-        "gtm",
-        "sales-ops",
-        "lead-enrichment",
-        "ai-agents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "cursor-pack",
-      "source": "./plugins/saas-packs/cursor-pack",
-      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "cursor",
-        "ai-editor",
-        "code-editor",
-        "composer",
-        "ai-coding",
-        "vscode-fork",
-        "copilot-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "exa-pack",
-      "source": "./plugins/saas-packs/exa-pack",
-      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "exa",
-        "neural-search",
-        "semantic-search",
-        "web-search",
-        "ai-search",
-        "retrieval",
-        "embeddings"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "firecrawl-pack",
-      "source": "./plugins/saas-packs/firecrawl-pack",
-      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "firecrawl",
-        "web-scraping",
-        "crawling",
-        "markdown",
-        "llm-ready",
-        "data-extraction",
-        "scraper"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "klingai-pack",
-      "source": "./plugins/saas-packs/klingai-pack",
-      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "klingai",
-        "kling",
-        "video-generation",
-        "text-to-video",
-        "ai-video",
-        "generative-ai",
-        "creative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "openrouter-pack",
-      "source": "./plugins/saas-packs/openrouter-pack",
-      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-      "version": "1.20.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openrouter",
-        "llm-routing",
-        "model-selection",
-        "ai-gateway",
-        "multi-model",
-        "cost-optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "perplexity-pack",
-      "source": "./plugins/saas-packs/perplexity-pack",
-      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "perplexity",
-        "ai-search",
-        "research",
-        "citations",
-        "real-time",
-        "knowledge",
-        "answers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "replit-pack",
-      "source": "./plugins/saas-packs/replit-pack",
-      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "replit",
-        "cloud-ide",
-        "deployments",
-        "collaborative",
-        "ai-coding",
-        "browser-ide",
-        "hosting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "retellai-pack",
-      "source": "./plugins/saas-packs/retellai-pack",
-      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
-      "version": "1.9.0",
-      "category": "saas-packs",
-      "keywords": [
-        "retellai",
-        "retell",
-        "voice-ai",
-        "phone-agents",
-        "conversational-ai",
-        "call-center",
-        "ivr"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "sentry-pack",
-      "source": "./plugins/saas-packs/sentry-pack",
-      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
-      "version": "1.51.0",
-      "category": "saas-packs",
-      "keywords": [
-        "sentry",
-        "error-monitoring",
-        "performance",
-        "observability",
-        "debugging",
-        "crash-reporting",
-        "apm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "windsurf-pack",
-      "source": "./plugins/saas-packs/windsurf-pack",
-      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "windsurf",
-        "ai-editor",
-        "cascade",
-        "codeium",
-        "ai-coding",
-        "code-completion",
-        "refactoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "coderabbit-pack",
-      "source": "./plugins/saas-packs/coderabbit-pack",
-      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "coderabbit",
-        "code-review",
-        "pr-automation",
-        "ai-review",
-        "code-quality",
-        "github-integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "fireflies-pack",
-      "source": "./plugins/saas-packs/fireflies-pack",
-      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "fireflies",
-        "meeting-transcription",
-        "ai-notes",
-        "conversation-intelligence",
-        "summaries"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "groq-pack",
-      "source": "./plugins/saas-packs/groq-pack",
-      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "groq",
-        "lpu",
-        "fast-inference",
-        "llm",
-        "groq-cloud",
-        "low-latency",
-        "ai-acceleration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "ideogram-pack",
-      "source": "./plugins/saas-packs/ideogram-pack",
-      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
-      "version": "1.10.0",
-      "category": "saas-packs",
-      "keywords": [
-        "ideogram",
-        "image-generation",
-        "text-to-image",
-        "ai-art",
-        "typography",
-        "creative",
-        "design"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "instantly-pack",
-      "source": "./plugins/saas-packs/instantly-pack",
-      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "instantly",
-        "cold-email",
-        "outreach",
-        "email-automation",
-        "lead-generation",
-        "sales"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "posthog-pack",
-      "source": "./plugins/saas-packs/posthog-pack",
-      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "posthog",
-        "product-analytics",
-        "feature-flags",
-        "session-replay",
-        "ab-testing",
-        "experimentation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "vastai-pack",
-      "source": "./plugins/saas-packs/vastai-pack",
-      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vastai",
-        "vast-ai",
-        "gpu-marketplace",
-        "cloud-gpu",
-        "ml-infrastructure",
-        "compute",
-        "training"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "apollo-pack",
-      "source": "./plugins/saas-packs/apollo-pack",
-      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "apollo",
-        "sales",
-        "prospecting",
-        "sequences",
-        "outbound",
-        "crm",
-        "sales-engagement",
-        "lead-generation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "deepgram-pack",
-      "source": "./plugins/saas-packs/deepgram-pack",
-      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "deepgram",
-        "speech-to-text",
-        "transcription",
-        "voice",
-        "audio",
-        "asr",
-        "real-time",
-        "voice-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "juicebox-pack",
-      "source": "./plugins/saas-packs/juicebox-pack",
-      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
-      "version": "1.16.0",
-      "category": "saas-packs",
-      "keywords": [
-        "juicebox",
-        "people-data",
-        "enrichment",
-        "contacts",
-        "search",
-        "data-api",
-        "lead-enrichment"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "customerio-pack",
-      "source": "./plugins/saas-packs/customerio-pack",
-      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "customerio",
-        "customer-io",
-        "marketing",
-        "email",
-        "automation",
-        "campaigns",
-        "sms",
-        "push-notifications"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "langchain-py-pack",
-      "source": "./plugins/saas-packs/langchain-py-pack",
-      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
-      "version": "2.5.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langchain",
-        "langgraph",
-        "python",
-        "llm",
-        "agents",
-        "rag",
-        "checkpointing",
-        "streaming",
-        "middleware",
-        "langsmith"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "lindy-pack",
-      "source": "./plugins/saas-packs/lindy-pack",
-      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
-      "version": "1.15.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lindy",
-        "ai-assistant",
-        "automation",
-        "workflows",
-        "tasks",
-        "intelligent-automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "granola-pack",
-      "source": "./plugins/saas-packs/granola-pack",
-      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "granola",
-        "meeting-notes",
-        "transcription",
-        "summaries",
-        "meetings",
-        "ai-notes",
-        "meeting-intelligence"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "ga4-pack",
-      "source": "./plugins/saas-packs/ga4-pack",
-      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
-      "version": "1.2.0",
-      "category": "saas-packs",
-      "keywords": [
-        "google-analytics",
-        "ga4",
-        "analytics",
-        "data-api",
-        "bigquery",
-        "reporting",
-        "dau-mau",
-        "cohort-retention"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "gamma-pack",
-      "source": "./plugins/saas-packs/gamma-pack",
-      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "gamma",
-        "presentations",
-        "documents",
-        "ai-generation",
-        "templates",
-        "slides",
-        "visual-content"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "clerk-pack",
-      "source": "./plugins/saas-packs/clerk-pack",
-      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clerk",
-        "authentication",
-        "auth",
-        "users",
-        "identity",
-        "sso",
-        "embeddable-ui",
-        "user-management"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "linear-pack",
-      "source": "./plugins/saas-packs/linear-pack",
-      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "linear",
-        "issues",
-        "project-management",
-        "tracking",
-        "workflows",
-        "agile",
-        "team-collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "databricks-pack",
-      "source": "./plugins/saas-packs/databricks-pack",
-      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
-      "version": "2.27.0",
-      "category": "saas-packs",
-      "keywords": [
-        "databricks",
-        "delta-lake",
-        "mlflow",
-        "spark",
-        "notebooks",
-        "clusters",
-        "data-engineering",
-        "lakehouse"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "mistral-pack",
-      "source": "./plugins/saas-packs/mistral-pack",
-      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "mistral",
-        "llm",
-        "inference",
-        "embeddings",
-        "fine-tuning",
-        "ai",
-        "machine-learning"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "langfuse-pack",
-      "source": "./plugins/saas-packs/langfuse-pack",
-      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langfuse",
-        "observability",
-        "tracing",
-        "prompts",
-        "evaluation",
-        "llm-ops",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "obsidian-pack",
-      "source": "./plugins/saas-packs/obsidian-pack",
-      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "obsidian",
-        "notes",
-        "vault",
-        "plugins",
-        "markdown",
-        "knowledge-management",
-        "pkm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "documenso-pack",
-      "source": "./plugins/saas-packs/documenso-pack",
-      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "documenso",
-        "document-signing",
-        "e-signature",
-        "templates",
-        "workflows",
-        "contracts",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "evernote-pack",
-      "source": "./plugins/saas-packs/evernote-pack",
-      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "evernote",
-        "notes",
-        "notebooks",
-        "tags",
-        "search",
-        "productivity",
-        "organization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "guidewire-pack",
-      "source": "./plugins/saas-packs/guidewire-pack",
-      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
-      "version": "1.25.0",
-      "category": "saas-packs",
-      "keywords": [
-        "guidewire",
-        "insurance",
-        "policycenter",
-        "claimcenter",
-        "billingcenter",
-        "insurancesuite",
-        "enterprise"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "lokalise-pack",
-      "source": "./plugins/saas-packs/lokalise-pack",
-      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lokalise",
-        "translation",
-        "localization",
-        "i18n",
-        "l10n",
-        "tms",
-        "internationalization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "maintainx-pack",
-      "source": "./plugins/saas-packs/maintainx-pack",
-      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "maintainx",
-        "cmms",
-        "work-orders",
-        "maintenance",
-        "assets",
-        "facilities",
-        "operations"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "openevidence-pack",
-      "source": "./plugins/saas-packs/openevidence-pack",
-      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openevidence",
-        "medical-ai",
-        "clinical",
-        "healthcare",
-        "evidence-based",
-        "decision-support",
-        "medicine"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "speak-pack",
-      "source": "./plugins/saas-packs/speak-pack",
-      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "speak",
-        "language-learning",
-        "speech",
-        "ai-tutor",
-        "education",
-        "conversation",
-        "edtech"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "twinmind-pack",
-      "source": "./plugins/saas-packs/twinmind-pack",
-      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "twinmind",
-        "meetings",
-        "transcription",
-        "summaries",
-        "ai-assistant",
-        "productivity",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "gastown",
-      "source": "./plugins/community/gastown",
-      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "multi-agent",
-        "orchestration",
-        "automation",
-        "polecats",
-        "convoys",
-        "beads",
-        "work-tracking",
-        "ai-factory",
-        "gastown",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      }
-    },
-    {
-      "name": "zai-cli",
-      "source": "./plugins/community/zai-cli",
-      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "vision",
-        "image-analysis",
-        "ocr",
-        "web-search",
-        "web-reader",
-        "github",
-        "mcp",
-        "z-ai",
-        "glm-4",
-        "multimodal"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      }
-    },
-    {
-      "name": "claude-reflect",
-      "source": "./plugins/community/claude-reflect",
-      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": [
-        "claude-code",
-        "self-learning",
-        "corrections",
-        "CLAUDE.md",
-        "memory",
-        "learnings",
-        "hooks",
-        "automation"
-      ],
-      "author": {
-        "name": "Bayram Annakov",
-        "url": "https://github.com/bayramannakov"
-      },
-      "repository": "https://github.com/bayramannakov/claude-reflect"
-    },
-    {
-      "name": "contributing-clanker",
-      "source": "./plugins/community/contributing-clanker",
-      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
-      "version": "0.8.0",
-      "category": "community",
-      "keywords": [
-        "oss",
-        "contributions",
-        "github",
-        "ai-slop-prevention",
-        "code-review",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
-      "repository": "https://github.com/jeremylongshore/contributing-clanker",
-      "license": "MIT"
-    },
-    {
-      "name": "neurodivergent-visual-org",
-      "source": "./plugins/productivity/neurodivergent-visual-org",
-      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
-      "version": "3.10.0",
-      "category": "productivity",
-      "keywords": [
-        "neurodivergent",
-        "adhd",
-        "autism",
-        "accessibility",
-        "mermaid-diagrams",
-        "visual-organization",
-        "task-breakdown",
-        "decision-trees"
-      ],
-      "author": {
-        "name": "Jack Reis",
-        "url": "https://github.com/JackReis"
-      },
-      "repository": "https://github.com/JackReis/neurodivergent-visual-org"
-    },
-    {
-      "name": "gh-dash",
-      "source": "./plugins/devops/gh-dash",
-      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
-      "version": "1.6.0",
-      "category": "devops",
-      "keywords": [
-        "github",
-        "pull-request",
-        "ci-cd",
-        "dashboard",
-        "devops",
-        "merge",
-        "code-review"
-      ],
-      "author": {
-        "name": "Jake Kozloski",
-        "email": "jakozloski@gmail.com"
-      }
-    },
-    {
-      "name": "youtube-strategy",
-      "source": "./plugins/productivity/youtube-strategy",
-      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
-      "version": "1.10.0",
-      "category": "productivity",
-      "keywords": [
-        "youtube",
-        "content-strategy",
-        "video-production",
-        "ideation",
-        "research",
-        "thumbnails",
-        "titles",
-        "outlining",
-        "content-creation"
-      ],
-      "author": {
-        "name": "Claude Code Plugins"
-      }
-    },
-    {
-      "name": "b12-claude-plugin",
-      "source": "./plugins/community/b12-claude-plugin",
-      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
-      "version": "1.9.0",
-      "category": "community",
-      "keywords": [
-        "website",
-        "b12",
-        "hosting",
-        "web-design",
-        "ai-website",
-        "website-generator",
-        "saas"
-      ],
-      "author": {
-        "name": "B12.io",
-        "url": "https://github.com/b12io"
-      }
-    },
-    {
-      "name": "wondelai-blue-ocean-strategy",
-      "source": "./plugins/business-tools/wondelai-blue-ocean-strategy",
-      "description": "Blue Ocean Strategy framework for creating uncontested market space. Use the Strategy Canvas, Four Actions Framework (ERRC), and value innovation to break the value-cost trade-off.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "strategy",
-        "blue-ocean",
-        "value-innovation",
-        "market-creation",
-        "errc",
-        "strategy-canvas",
-        "competition",
-        "positioning"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-contagious",
-      "source": "./plugins/business-tools/wondelai-contagious",
-      "description": "Word-of-mouth and virality framework using the STEPPS model (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Engineer products and content that people naturally share.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "virality",
-        "word-of-mouth",
-        "stepps",
-        "social-currency",
-        "marketing",
-        "content-strategy",
-        "sharing",
-        "growth"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-cro-methodology",
-      "source": "./plugins/business-tools/wondelai-cro-methodology",
-      "description": "Customer-centric conversion rate optimization methodology. Audit landing pages, identify conversion blockers, write persuasive copy, design A/B tests, and optimize funnels.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "cro",
-        "conversion",
-        "optimization",
-        "landing-pages",
-        "ab-testing",
-        "copywriting",
-        "persuasion",
-        "funnels"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-crossing-the-chasm",
-      "source": "./plugins/business-tools/wondelai-crossing-the-chasm",
-      "description": "Technology adoption and go-to-market strategy for crossing from early adopters to mainstream market. Choose beachhead segments, build whole products, and position against incumbents.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "go-to-market",
-        "technology-adoption",
-        "chasm",
-        "beachhead",
-        "b2b",
-        "saas",
-        "market-strategy",
-        "positioning"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-design-everyday-things",
-      "source": "./plugins/design/wondelai-design-everyday-things",
-      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "design",
-        "ux",
-        "affordances",
-        "signifiers",
-        "human-centered-design",
-        "usability",
-        "don-norman",
-        "hcd"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
       "name": "wondelai-design-sprint",
       "source": "./plugins/productivity/wondelai-design-sprint",
       "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
@@ -6394,144 +5933,6 @@
         "product-design",
         "rapid-iteration",
         "mvp"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-drive-motivation",
-      "source": "./plugins/business-tools/wondelai-drive-motivation",
-      "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "motivation",
-        "autonomy",
-        "mastery",
-        "purpose",
-        "engagement",
-        "gamification",
-        "intrinsic-motivation",
-        "team-management"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-hooked-ux",
-      "source": "./plugins/design/wondelai-hooked-ux",
-      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "habits",
-        "engagement",
-        "retention",
-        "hook-model",
-        "triggers",
-        "rewards",
-        "onboarding",
-        "ux"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-hundred-million-offers",
-      "source": "./plugins/business-tools/wondelai-hundred-million-offers",
-      "description": "Grand Slam Offer creation framework. Create irresistible offers using the Value Equation, stack bonuses, design risk-reversing guarantees, and apply ethical scarcity.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "offers",
-        "pricing",
-        "value-equation",
-        "guarantees",
-        "bonuses",
-        "scarcity",
-        "sales",
-        "hormozi"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-influence-psychology",
-      "source": "./plugins/business-tools/wondelai-influence-psychology",
-      "description": "Persuasion science framework based on Cialdini's six principles (Reciprocity, Commitment, Social Proof, Authority, Liking, Scarcity). Apply ethical persuasion to product design and marketing.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "persuasion",
-        "influence",
-        "cialdini",
-        "social-proof",
-        "reciprocity",
-        "scarcity",
-        "psychology",
-        "marketing"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-ios-hig-design",
-      "source": "./plugins/design/wondelai-ios-hig-design",
-      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ios",
-        "apple",
-        "hig",
-        "swiftui",
-        "uikit",
-        "mobile-design",
-        "accessibility",
-        "interface-guidelines"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-jobs-to-be-done",
-      "source": "./plugins/business-tools/wondelai-jobs-to-be-done",
-      "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "jtbd",
-        "jobs-to-be-done",
-        "product-strategy",
-        "customer-discovery",
-        "innovation",
-        "christensen",
-        "product-market-fit",
-        "interviews"
       ],
       "author": {
         "name": "Wondel.ai",
@@ -6564,307 +5965,25 @@
       "repository": "https://github.com/wondelai/skills"
     },
     {
-      "name": "navigating-github",
-      "source": "./plugins/productivity/navigating-github",
-      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
-      "version": "2.5.0",
+      "name": "youtube-strategy",
+      "source": "./plugins/productivity/youtube-strategy",
+      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
+      "version": "1.10.0",
       "category": "productivity",
       "keywords": [
-        "github",
-        "git",
-        "learning",
-        "onboarding",
-        "beginner-friendly",
-        "interactive-learning",
-        "version-control",
-        "vibe-coding",
-        "setup",
-        "collaboration"
+        "youtube",
+        "content-strategy",
+        "video-production",
+        "ideation",
+        "research",
+        "thumbnails",
+        "titles",
+        "outlining",
+        "content-creation"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/jeremylongshore/navigating-github"
-    },
-    {
-      "name": "wondelai-made-to-stick",
-      "source": "./plugins/business-tools/wondelai-made-to-stick",
-      "description": "Sticky messaging framework using the SUCCESs model (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Make product messaging memorable and create compelling presentations.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "messaging",
-        "storytelling",
-        "success",
-        "sticky",
-        "communication",
-        "presentations",
-        "copywriting",
-        "branding"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-negotiation",
-      "source": "./plugins/business-tools/wondelai-negotiation",
-      "description": "Tactical negotiation framework based on Chris Voss's techniques. Use mirroring, labeling, calibrated questions, the Ackerman method, and accusation audits for business and salary negotiations.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "negotiation",
-        "chris-voss",
-        "mirroring",
-        "labeling",
-        "ackerman",
-        "salary",
-        "deals",
-        "conflict-resolution"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-obviously-awesome",
-      "source": "./plugins/business-tools/wondelai-obviously-awesome",
-      "description": "Product positioning framework for competitive differentiation. Define competitive alternatives, identify unique attributes, map value themes, and choose the right market category.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "positioning",
-        "differentiation",
-        "competitive-analysis",
-        "market-category",
-        "value-proposition",
-        "april-dunford",
-        "go-to-market",
-        "branding"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-one-page-marketing",
-      "source": "./plugins/business-tools/wondelai-one-page-marketing",
-      "description": "End-to-end marketing plan framework. Define target market, craft USP, choose channels, design lead capture and nurture sequences, optimize conversion, and build referral systems.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "marketing-plan",
-        "usp",
-        "lead-generation",
-        "nurture",
-        "referral",
-        "advertising",
-        "customer-lifetime-value",
-        "marketing-strategy"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-predictable-revenue",
-      "source": "./plugins/business-tools/wondelai-predictable-revenue",
-      "description": "Outbound sales methodology for scalable B2B pipeline. Implement Cold Calling 2.0, structure SDR/AE/CSM roles, design prospecting sequences, and build predictable revenue engines.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "sales",
-        "outbound",
-        "sdr",
-        "pipeline",
-        "b2b",
-        "saas",
-        "prospecting",
-        "cold-calling",
-        "revenue"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-refactoring-ui",
-      "source": "./plugins/design/wondelai-refactoring-ui",
-      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ui-design",
-        "visual-hierarchy",
-        "typography",
-        "color-palette",
-        "tailwind",
-        "shadows",
-        "spacing",
-        "refactoring-ui"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-scorecard-marketing",
-      "source": "./plugins/business-tools/wondelai-scorecard-marketing",
-      "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "lead-generation",
-        "quiz-funnel",
-        "assessment",
-        "scorecard",
-        "conversion",
-        "segmentation",
-        "lead-magnet",
-        "marketing-automation"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-storybrand-messaging",
-      "source": "./plugins/business-tools/wondelai-storybrand-messaging",
-      "description": "StoryBrand messaging framework that positions customer as hero. Create brand scripts, write website copy that converts, craft one-liners, and build narrative-driven landing pages.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "storybrand",
-        "messaging",
-        "brand-script",
-        "copywriting",
-        "narrative",
-        "website-copy",
-        "one-liner",
-        "donald-miller"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-top-design",
-      "source": "./plugins/design/wondelai-top-design",
-      "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "web-design",
-        "awwwards",
-        "animations",
-        "typography",
-        "scroll-effects",
-        "brand-website",
-        "premium-design",
-        "motion"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-traction-eos",
-      "source": "./plugins/business-tools/wondelai-traction-eos",
-      "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "eos",
-        "traction",
-        "operating-system",
-        "rocks",
-        "l10-meetings",
-        "accountability",
-        "vision",
-        "execution"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-ux-heuristics",
-      "source": "./plugins/design/wondelai-ux-heuristics",
-      "description": "Usability heuristics and UX audit framework based on Nielsen and Krug. Conduct heuristic evaluations, identify usability problems, and prioritize fixes by severity.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ux",
-        "usability",
-        "heuristics",
-        "nielsen",
-        "krug",
-        "ux-audit",
-        "evaluation",
-        "accessibility"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-web-typography",
-      "source": "./plugins/design/wondelai-web-typography",
-      "description": "Web typography framework for readable, beautiful type. Select and pair typefaces, set optimal line length and height, implement responsive typography, and optimize web font loading.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "typography",
-        "web-fonts",
-        "typeface",
-        "font-pairing",
-        "readability",
-        "responsive-typography",
-        "css",
-        "type-hierarchy"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
+        "name": "Claude Code Plugins"
+      }
     },
     {
       "name": "abridge-pack",
@@ -6985,6 +6104,28 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "apollo-pack",
+      "source": "./plugins/saas-packs/apollo-pack",
+      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "apollo",
+        "sales",
+        "prospecting",
+        "sequences",
+        "outbound",
+        "crm",
+        "sales-engagement",
+        "lead-generation"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7158,6 +6299,49 @@
       }
     },
     {
+      "name": "clay-pack",
+      "source": "./plugins/saas-packs/clay-pack",
+      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clay",
+        "data-enrichment",
+        "waterfall",
+        "gtm",
+        "sales-ops",
+        "lead-enrichment",
+        "ai-agents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "clerk-pack",
+      "source": "./plugins/saas-packs/clerk-pack",
+      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clerk",
+        "authentication",
+        "auth",
+        "users",
+        "identity",
+        "sso",
+        "embeddable-ui",
+        "user-management"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "clickhouse-pack",
       "source": "./plugins/saas-packs/clickhouse-pack",
       "description": "Claude Code skill pack for ClickHouse (24 skills)",
@@ -7186,6 +6370,26 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "coderabbit-pack",
+      "source": "./plugins/saas-packs/coderabbit-pack",
+      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "coderabbit",
+        "code-review",
+        "pr-automation",
+        "ai-review",
+        "code-quality",
+        "github-integration"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7230,6 +6434,114 @@
       }
     },
     {
+      "name": "cursor-pack",
+      "source": "./plugins/saas-packs/cursor-pack",
+      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "cursor",
+        "ai-editor",
+        "code-editor",
+        "composer",
+        "ai-coding",
+        "vscode-fork",
+        "copilot-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "customerio-pack",
+      "source": "./plugins/saas-packs/customerio-pack",
+      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "customerio",
+        "customer-io",
+        "marketing",
+        "email",
+        "automation",
+        "campaigns",
+        "sms",
+        "push-notifications"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "databricks-pack",
+      "source": "./plugins/saas-packs/databricks-pack",
+      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
+      "version": "2.27.0",
+      "category": "saas-packs",
+      "keywords": [
+        "databricks",
+        "delta-lake",
+        "mlflow",
+        "spark",
+        "notebooks",
+        "clusters",
+        "data-engineering",
+        "lakehouse"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "deepgram-pack",
+      "source": "./plugins/saas-packs/deepgram-pack",
+      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "deepgram",
+        "speech-to-text",
+        "transcription",
+        "voice",
+        "audio",
+        "asr",
+        "real-time",
+        "voice-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "documenso-pack",
+      "source": "./plugins/saas-packs/documenso-pack",
+      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "documenso",
+        "document-signing",
+        "e-signature",
+        "templates",
+        "workflows",
+        "contracts",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "elevenlabs-pack",
       "source": "./plugins/saas-packs/elevenlabs-pack",
       "description": "Claude Code skill pack for ElevenLabs (18 skills)",
@@ -7240,6 +6552,48 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "evernote-pack",
+      "source": "./plugins/saas-packs/evernote-pack",
+      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "evernote",
+        "notes",
+        "notebooks",
+        "tags",
+        "search",
+        "productivity",
+        "organization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "exa-pack",
+      "source": "./plugins/saas-packs/exa-pack",
+      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "exa",
+        "neural-search",
+        "semantic-search",
+        "web-search",
+        "ai-search",
+        "retrieval",
+        "embeddings"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7294,6 +6648,46 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "firecrawl-pack",
+      "source": "./plugins/saas-packs/firecrawl-pack",
+      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "firecrawl",
+        "web-scraping",
+        "crawling",
+        "markdown",
+        "llm-ready",
+        "data-extraction",
+        "scraper"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "fireflies-pack",
+      "source": "./plugins/saas-packs/fireflies-pack",
+      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "fireflies",
+        "meeting-transcription",
+        "ai-notes",
+        "conversation-intelligence",
+        "summaries"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7375,6 +6769,49 @@
       }
     },
     {
+      "name": "ga4-pack",
+      "source": "./plugins/saas-packs/ga4-pack",
+      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+      "version": "1.2.0",
+      "category": "saas-packs",
+      "keywords": [
+        "google-analytics",
+        "ga4",
+        "analytics",
+        "data-api",
+        "bigquery",
+        "reporting",
+        "dau-mau",
+        "cohort-retention"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "gamma-pack",
+      "source": "./plugins/saas-packs/gamma-pack",
+      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "gamma",
+        "presentations",
+        "documents",
+        "ai-generation",
+        "templates",
+        "slides",
+        "visual-content"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "glean-pack",
       "source": "./plugins/saas-packs/glean-pack",
       "description": "Claude Code skill pack for Glean (24 skills)",
@@ -7403,6 +6840,69 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "granola-pack",
+      "source": "./plugins/saas-packs/granola-pack",
+      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "granola",
+        "meeting-notes",
+        "transcription",
+        "summaries",
+        "meetings",
+        "ai-notes",
+        "meeting-intelligence"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "groq-pack",
+      "source": "./plugins/saas-packs/groq-pack",
+      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "groq",
+        "lpu",
+        "fast-inference",
+        "llm",
+        "groq-cloud",
+        "low-latency",
+        "ai-acceleration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "guidewire-pack",
+      "source": "./plugins/saas-packs/guidewire-pack",
+      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
+      "version": "1.25.0",
+      "category": "saas-packs",
+      "keywords": [
+        "guidewire",
+        "insurance",
+        "policycenter",
+        "claimcenter",
+        "billingcenter",
+        "insurancesuite",
+        "enterprise"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7465,6 +6965,47 @@
       }
     },
     {
+      "name": "ideogram-pack",
+      "source": "./plugins/saas-packs/ideogram-pack",
+      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
+      "version": "1.10.0",
+      "category": "saas-packs",
+      "keywords": [
+        "ideogram",
+        "image-generation",
+        "text-to-image",
+        "ai-art",
+        "typography",
+        "creative",
+        "design"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "instantly-pack",
+      "source": "./plugins/saas-packs/instantly-pack",
+      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "instantly",
+        "cold-email",
+        "outreach",
+        "email-automation",
+        "lead-generation",
+        "sales"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "intercom-pack",
       "source": "./plugins/saas-packs/intercom-pack",
       "description": "Claude Code skill pack for Intercom (24 skills)",
@@ -7475,6 +7016,27 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "juicebox-pack",
+      "source": "./plugins/saas-packs/juicebox-pack",
+      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
+      "version": "1.16.0",
+      "category": "saas-packs",
+      "keywords": [
+        "juicebox",
+        "people-data",
+        "enrichment",
+        "contacts",
+        "search",
+        "data-api",
+        "lead-enrichment"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7501,6 +7063,113 @@
       }
     },
     {
+      "name": "klingai-pack",
+      "source": "./plugins/saas-packs/klingai-pack",
+      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "klingai",
+        "kling",
+        "video-generation",
+        "text-to-video",
+        "ai-video",
+        "generative-ai",
+        "creative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "langchain-py-pack",
+      "source": "./plugins/saas-packs/langchain-py-pack",
+      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
+      "version": "2.5.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langchain",
+        "langgraph",
+        "python",
+        "llm",
+        "agents",
+        "rag",
+        "checkpointing",
+        "streaming",
+        "middleware",
+        "langsmith"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "langfuse-pack",
+      "source": "./plugins/saas-packs/langfuse-pack",
+      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langfuse",
+        "observability",
+        "tracing",
+        "prompts",
+        "evaluation",
+        "llm-ops",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "lindy-pack",
+      "source": "./plugins/saas-packs/lindy-pack",
+      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
+      "version": "1.15.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lindy",
+        "ai-assistant",
+        "automation",
+        "workflows",
+        "tasks",
+        "intelligent-automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "linear-pack",
+      "source": "./plugins/saas-packs/linear-pack",
+      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "linear",
+        "issues",
+        "project-management",
+        "tracking",
+        "workflows",
+        "agile",
+        "team-collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "linktree-pack",
       "source": "./plugins/saas-packs/linktree-pack",
       "description": "Claude Code skill pack for Linktree (18 skills)",
@@ -7519,6 +7188,27 @@
       }
     },
     {
+      "name": "lokalise-pack",
+      "source": "./plugins/saas-packs/lokalise-pack",
+      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lokalise",
+        "translation",
+        "localization",
+        "i18n",
+        "l10n",
+        "tms",
+        "internationalization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "lucidchart-pack",
       "source": "./plugins/saas-packs/lucidchart-pack",
       "description": "Claude Code skill pack for Lucidchart (18 skills)",
@@ -7529,6 +7219,27 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "maintainx-pack",
+      "source": "./plugins/saas-packs/maintainx-pack",
+      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "maintainx",
+        "cmms",
+        "work-orders",
+        "maintenance",
+        "assets",
+        "facilities",
+        "operations"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7573,6 +7284,27 @@
       }
     },
     {
+      "name": "mistral-pack",
+      "source": "./plugins/saas-packs/mistral-pack",
+      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "mistral",
+        "llm",
+        "inference",
+        "embeddings",
+        "fine-tuning",
+        "ai",
+        "machine-learning"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "navan-pack",
       "source": "./plugins/saas-packs/navan-pack",
       "description": "Claude Code skill pack for Navan (24 skills)",
@@ -7609,6 +7341,27 @@
       }
     },
     {
+      "name": "obsidian-pack",
+      "source": "./plugins/saas-packs/obsidian-pack",
+      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "obsidian",
+        "notes",
+        "vault",
+        "plugins",
+        "markdown",
+        "knowledge-management",
+        "pkm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "onenote-pack",
       "source": "./plugins/saas-packs/onenote-pack",
       "description": "Claude Code skill pack for OneNote (18 skills)",
@@ -7619,6 +7372,47 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "openevidence-pack",
+      "source": "./plugins/saas-packs/openevidence-pack",
+      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openevidence",
+        "medical-ai",
+        "clinical",
+        "healthcare",
+        "evidence-based",
+        "decision-support",
+        "medicine"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "openrouter-pack",
+      "source": "./plugins/saas-packs/openrouter-pack",
+      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
+      "version": "1.20.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openrouter",
+        "llm-routing",
+        "model-selection",
+        "ai-gateway",
+        "multi-model",
+        "cost-optimization"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7664,6 +7458,27 @@
       }
     },
     {
+      "name": "perplexity-pack",
+      "source": "./plugins/saas-packs/perplexity-pack",
+      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "perplexity",
+        "ai-search",
+        "research",
+        "citations",
+        "real-time",
+        "knowledge",
+        "answers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "persona-pack",
       "source": "./plugins/saas-packs/persona-pack",
       "description": "Claude Code skill pack for Persona (18 skills)",
@@ -7697,6 +7512,26 @@
         "rag",
         "call-transcripts",
         "multi-location"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "posthog-pack",
+      "source": "./plugins/saas-packs/posthog-pack",
+      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "posthog",
+        "product-analytics",
+        "feature-flags",
+        "session-replay",
+        "ab-testing",
+        "experimentation"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7777,6 +7612,48 @@
       }
     },
     {
+      "name": "replit-pack",
+      "source": "./plugins/saas-packs/replit-pack",
+      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "replit",
+        "cloud-ide",
+        "deployments",
+        "collaborative",
+        "ai-coding",
+        "browser-ide",
+        "hosting"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "retellai-pack",
+      "source": "./plugins/saas-packs/retellai-pack",
+      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
+      "version": "1.9.0",
+      "category": "saas-packs",
+      "keywords": [
+        "retellai",
+        "retell",
+        "voice-ai",
+        "phone-agents",
+        "conversational-ai",
+        "call-center",
+        "ivr"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "runway-pack",
       "source": "./plugins/saas-packs/runway-pack",
       "description": "Claude Code skill pack for Runway (18 skills)",
@@ -7823,6 +7700,27 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "sentry-pack",
+      "source": "./plugins/saas-packs/sentry-pack",
+      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
+      "version": "1.51.0",
+      "category": "saas-packs",
+      "keywords": [
+        "sentry",
+        "error-monitoring",
+        "performance",
+        "observability",
+        "debugging",
+        "crash-reporting",
+        "apm"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7887,6 +7785,27 @@
       }
     },
     {
+      "name": "speak-pack",
+      "source": "./plugins/saas-packs/speak-pack",
+      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "speak",
+        "language-learning",
+        "speech",
+        "ai-tutor",
+        "education",
+        "conversation",
+        "edtech"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "stackblitz-pack",
       "source": "./plugins/saas-packs/stackblitz-pack",
       "description": "Claude Code skill pack for StackBlitz (18 skills)",
@@ -7897,6 +7816,32 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "supabase-pack",
+      "source": "./plugins/saas-packs/supabase-pack",
+      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.53.0",
+      "category": "saas-packs",
+      "keywords": [
+        "supabase",
+        "postgres",
+        "database",
+        "authentication",
+        "realtime",
+        "storage",
+        "edge-functions",
+        "rls",
+        "row-level-security",
+        "baas",
+        "backend-as-a-service",
+        "firebase-alternative"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7942,6 +7887,48 @@
       }
     },
     {
+      "name": "twinmind-pack",
+      "source": "./plugins/saas-packs/twinmind-pack",
+      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "twinmind",
+        "meetings",
+        "transcription",
+        "summaries",
+        "ai-assistant",
+        "productivity",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "vastai-pack",
+      "source": "./plugins/saas-packs/vastai-pack",
+      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vastai",
+        "vast-ai",
+        "gpu-marketplace",
+        "cloud-gpu",
+        "ml-infrastructure",
+        "compute",
+        "training"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "veeva-pack",
       "source": "./plugins/saas-packs/veeva-pack",
       "description": "Claude Code skill pack for Veeva (24 skills)",
@@ -7960,6 +7947,30 @@
       }
     },
     {
+      "name": "vercel-pack",
+      "source": "./plugins/saas-packs/vercel-pack",
+      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vercel",
+        "deployment",
+        "edge-functions",
+        "serverless",
+        "preview",
+        "ci-cd",
+        "hosting",
+        "next-js",
+        "jamstack",
+        "frontend-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
       "name": "webflow-pack",
       "source": "./plugins/saas-packs/webflow-pack",
       "description": "Claude Code skill pack for Webflow (24 skills)",
@@ -7970,6 +7981,27 @@
         "saas",
         "sdk",
         "integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "windsurf-pack",
+      "source": "./plugins/saas-packs/windsurf-pack",
+      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "windsurf",
+        "ai-editor",
+        "cascade",
+        "codeium",
+        "ai-coding",
+        "code-completion",
+        "refactoring"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -8014,1044 +8046,19 @@
       }
     },
     {
-      "name": "pm-ai-partner",
-      "source": "./plugins/productivity/pm-ai-partner",
-      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
-      "version": "1.8.0",
-      "category": "productivity",
+      "name": "access-control-auditor",
+      "source": "./plugins/security/access-control-auditor",
+      "description": "Audit access control implementations",
+      "version": "1.24.0",
+      "category": "security",
       "keywords": [
-        "product-management",
-        "pm",
-        "ai-partner",
-        "skills",
-        "commands",
-        "hooks"
-      ],
-      "author": {
-        "name": "Ahmed Khaled",
-        "email": "ahmd.khaled.a.mohamed@gmail.com"
-      }
-    },
-    {
-      "name": "validate-plugin",
-      "source": "./plugins/skill-enhancers/validate-plugin",
-      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
-      "version": "1.8.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "validation",
-        "plugin-development",
-        "quality-assurance",
-        "linting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "zero-tech-debt",
-      "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
-      "version": "1.1.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "refactoring",
-        "tech-debt",
-        "architecture",
-        "cleanup",
-        "modernization",
-        "code-quality"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "executive-assistant-skills",
-      "source": "./plugins/business-tools/executive-assistant-skills",
-      "version": "1.8.0",
-      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
-      "author": {
-        "name": "Martin Gontovnikas",
-        "email": "gonto@hypergrowthpartners.com",
-        "url": "https://github.com/mgonto"
-      },
-      "category": "business-tools",
-      "keywords": [
-        "executive-assistant",
-        "meeting-prep",
-        "email",
-        "productivity",
-        "automation",
-        "todoist"
-      ],
-      "license": "MIT",
-      "repository": "https://github.com/mgonto/executive-assistant-skills"
-    },
-    {
-      "name": "box-cloud-filesystem",
-      "source": "./plugins/productivity/box-cloud-filesystem",
-      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "box",
-        "cloud-storage",
-        "filesystem",
-        "file-sync",
-        "box-cli",
-        "upload",
-        "download",
-        "document-management",
-        "collaboration",
-        "ai-agent-storage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT"
-    },
-    {
-      "name": "pr-to-spec",
-      "source": "./plugins/mcp/pr-to-spec",
-      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
-      "version": "0.8.0",
-      "category": "mcp",
-      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "license": "MIT",
-      "keywords": [
-        "mcp",
-        "pr-analysis",
-        "intent-drift",
-        "code-review",
-        "agent-protocol"
-      ]
-    },
-    {
-      "name": "slack-channel",
-      "source": "./plugins/mcp/slack-channel",
-      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "slack",
-        "channel",
-        "mcp",
-        "socket-mode",
-        "chatops",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT"
-    },
-    {
-      "name": "x-bug-triage-plugin",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "keywords": [
-        "bug-triage",
-        "x-twitter",
-        "slack",
-        "devops",
-        "mcp"
-      ],
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT"
-    },
-    {
-      "name": "framecraft",
-      "source": "./plugins/community/framecraft",
-      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
-      "version": "1.3.0",
-      "category": "community",
-      "keywords": [
-        "demo-video",
-        "video-generation",
-        "playwright",
-        "ffmpeg",
-        "edge-tts",
-        "mcp"
-      ],
-      "author": {
-        "name": "vaddisrinivas",
-        "url": "https://github.com/vaddisrinivas"
-      }
-    },
-    {
-      "name": "tweetclaw",
-      "source": "./plugins/devops/tweetclaw",
-      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
-      "version": "1.5.3",
-      "category": "devops",
-      "keywords": [
-        "twitter",
-        "x",
-        "automation",
-        "social-media",
-        "tweets",
-        "monitoring",
-        "giveaway",
-        "scraping"
-      ],
-      "author": {
-        "name": "Burak Bayir",
-        "email": "burak@xquik.com",
-        "url": "https://xquik.com"
-      },
-      "repository": "https://github.com/Xquik-dev/tweetclaw",
-      "homepage": "https://xquik.com",
-      "license": "MIT"
-    },
-    {
-      "name": "shipwright",
-      "source": "./plugins/ai-agency/shipwright",
-      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
-      "version": "1.3.0",
-      "category": "ai-agency",
-      "author": {
-        "name": "Nate Nelson",
-        "url": "https://github.com/Wynelson94"
-      },
-      "keywords": [
-        "app-builder",
-        "code-generator",
-        "autonomous-agent",
-        "pipeline",
-        "nextjs",
-        "supabase",
-        "sveltekit",
-        "astro",
-        "ai-agency"
-      ],
-      "repository": "https://github.com/Wynelson94/shipwright",
-      "homepage": "https://github.com/Wynelson94/shipwright",
-      "license": "MIT"
-    },
-    {
-      "name": "hyperfocus",
-      "source": "./plugins/productivity/hyperfocus",
-      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
-      "version": "0.2.0",
-      "category": "productivity",
-      "author": {
-        "name": "Nestor Magalhaes",
-        "email": "nestor.magalhaes@appex.world"
-      },
-      "keywords": [
-        "accessibility",
-        "adhd",
-        "neurodivergent",
-        "formatting",
-        "readability",
-        "productivity",
-        "cognitive-accessibility"
-      ],
-      "repository": "https://github.com/nextor2k/hyperfocus",
-      "homepage": "https://github.com/nextor2k/hyperfocus",
-      "license": "MIT"
-    },
-    {
-      "name": "plane",
-      "source": "./plugins/productivity/plane",
-      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
-      "version": "0.3.0",
-      "category": "productivity",
-      "keywords": [
-        "plane",
-        "project-management",
-        "team-behavior",
-        "observability",
-        "productivity",
-        "agent-skills",
-        "forge-generated"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "local-tts",
-      "source": "./plugins/ai-ml/local-tts",
-      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
-      "version": "1.3.0",
-      "category": "ai-ml",
-      "keywords": [
-        "tts",
-        "text-to-speech",
-        "voice",
-        "voice-cloning",
-        "voice-design",
-        "offline",
-        "voxcpm",
-        "apple-silicon",
-        "audio",
-        "narration"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "Apache-2.0",
-      "repository": "https://github.com/vdk888/local-tts"
-    },
-    {
-      "name": "boycott-filter",
-      "source": "./plugins/community/boycott-filter",
-      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
-      "version": "1.2.0",
-      "category": "community",
-      "keywords": [
-        "boycott",
-        "consumer",
-        "shopping",
-        "brands",
-        "chrome-extension",
-        "conversational",
-        "privacy",
-        "ethical-consumption"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/vdk888/boycott-filter"
-    },
-    {
-      "name": "web-analytics",
-      "source": "./plugins/analytics/web-analytics",
-      "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
-      "version": "1.4.0",
-      "category": "analytics",
-      "keywords": [
-        "analytics",
-        "umami",
-        "ga4",
-        "traffic",
-        "mcp",
-        "self-hosted",
-        "multi-agent",
-        "push-based"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "aomi",
-      "source": "./plugins/crypto/aomi",
-      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
-      "version": "0.10.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "defi",
-        "web3",
-        "evm",
-        "ethereum",
-        "wallet",
-        "account-abstraction",
-        "trading",
-        "agent",
-        "mcp"
-      ],
-      "author": {
-        "name": "aomi-labs",
-        "url": "https://aomi.dev",
-        "email": "info@aomi.dev"
-      }
-    },
-    {
-      "name": "cli-power-skills",
-      "source": "./plugins/productivity/cli-power-skills",
-      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "cli-tools",
-        "agentic-skills",
-        "data-processing",
         "security",
-        "web-crawling",
-        "python",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Yuriy Kotik",
-        "url": "https://github.com/ykotik"
-      },
-      "repository": "https://github.com/ykotik/cli-power-skills",
-      "license": "MIT"
-    },
-    {
-      "name": "claude-workflow-skills",
-      "source": "./plugins/productivity/claude-workflow-skills",
-      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
-      "version": "1.7.1",
-      "category": "productivity",
-      "keywords": [
-        "workflow",
-        "promote",
-        "release",
-        "audit",
-        "standards",
-        "improve",
-        "triage",
-        "git",
-        "review",
-        "pull-request"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
-      "repository": "https://github.com/ali5ter/claude-workflow-skills",
-      "license": "MIT"
-    },
-    {
-      "name": "cli-ux-tester",
-      "source": "./plugins/testing/cli-ux-tester",
-      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
-      "version": "3.1.0",
-      "category": "testing",
-      "keywords": [
-        "CLI",
-        "UX",
-        "testing",
-        "developer-experience",
-        "terminal",
-        "usability"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
-      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
-      "license": "MIT"
-    },
-    {
-      "name": "skyvern",
-      "source": "./plugins/productivity/skyvern",
-      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
-      "version": "0.1.0",
-      "category": "productivity",
-      "author": {
-        "name": "Skyvern-AI",
-        "url": "https://github.com/Skyvern-AI"
-      },
-      "license": "AGPL-3.0"
-    },
-    {
-      "name": "tonone",
-      "source": "./plugins/ai-agency/tonone",
-      "description": "23-agent engineering + product team with 125 skills for Claude Code",
-      "version": "1.8.0",
-      "category": "ai-agency",
-      "keywords": [
-        "agents",
-        "engineering-team",
-        "infrastructure",
-        "devops",
-        "backend",
-        "security",
-        "observability",
-        "frontend",
-        "ml",
-        "mobile",
-        "embedded",
-        "analytics",
-        "testing",
-        "platform",
-        "sales",
-        "revenue",
-        "customer-success",
-        "content-marketing",
-        "pr",
-        "community",
-        "finance",
-        "people",
-        "operations",
-        "support"
-      ],
-      "author": {
-        "name": "tonone-ai",
-        "url": "https://tonone.ai"
-      },
-      "repository": "https://github.com/tonone-ai/tonone",
-      "license": "MIT"
-    },
-    {
-      "name": "x-bug-triage",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "triage",
-        "x-api",
-        "bug-tracking",
-        "clustering"
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "license": "MIT"
-    },
-    {
-      "name": "hyperflow",
-      "source": "./plugins/ai-agency/hyperflow",
-      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
-      "version": "4.26.1",
-      "category": "ai-agency",
-      "keywords": [
-        "claude-code-plugin",
-        "multi-agent",
-        "dynamic-workflows",
-        "workflow-chain",
-        "triageflow",
-        "personas",
-        "flow-profiles",
-        "code-review",
-        "project-memory",
-        "multi-tool"
-      ],
-      "author": {
-        "name": "Mohammed Abdelhady",
-        "url": "https://github.com/Mohammed-Abdelhady"
-      },
-      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-anti-deception",
-      "source": "./plugins/community/ejentum-anti-deception",
-      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-code",
-      "source": "./plugins/community/ejentum-code",
-      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-memory",
-      "source": "./plugins/community/ejentum-memory",
-      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-reasoning",
-      "source": "./plugins/community/ejentum-reasoning",
-      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "over-50s-health",
-      "source": "./plugins/productivity/over-50s-health",
-      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
-      "version": "3.3.0",
-      "category": "productivity",
-      "keywords": [
-        "health",
-        "fitness",
-        "nutrition",
-        "longevity",
-        "50+"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
-      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
-      "license": "MIT"
-    },
-    {
-      "name": "obsidian-project-documentation",
-      "source": "./plugins/productivity/obsidian-project-documentation",
-      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
-      "version": "3.2.5",
-      "category": "productivity",
-      "keywords": [
-        "obsidian",
-        "documentation",
-        "notes",
-        "projects"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
-      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
-      "license": "MIT"
-    },
-    {
-      "name": "pair-programmer",
-      "source": "./plugins/productivity/pair-programmer",
-      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "pair-programming",
-        "coding",
-        "skill-development",
-        "graduated-assistance"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/pair-programmer",
-      "repository": "https://github.com/ali5ter/pair-programmer",
-      "license": "MIT"
-    },
-    {
-      "name": "governed-second-brain",
-      "source": "./plugins/mcp/governed-second-brain",
-      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
-      "version": "1.1.2",
-      "category": "mcp",
-      "keywords": [
-        "memory",
-        "knowledge",
-        "governance",
-        "qmd",
-        "brain",
-        "citations",
-        "local-first",
-        "second-brain"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "databricks-workspace-mcp",
-      "source": "./plugins/mcp/databricks-workspace-mcp",
-      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "model-context-protocol",
-        "databricks",
-        "lakehouse",
-        "unity-catalog",
-        "clusters",
-        "dlt",
-        "finops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://tonsofskills.com/learn/databricks/",
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "license": "MIT"
-    },
-    {
-      "name": "beads-dolt",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "beads",
-        "bd",
-        "dolt",
-        "dolthub",
-        "task-tracking",
-        "mcp",
-        "version-control",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "publishing-skills",
-      "source": "./plugins/productivity/publishing-skills",
-      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "ghost",
-        "blogging",
-        "seo",
-        "content-creation",
-        "publishing",
-        "claude-code",
-        "ai-writing"
-      ],
-      "author": {
-        "name": "AutomateLab",
-        "url": "https://github.com/AutomateLab-tech",
-        "email": "hello@automatelab.tech"
-      },
-      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
-      "license": "MIT-0"
-    },
-    {
-      "name": "dolt-mcp-vcs",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "dolt-mcp-vcs",
-        "dolt",
-        "dolthub",
-        "dolt-mcp",
-        "version-control",
-        "vcs",
-        "mcp",
-        "sql",
-        "beads",
-        "bd"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "hermes-tweet",
-      "source": "./plugins/community/hermes-tweet",
-      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
-      "version": "0.1.6",
-      "category": "community",
-      "keywords": [
-        "hermes-agent",
-        "hermes-plugin",
-        "xquik",
-        "twitter",
-        "x",
-        "social-media",
-        "automation"
-      ],
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
-      "repository": "https://github.com/Xquik-dev/hermes-tweet",
-      "license": "MIT"
-    },
-    {
-      "name": "x-twitter-scraper",
-      "source": "./plugins/api-development/x-twitter-scraper",
-      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
-      "version": "0.1.0",
-      "category": "api-development",
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
-      "license": "MIT"
-    },
-    {
-      "name": "servicegraph",
-      "source": "./plugins/mcp/servicegraph",
-      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
-      "version": "0.2.0",
-      "category": "mcp",
-      "keywords": [
-        "servicegraph",
-        "service-providers",
-        "agencies",
-        "law-firms",
-        "consulting",
-        "accounting",
-        "marketing",
-        "lead-generation",
-        "professional-services",
-        "us-firms",
-        "product-directories",
-        "saas-directories",
-        "mcp-directories",
-        "ai-directories",
-        "product-launch",
-        "backlinks"
-      ],
-      "author": {
-        "name": "Artur Briugeman",
-        "url": "https://servicegraph.co",
-        "email": "artur@nostr.band"
-      },
-      "homepage": "https://servicegraph.co",
-      "repository": "https://github.com/nostrband/servicegraph",
-      "license": "MIT"
-    },
-    {
-      "name": "schedule-after-usage-reset",
-      "source": "./plugins/productivity/schedule-after-usage-reset",
-      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "schedule",
-        "usage-reset",
-        "rate-limit",
-        "claude-code",
-        "automation"
-      ],
-      "author": {
-        "name": "patricksong1993",
-        "url": "https://github.com/patricksong1993"
-      },
-      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "mnemos",
-      "source": "./plugins/community/mnemos",
-      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
-      "version": "0.9.0",
-      "category": "community",
-      "keywords": [
-        "memory",
-        "mcp",
-        "claude-code",
-        "persistent-memory",
-        "agent-memory",
-        "knowledge-graph",
-        "context",
-        "skill",
-        "observations",
-        "provenance",
-        "learning-loop",
-        "golang"
-      ],
-      "author": {
-        "name": "André Figueira",
-        "url": "https://polyxmedia.com",
-        "email": "andre@polyxmedia.com"
-      },
-      "homepage": "https://github.com/polyxmedia/mnemos",
-      "repository": "https://github.com/polyxmedia/mnemos",
-      "license": "MIT"
-    },
-    {
-      "name": "portaljs",
-      "source": "./plugins/community/portaljs",
-      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
-      "version": "0.1.0",
-      "category": "community",
-      "keywords": [
-        "portaljs",
-        "data-portal",
-        "ckan",
-        "nextjs",
-        "data-catalog"
-      ],
-      "author": {
-        "name": "Datopian",
-        "url": "https://www.datopian.com"
-      },
-      "homepage": "https://github.com/datopian/portaljs",
-      "repository": "https://github.com/datopian/portaljs",
-      "license": "MIT"
-    },
-    {
-      "name": "llm-box",
-      "source": "./plugins/community/llm-box",
-      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
-      "version": "0.3.0",
-      "category": "community",
-      "keywords": [
-        "workflow",
-        "automation",
-        "terminal",
-        "cli",
-        "yaml",
-        "llm",
-        "mcp"
-      ],
-      "author": {
-        "name": "alib8b8",
-        "url": "https://github.com/alib8b8"
-      },
-      "homepage": "https://github.com/alib8b8/llm-box",
-      "repository": "https://github.com/alib8b8/llm-box",
-      "license": "MIT"
-    },
-    {
-      "name": "j-rig",
-      "source": "./plugins/productivity/j-rig",
-      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "skill-refiner",
-        "eval-guided",
-        "skill-md",
-        "meta-tooling",
-        "hooks"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "intent-labs-pack",
-      "source": "./plugins/productivity/intent-labs-pack",
-      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "audit-tests",
-        "validate-skillmd",
-        "testing",
-        "skill-validation",
-        "intent-eval",
-        "dogfood"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "email": "[email protected]"
       }
     },
     {
@@ -9079,119 +8086,1131 @@
       "license": "MIT"
     },
     {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
+      "name": "authentication-validator",
+      "source": "./plugins/security/authentication-validator",
+      "description": "Validate authentication implementations",
+      "version": "1.26.0",
+      "category": "security",
       "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "compliance-report-generator",
+      "source": "./plugins/security/compliance-report-generator",
+      "description": "Generate compliance reports",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cors-policy-validator",
+      "source": "./plugins/security/cors-policy-validator",
+      "description": "Validate CORS policies",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "csrf-protection-validator",
+      "source": "./plugins/security/csrf-protection-validator",
+      "description": "Validate CSRF protection",
+      "version": "1.26.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "data-privacy-scanner",
+      "source": "./plugins/security/data-privacy-scanner",
+      "description": "Scan for data privacy issues",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "dependency-checker",
+      "source": "./plugins/security/dependency-checker",
+      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "dependencies",
+        "npm",
+        "pip",
+        "composer",
+        "vulnerabilities"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "encryption-tool",
+      "source": "./plugins/security/encryption-tool",
+      "description": "Encrypt and decrypt data with various algorithms",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "gdpr-compliance-scanner",
+      "source": "./plugins/security/gdpr-compliance-scanner",
+      "description": "Scan for GDPR compliance issues",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "hipaa-compliance-checker",
+      "source": "./plugins/security/hipaa-compliance-checker",
+      "description": "Check HIPAA compliance",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "input-validation-scanner",
+      "source": "./plugins/security/input-validation-scanner",
+      "description": "Scan input validation practices",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "owasp-compliance-checker",
+      "source": "./plugins/security/owasp-compliance-checker",
+      "description": "Check OWASP Top 10 compliance",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "pci-dss-validator",
+      "source": "./plugins/security/pci-dss-validator",
+      "description": "Validate PCI DSS compliance",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "penetration-tester",
+      "source": "./plugins/security/penetration-tester",
+      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
+      "version": "3.30.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "penetration-testing",
+        "pentesting",
+        "owasp",
+        "owasp-top-10",
+        "vulnerability-scanning",
+        "dependency-audit",
+        "license-compliance",
+        "engagement-governance",
+        "chain-of-custody"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "secret-scanner",
+      "source": "./plugins/security/secret-scanner",
+      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "secrets",
+        "api-keys",
+        "credentials",
+        "passwords"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-audit-reporter",
+      "source": "./plugins/security/security-audit-reporter",
+      "description": "Generate comprehensive security audit reports",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-headers-analyzer",
+      "source": "./plugins/security/security-headers-analyzer",
+      "description": "Analyze HTTP security headers",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-incident-responder",
+      "source": "./plugins/security/security-incident-responder",
+      "description": "Assist with security incident response",
+      "version": "1.32.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-misconfiguration-finder",
+      "source": "./plugins/security/security-misconfiguration-finder",
+      "description": "Find security misconfigurations",
+      "version": "1.29.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "session-security-checker",
+      "source": "./plugins/security/session-security-checker",
+      "description": "Check session security implementation",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "severity1-marketplace",
+      "source": "./plugins/security/severity1-marketplace",
+      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
+      "version": "1.6.0",
+      "category": "security",
+      "keywords": [
+        "severity",
+        "classification",
+        "prompt-improvement",
+        "marketplace",
+        "security",
+        "quality",
+        "triage",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "severity1",
+        "email": "severity1@intentsolutions.io"
+      }
+    },
+    {
+      "name": "soc2-audit-helper",
+      "source": "./plugins/security/soc2-audit-helper",
+      "description": "Assist with SOC2 audit preparation",
+      "version": "1.30.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "sql-injection-detector",
+      "source": "./plugins/security/sql-injection-detector",
+      "description": "Detect SQL injection vulnerabilities",
+      "version": "1.31.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "ssl-certificate-manager",
+      "source": "./plugins/security/ssl-certificate-manager",
+      "description": "Manage and monitor SSL/TLS certificates",
+      "version": "1.21.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "vulnerability-scanner",
+      "source": "./plugins/security/vulnerability-scanner",
+      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "vulnerability",
+        "scanning",
+        "cve",
+        "sast"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "xss-vulnerability-scanner",
+      "source": "./plugins/security/xss-vulnerability-scanner",
+      "description": "Scan for XSS vulnerabilities",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "axiom",
+      "source": "./plugins/skill-enhancers/axiom",
+      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
+      "version": "0.3.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "ios",
+        "debugging",
+        "swift",
+        "persistence",
+        "testing",
+        "performance",
+        "xcode",
+        "concurrency",
+        "database",
+        "swiftdata",
+        "grdb",
+        "liquid-glass",
+        "swiftui"
+      ],
+      "author": {
+        "name": "Charles Wiltgen",
+        "url": "https://github.com/CharlesWiltgen"
+      }
+    },
+    {
+      "name": "calendar-to-workflow",
+      "source": "./plugins/skill-enhancers/calendar-to-workflow",
+      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "calendar",
+        "automation",
+        "meetings",
+        "productivity"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "file-to-code",
+      "source": "./plugins/skill-enhancers/file-to-code",
+      "description": "Converts file references into executable code implementations",
+      "version": "0.16.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "files",
+        "automation",
+        "code-generation"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "research-to-deploy",
+      "source": "./plugins/skill-enhancers/research-to-deploy",
+      "description": "Transforms research findings into deployed solutions automatically",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "research",
+        "automation",
+        "deployment"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "search-to-slack",
+      "source": "./plugins/skill-enhancers/search-to-slack",
+      "description": "Automatically posts search results to Slack channels",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "search",
+        "slack",
+        "automation",
+        "integration"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "skill-creator",
+      "source": "./plugins/skill-enhancers/skill-creator",
+      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
+      "version": "5.20.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "skill-creation",
+        "validation",
+        "meta-tooling",
+        "grading",
+        "anthropic-spec"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "validate-plugin",
+      "source": "./plugins/skill-enhancers/validate-plugin",
+      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
+      "version": "1.8.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "validation",
+        "plugin-development",
+        "quality-assurance",
+        "linting"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "web-to-github-issue",
+      "source": "./plugins/skill-enhancers/web-to-github-issue",
+      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
+      "version": "1.27.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "web-search",
         "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
+        "automation",
+        "research",
+        "issue-tracking",
+        "skill-enhancer",
+        "productivity",
+        "workflow"
       ],
       "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
+        "name": "Claude Code Plugins Team",
+        "email": "[email protected]"
       },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
     },
     {
-      "name": "skills-janitor",
-      "source": "./plugins/community/skills-janitor",
-      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
-      "version": "0.1.0",
-      "category": "community",
+      "name": "zero-tech-debt",
+      "source": "./plugins/skill-enhancers/zero-tech-debt",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "version": "1.1.0",
+      "category": "skill-enhancers",
       "keywords": [
-        "skills",
+        "refactoring",
+        "tech-debt",
+        "architecture",
         "cleanup",
-        "context-window",
-        "token-budget",
-        "maintenance",
-        "tui"
+        "modernization",
+        "code-quality"
       ],
       "author": {
-        "name": "Krzysztof Hendzel",
-        "url": "https://github.com/khendzel",
-        "email": "krzysztoff.hendzel@gmail.com"
-      },
-      "repository": "https://github.com/khendzel/skills-janitor",
-      "license": "MIT"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
     },
     {
-      "name": "walkie-talkie",
-      "source": "./plugins/community/walkie-talkie",
-      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Walkie-Talkie Maintainers",
-        "url": "https://github.com/walkie-talkie-skill"
-      },
-      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
-      "license": "MIT"
-    },
-    {
-      "name": "brand-forge",
-      "source": "./plugins/design/brand-forge",
-      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
-      "version": "0.5.1",
-      "category": "design",
+      "name": "accessibility-test-scanner",
+      "source": "./plugins/testing/accessibility-test-scanner",
+      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
+      "version": "1.23.0",
+      "category": "testing",
       "keywords": [
-        "branding",
-        "logo",
-        "brand-identity",
-        "design",
-        "svg",
-        "templates",
-        "image-generation"
+        "testing",
+        "accessibility",
+        "a11y",
+        "wcag",
+        "aria",
+        "screen-reader",
+        "compliance"
       ],
       "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
-      },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
-      "repository": "https://github.com/localplugins/plugins",
-      "license": "MIT"
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
     },
     {
-      "name": "content-multiplier",
-      "source": "./plugins/productivity/content-multiplier",
-      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
-      "version": "0.2.1",
-      "category": "productivity",
+      "name": "api-fuzzer",
+      "source": "./plugins/testing/api-fuzzer",
+      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
+      "version": "1.25.0",
+      "category": "testing",
       "keywords": [
-        "marketing",
-        "content",
-        "repurposing",
-        "brand-voice",
-        "localization",
-        "social-media"
+        "testing",
+        "fuzzing",
+        "api",
+        "security",
+        "edge-cases",
+        "input-validation"
       ],
       "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "api-test-automation",
+      "source": "./plugins/testing/api-test-automation",
+      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "api",
+        "rest",
+        "graphql",
+        "automation",
+        "endpoints"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "browser-compatibility-tester",
+      "source": "./plugins/testing/browser-compatibility-tester",
+      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
+      "version": "2.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "cross-browser",
+        "browserstack",
+        "selenium",
+        "playwright",
+        "compatibility"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "chaos-engineering-toolkit",
+      "source": "./plugins/testing/chaos-engineering-toolkit",
+      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "chaos-engineering",
+        "resilience",
+        "failure-injection",
+        "fault-tolerance",
+        "reliability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cli-ux-tester",
+      "source": "./plugins/testing/cli-ux-tester",
+      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
+      "version": "3.1.0",
+      "category": "testing",
+      "keywords": [
+        "CLI",
+        "UX",
+        "testing",
+        "developer-experience",
+        "terminal",
+        "usability"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
       },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
-      "repository": "https://github.com/localplugins/plugins",
+      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
       "license": "MIT"
     },
     {
-      "name": "quit-sponsor",
-      "source": "./plugins/community/quit-sponsor",
-      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
-      "version": "0.1.0",
-      "category": "community",
+      "name": "code-cleanup",
+      "source": "./plugins/testing/code-cleanup",
+      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+      "version": "1.7.0",
+      "category": "testing",
+      "keywords": [
+        "code-quality",
+        "cleanup",
+        "refactoring",
+        "dead-code",
+        "deduplication",
+        "type-safety",
+        "security",
+        "performance",
+        "async",
+        "tech-debt",
+        "code-review"
+      ],
       "author": {
-        "name": "metr0x",
-        "url": "https://github.com/metrox-eth"
-      },
-      "repository": "https://github.com/metrox-eth/quit-sponsor",
-      "license": "MIT"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "contract-test-validator",
+      "source": "./plugins/testing/contract-test-validator",
+      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "contract-testing",
+        "pact",
+        "openapi",
+        "api",
+        "microservices",
+        "consumer-driven"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "database-test-manager",
+      "source": "./plugins/testing/database-test-manager",
+      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "database",
+        "sql",
+        "test-data",
+        "fixtures",
+        "migrations",
+        "transactions"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "e2e-test-framework",
+      "source": "./plugins/testing/e2e-test-framework",
+      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "e2e",
+        "playwright",
+        "cypress",
+        "selenium",
+        "browser-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "integration-test-runner",
+      "source": "./plugins/testing/integration-test-runner",
+      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "integration-tests",
+        "test-runner",
+        "e2e",
+        "api-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "kobiton-automate",
+      "source": "./plugins/testing/kobiton-automate",
+      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
+      "version": "1.0.2",
+      "category": "testing",
+      "keywords": [
+        "mobile",
+        "testing",
+        "appium",
+        "automation",
+        "devices",
+        "ios",
+        "android",
+        "real-device",
+        "mcp",
+        "kobiton"
+      ],
+      "author": {
+        "name": "Kobiton Inc.",
+        "url": "https://github.com/kobiton"
+      }
+    },
+    {
+      "name": "load-balancer-tester",
+      "source": "./plugins/testing/load-balancer-tester",
+      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "load-balancer",
+        "traffic-distribution",
+        "failover",
+        "high-availability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "mobile-app-tester",
+      "source": "./plugins/testing/mobile-app-tester",
+      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mobile",
+        "appium",
+        "detox",
+        "xcuitest",
+        "espresso",
+        "ios",
+        "android"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "mutation-test-runner",
+      "source": "./plugins/testing/mutation-test-runner",
+      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mutation-testing",
+        "test-quality",
+        "stryker",
+        "pitest"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "performance-test-suite",
+      "source": "./plugins/testing/performance-test-suite",
+      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
+      "version": "1.30.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "performance",
+        "load-testing",
+        "benchmarking",
+        "stress-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "regression-test-tracker",
+      "source": "./plugins/testing/regression-test-tracker",
+      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "regression-testing",
+        "test-tracking",
+        "ci-cd",
+        "quality-assurance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-test-scanner",
+      "source": "./plugins/testing/security-test-scanner",
+      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
+      "version": "1.29.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "security",
+        "vulnerabilities",
+        "owasp",
+        "penetration-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "smoke-test-runner",
+      "source": "./plugins/testing/smoke-test-runner",
+      "description": "Quick smoke test suites to verify critical functionality after deployments",
+      "version": "1.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "smoke-tests",
+        "deployment",
+        "sanity-check",
+        "critical-path"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "snapshot-test-manager",
+      "source": "./plugins/testing/snapshot-test-manager",
+      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "snapshot",
+        "jest",
+        "vitest",
+        "diff-analysis",
+        "test-management"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-coverage-analyzer",
+      "source": "./plugins/testing/test-coverage-analyzer",
+      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "coverage",
+        "code-coverage",
+        "metrics",
+        "analysis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-data-generator",
+      "source": "./plugins/testing/test-data-generator",
+      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "test-data",
+        "fake-data",
+        "fixtures",
+        "factory"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-doubles-generator",
+      "source": "./plugins/testing/test-doubles-generator",
+      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mocks",
+        "stubs",
+        "spies",
+        "fakes",
+        "test-doubles",
+        "jest",
+        "sinon"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-environment-manager",
+      "source": "./plugins/testing/test-environment-manager",
+      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "environment",
+        "docker",
+        "testcontainers",
+        "isolation",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-orchestrator",
+      "source": "./plugins/testing/test-orchestrator",
+      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "orchestration",
+        "workflow",
+        "parallel",
+        "test-selection",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-report-generator",
+      "source": "./plugins/testing/test-report-generator",
+      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
+      "version": "1.23.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "reporting",
+        "coverage",
+        "metrics",
+        "dashboard",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "unit-test-generator",
+      "source": "./plugins/testing/unit-test-generator",
+      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "unit-tests",
+        "test-generation",
+        "jest",
+        "pytest",
+        "mocha",
+        "junit"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "visual-regression-tester",
+      "source": "./plugins/testing/visual-regression-tester",
+      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "visual-regression",
+        "ui-testing",
+        "percy",
+        "chromatic",
+        "backstop",
+        "screenshot-testing"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,151 @@
   },
   "plugins": [
     {
+      "name": "000-jeremy-content-consistency-validator",
+      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
+      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
+      "version": "3.29.0",
+      "category": "productivity",
+      "keywords": [
+        "documentation",
+        "consistency",
+        "validation",
+        "drift-detection",
+        "source-of-truth",
+        "authority-registry",
+        "content-audit",
+        "quality-assurance",
+        "release-gate",
+        "standards"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "002-jeremy-yaml-master-agent",
+      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
+      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
+      "version": "2.21.0",
+      "category": "productivity",
+      "keywords": [
+        "yaml",
+        "validation",
+        "linting",
+        "schema",
+        "json",
+        "conversion",
+        "parsing",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "003-jeremy-vertex-ai-media-master",
+      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
+      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
+      "version": "2.25.0",
+      "category": "productivity",
+      "keywords": [
+        "vertex-ai",
+        "gemini",
+        "multimodal",
+        "video-processing",
+        "audio-generation",
+        "image-generation",
+        "marketing",
+        "campaigns",
+        "content-generation",
+        "imagen",
+        "media-production",
+        "google-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "004-jeremy-google-cloud-agent-sdk",
+      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
+      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
+      "version": "2.24.0",
+      "category": "productivity",
+      "keywords": [
+        "agent-development-kit",
+        "adk",
+        "agent-starter-pack",
+        "multi-agent",
+        "containerized-agents",
+        "cloud-run",
+        "gke",
+        "agent-engine",
+        "rag-agents",
+        "react-agents",
+        "google-cloud",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "access-control-auditor",
+      "source": "./plugins/security/access-control-auditor",
+      "description": "Audit access control implementations",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "accessibility-test-scanner",
+      "source": "./plugins/testing/accessibility-test-scanner",
+      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
+      "version": "1.23.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "accessibility",
+        "a11y",
+        "wcag",
+        "aria",
+        "screen-reader",
+        "compliance"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "agent-context-manager",
+      "source": "./plugins/productivity/agent-context-manager",
+      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
+      "version": "1.23.0",
+      "category": "productivity",
+      "keywords": [
+        "agents",
+        "context",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore"
+      }
+    },
+    {
       "name": "agency-os",
       "source": "./plugins/ai-agency/agency-os",
       "description": "Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel with dependency ordering and model routing.",
@@ -36,202 +181,23 @@
       }
     },
     {
-      "name": "discovery-questionnaire",
-      "source": "./plugins/ai-agency/discovery-questionnaire",
-      "description": "Generate custom discovery questionnaires for AI agency prospects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "discovery",
-        "questionnaire",
-        "client",
-        "sales",
-        "agency",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "hyperflow",
-      "source": "./plugins/ai-agency/hyperflow",
-      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
-      "version": "4.26.1",
-      "category": "ai-agency",
-      "keywords": [
-        "claude-code-plugin",
-        "multi-agent",
-        "dynamic-workflows",
-        "workflow-chain",
-        "triageflow",
-        "personas",
-        "flow-profiles",
-        "code-review",
-        "project-memory",
-        "multi-tool"
-      ],
-      "author": {
-        "name": "Mohammed Abdelhady",
-        "url": "https://github.com/Mohammed-Abdelhady"
-      },
-      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
-      "license": "MIT"
-    },
-    {
-      "name": "make-scenario-builder",
-      "source": "./plugins/ai-agency/make-scenario-builder",
-      "description": "Create Make.com (Integromat) scenarios with AI assistance",
-      "version": "1.15.0",
-      "category": "ai-agency",
-      "keywords": [
-        "make",
-        "integromat",
-        "automation",
-        "scenarios",
-        "workflow",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "n8n-workflow-designer",
-      "source": "./plugins/ai-agency/n8n-workflow-designer",
-      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
-      "version": "1.13.0",
-      "category": "ai-agency",
-      "keywords": [
-        "n8n",
-        "workflow",
-        "automation",
-        "self-hosted",
-        "open-source",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "url": "https://github.com/jeremylongshore/claude-code-plugins"
-      }
-    },
-    {
-      "name": "roi-calculator",
-      "source": "./plugins/ai-agency/roi-calculator",
-      "description": "Calculate and present ROI for AI automation projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "roi",
-        "return on investment",
-        "calculator",
-        "sales",
-        "value",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "shipwright",
-      "source": "./plugins/ai-agency/shipwright",
-      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
-      "version": "1.3.0",
-      "category": "ai-agency",
-      "author": {
-        "name": "Nate Nelson",
-        "url": "https://github.com/Wynelson94"
-      },
-      "keywords": [
-        "app-builder",
-        "code-generator",
-        "autonomous-agent",
-        "pipeline",
-        "nextjs",
-        "supabase",
-        "sveltekit",
-        "astro",
-        "ai-agency"
-      ],
-      "repository": "https://github.com/Wynelson94/shipwright",
-      "homepage": "https://github.com/Wynelson94/shipwright",
-      "license": "MIT"
-    },
-    {
-      "name": "sow-generator",
-      "source": "./plugins/ai-agency/sow-generator",
-      "description": "Generate professional Statements of Work for AI projects",
-      "version": "1.9.0",
-      "category": "ai-agency",
-      "keywords": [
-        "sow",
-        "statement of work",
-        "contract",
-        "proposal",
-        "agency",
-        "ai-agency"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub"
-      }
-    },
-    {
-      "name": "tonone",
-      "source": "./plugins/ai-agency/tonone",
-      "description": "23-agent engineering + product team with 125 skills for Claude Code",
-      "version": "1.8.0",
-      "category": "ai-agency",
-      "keywords": [
-        "agents",
-        "engineering-team",
-        "infrastructure",
-        "devops",
-        "backend",
-        "security",
-        "observability",
-        "frontend",
-        "ml",
-        "mobile",
-        "embedded",
-        "analytics",
-        "testing",
-        "platform",
-        "sales",
-        "revenue",
-        "customer-success",
-        "content-marketing",
-        "pr",
-        "community",
-        "finance",
-        "people",
-        "operations",
-        "support"
-      ],
-      "author": {
-        "name": "tonone-ai",
-        "url": "https://tonone.ai"
-      },
-      "repository": "https://github.com/tonone-ai/tonone",
-      "license": "MIT"
-    },
-    {
-      "name": "zapier-zap-builder",
-      "source": "./plugins/ai-agency/zapier-zap-builder",
-      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
+      "name": "ai-commit-gen",
+      "source": "./plugins/productivity/ai-commit-gen",
+      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
       "version": "1.10.0",
-      "category": "ai-agency",
+      "category": "productivity",
       "keywords": [
-        "zapier",
-        "zap",
+        "git",
+        "commit",
+        "conventional-commits",
+        "ai",
         "automation",
-        "integration",
-        "workflow",
-        "ai-agency"
+        "productivity",
+        "devops"
       ],
       "author": {
-        "name": "Claude Code Plugin Hub"
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
       }
     },
     {
@@ -246,6 +212,64 @@
         "bias",
         "responsible-ai",
         "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "a2a-client",
+      "source": "./plugins/mcp/a2a-client",
+      "description": "Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "a2a",
+        "agent2agent",
+        "agent-card",
+        "multi-agent",
+        "interoperability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "ai-experiment-logger",
+      "source": "./plugins/mcp/ai-experiment-logger",
+      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
+      "version": "1.12.0",
+      "category": "mcp",
+      "keywords": [
+        "ai",
+        "experiments",
+        "logging",
+        "mcp"
+      ],
+      "author": {
+        "name": "Claude Code Plugins"
+      }
+    },
+    {
+      "name": "ai-ml-engineering-pack",
+      "source": "./plugins/packages/ai-ml-engineering-pack",
+      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "ai",
+        "ml",
+        "llm",
+        "prompt-engineering",
+        "rag",
+        "vector-database",
+        "ai-safety",
+        "openai",
+        "anthropic",
+        "package"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -279,6 +303,23 @@
       }
     },
     {
+      "name": "alerting-rule-creator",
+      "source": "./plugins/performance/alerting-rule-creator",
+      "description": "Create intelligent alerting rules for performance monitoring",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "alerting",
+        "monitoring",
+        "sre",
+        "observability"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "anomaly-detection-system",
       "source": "./plugins/ai-ml/anomaly-detection-system",
       "description": "Detect anomalies and outliers in data",
@@ -297,642 +338,21 @@
       }
     },
     {
-      "name": "automl-pipeline-builder",
-      "source": "./plugins/ai-ml/automl-pipeline-builder",
-      "description": "Build AutoML pipelines",
-      "version": "1.25.0",
-      "category": "ai-ml",
+      "name": "ansible-playbook-creator",
+      "source": "./plugins/devops/ansible-playbook-creator",
+      "description": "Create Ansible playbooks for configuration management",
+      "version": "1.27.0",
+      "category": "devops",
       "keywords": [
-        "automl",
-        "automated",
-        "pipeline",
-        "h2o",
-        "ml"
+        "ansible",
+        "automation",
+        "configuration",
+        "playbooks",
+        "devops"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
-      }
-    },
-    {
-      "name": "classification-model-builder",
-      "source": "./plugins/ai-ml/classification-model-builder",
-      "description": "Build classification models",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "classification",
-        "supervised",
-        "predictor",
-        "labels",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "clustering-algorithm-runner",
-      "source": "./plugins/ai-ml/clustering-algorithm-runner",
-      "description": "Run clustering algorithms on datasets",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "clustering",
-        "kmeans",
-        "dbscan",
-        "hierarchical",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "computer-vision-processor",
-      "source": "./plugins/ai-ml/computer-vision-processor",
-      "description": "Computer vision image processing and analysis",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "cv",
-        "vision",
-        "images",
-        "detection",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "data-preprocessing-pipeline",
-      "source": "./plugins/ai-ml/data-preprocessing-pipeline",
-      "description": "Automated data preprocessing and cleaning pipelines",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "preprocessing",
-        "cleaning",
-        "etl",
-        "pipeline",
-        "data"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "data-visualization-creator",
-      "source": "./plugins/ai-ml/data-visualization-creator",
-      "description": "Create data visualizations and plots",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "visualization",
-        "plots",
-        "charts",
-        "graphs",
-        "analytics"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "dataset-splitter",
-      "source": "./plugins/ai-ml/dataset-splitter",
-      "description": "Split datasets for training, validation, and testing",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "split",
-        "train-test",
-        "validation",
-        "stratify",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "deep-learning-optimizer",
-      "source": "./plugins/ai-ml/deep-learning-optimizer",
-      "description": "Deep learning optimization techniques",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "optimization",
-        "adam",
-        "sgd",
-        "learning-rate",
-        "deep-learning"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "experiment-tracking-setup",
-      "source": "./plugins/ai-ml/experiment-tracking-setup",
-      "description": "Set up ML experiment tracking",
-      "version": "1.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "experiments",
-        "mlflow",
-        "wandb",
-        "tracking",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "feature-engineering-toolkit",
-      "source": "./plugins/ai-ml/feature-engineering-toolkit",
-      "description": "Feature creation, selection, and transformation tools",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "features",
-        "engineering",
-        "selection",
-        "transformation",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "hyperparameter-tuner",
-      "source": "./plugins/ai-ml/hyperparameter-tuner",
-      "description": "Optimize hyperparameters using grid/random/bayesian search",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "hyperparameters",
-        "optimization",
-        "tuning",
-        "search",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "jeremy-adk-orchestrator",
-      "source": "./plugins/ai-ml/jeremy-adk-orchestrator",
-      "description": "Production ADK orchestrator for A2A protocol and multi-agent coordination on Vertex AI",
-      "version": "2.29.0",
-      "category": "ai-ml",
-      "keywords": [
-        "vertex-ai",
-        "adk",
-        "a2a-protocol",
-        "multi-agent",
-        "code-execution",
-        "memory-bank"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-adk-software-engineer",
-      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
-      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
-      "version": "2.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "adk",
-        "software-engineer",
-        "agent-development",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-gcp-starter-examples",
-      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
-      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
-      "version": "2.25.0",
-      "category": "ai-ml",
-      "keywords": [
-        "google-cloud",
-        "adk-samples",
-        "genkit-examples",
-        "vertex-ai",
-        "agent-starter-pack",
-        "code-examples",
-        "starter-kits",
-        "templates"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-genkit-pro",
-      "source": "./plugins/ai-ml/jeremy-genkit-pro",
-      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
-      "version": "2.26.0",
-      "category": "ai-ml",
-      "keywords": [
-        "firebase",
-        "genkit",
-        "ai-flows",
-        "rag",
-        "monitoring",
-        "gemini",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-google-adk",
-      "source": "./plugins/ai-ml/jeremy-google-adk",
-      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
-      "version": "2.2.0",
-      "category": "ai-ml",
-      "keywords": [
-        "google",
-        "adk",
-        "agent-development-kit",
-        "ai-agents",
-        "react-pattern",
-        "multi-agent",
-        "vertex-ai",
-        "agent-engine"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-vertex-ai",
-      "source": "./plugins/ai-ml/jeremy-vertex-ai",
-      "description": "Build and deploy generative AI agents on Vertex AI: Gemini model selection, RAG with grounded retrieval, function calling, multimodal extraction, evaluation, and Agent Engine deployment with operational guardrails.",
-      "version": "2.2.0",
-      "category": "ai-ml",
-      "keywords": [
-        "vertex-ai",
-        "gemini",
-        "google-cloud",
-        "generative-ai",
-        "rag",
-        "agent-engine",
-        "function-calling",
-        "multimodal"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-vertex-engine",
-      "source": "./plugins/ai-ml/jeremy-vertex-engine",
-      "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
-      "version": "2.31.0",
-      "category": "ai-ml",
-      "keywords": [
-        "vertex-ai",
-        "agent-engine",
-        "runtime-inspector",
-        "agent-monitoring",
-        "compliance",
-        "production-validation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-vertex-validator",
-      "source": "./plugins/ai-ml/jeremy-vertex-validator",
-      "description": "Production readiness validator for Vertex AI deployments and configurations",
-      "version": "2.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "vertex-ai",
-        "validation",
-        "production-readiness",
-        "security",
-        "compliance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "local-tts",
-      "source": "./plugins/ai-ml/local-tts",
-      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
-      "version": "1.3.0",
-      "category": "ai-ml",
-      "keywords": [
-        "tts",
-        "text-to-speech",
-        "voice",
-        "voice-cloning",
-        "voice-design",
-        "offline",
-        "voxcpm",
-        "apple-silicon",
-        "audio",
-        "narration"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "Apache-2.0",
-      "repository": "https://github.com/vdk888/local-tts"
-    },
-    {
-      "name": "ml-model-trainer",
-      "source": "./plugins/ai-ml/ml-model-trainer",
-      "description": "Train and optimize machine learning models with automated workflows",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "ml",
-        "machine-learning",
-        "training",
-        "models",
-        "ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-deployment-helper",
-      "source": "./plugins/ai-ml/model-deployment-helper",
-      "description": "Deploy ML models to production",
-      "version": "1.19.0",
-      "category": "ai-ml",
-      "keywords": [
-        "deployment",
-        "serving",
-        "production",
-        "api",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-evaluation-suite",
-      "source": "./plugins/ai-ml/model-evaluation-suite",
-      "description": "Comprehensive model evaluation with multiple metrics",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "evaluation",
-        "metrics",
-        "testing",
-        "validation",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-explainability-tool",
-      "source": "./plugins/ai-ml/model-explainability-tool",
-      "description": "Model interpretability and explainability",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "explainability",
-        "shap",
-        "lime",
-        "interpretability",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "model-versioning-tracker",
-      "source": "./plugins/ai-ml/model-versioning-tracker",
-      "description": "Track and manage model versions",
-      "version": "1.24.0",
-      "category": "ai-ml",
-      "keywords": [
-        "versioning",
-        "mlflow",
-        "tracking",
-        "registry",
-        "mlops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "neural-network-builder",
-      "source": "./plugins/ai-ml/neural-network-builder",
-      "description": "Build and configure neural network architectures",
-      "version": "1.20.0",
-      "category": "ai-ml",
-      "keywords": [
-        "neural-networks",
-        "deep-learning",
-        "architecture",
-        "pytorch",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "nlp-text-analyzer",
-      "source": "./plugins/ai-ml/nlp-text-analyzer",
-      "description": "Natural language processing and text analysis",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "nlp",
-        "text",
-        "analysis",
-        "tokenization",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ollama-local-ai",
-      "source": "./plugins/ai-ml/ollama-local-ai",
-      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
-      "version": "1.18.0",
-      "category": "ai-ml",
-      "keywords": [
-        "ollama",
-        "local-llm",
-        "free-ai",
-        "self-hosted",
-        "llama",
-        "mistral",
-        "privacy",
-        "zero-cost",
-        "openai-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "recommendation-engine",
-      "source": "./plugins/ai-ml/recommendation-engine",
-      "description": "Build recommendation systems and engines",
-      "version": "1.21.0",
-      "category": "ai-ml",
-      "keywords": [
-        "recommendations",
-        "collaborative",
-        "content-based",
-        "ranking",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "regression-analysis-tool",
-      "source": "./plugins/ai-ml/regression-analysis-tool",
-      "description": "Regression analysis and modeling",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "regression",
-        "prediction",
-        "linear",
-        "polynomial",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "sentiment-analysis-tool",
-      "source": "./plugins/ai-ml/sentiment-analysis-tool",
-      "description": "Sentiment analysis on text data",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "sentiment",
-        "opinion",
-        "emotion",
-        "polarity",
-        "nlp"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "time-series-forecaster",
-      "source": "./plugins/ai-ml/time-series-forecaster",
-      "description": "Time series forecasting and analysis",
-      "version": "1.23.0",
-      "category": "ai-ml",
-      "keywords": [
-        "time-series",
-        "forecasting",
-        "arima",
-        "prophet",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "transfer-learning-adapter",
-      "source": "./plugins/ai-ml/transfer-learning-adapter",
-      "description": "Transfer learning adaptation",
-      "version": "1.22.0",
-      "category": "ai-ml",
-      "keywords": [
-        "transfer-learning",
-        "fine-tuning",
-        "pretrained",
-        "adapters",
-        "ml"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "web-analytics",
-      "source": "./plugins/analytics/web-analytics",
-      "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
-      "version": "1.4.0",
-      "category": "analytics",
-      "keywords": [
-        "analytics",
-        "umami",
-        "ga4",
-        "traffic",
-        "mcp",
-        "self-hosted",
-        "multi-agent",
-        "push-based"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
       }
     },
     {
@@ -1053,6 +473,25 @@
       ],
       "author": {
         "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "api-fuzzer",
+      "source": "./plugins/testing/api-fuzzer",
+      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "fuzzing",
+        "api",
+        "security",
+        "edge-cases",
+        "input-validation"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
       }
     },
@@ -1245,6 +684,25 @@
       }
     },
     {
+      "name": "api-test-automation",
+      "source": "./plugins/testing/api-test-automation",
+      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "api",
+        "rest",
+        "graphql",
+        "automation",
+        "endpoints"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "api-throttling-manager",
       "source": "./plugins/api-development/api-throttling-manager",
       "description": "Manage API throttling with dynamic rate limits and quota management",
@@ -1279,199 +737,17 @@
       }
     },
     {
-      "name": "graphql-server-builder",
-      "source": "./plugins/api-development/graphql-server-builder",
-      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
-      "version": "1.22.0",
-      "category": "api-development",
-      "keywords": [
-        "graphql",
-        "api",
-        "server",
-        "apollo",
-        "schema",
-        "resolvers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "grpc-service-generator",
-      "source": "./plugins/api-development/grpc-service-generator",
-      "description": "Generate gRPC services with Protocol Buffers and streaming support",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "grpc",
-        "protobuf",
-        "microservices",
-        "streaming"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "rest-api-generator",
-      "source": "./plugins/api-development/rest-api-generator",
-      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
-      "version": "1.23.0",
-      "category": "api-development",
-      "keywords": [
-        "api",
-        "rest",
-        "generator",
-        "openapi",
-        "swagger",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "webhook-handler-creator",
-      "source": "./plugins/api-development/webhook-handler-creator",
-      "description": "Create secure webhook endpoints with signature verification and retry logic",
-      "version": "1.25.0",
-      "category": "api-development",
-      "keywords": [
-        "webhook",
-        "events",
-        "signature",
-        "security"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "websocket-server-builder",
-      "source": "./plugins/api-development/websocket-server-builder",
-      "description": "Build WebSocket servers for real-time bidirectional communication",
-      "version": "1.24.0",
-      "category": "api-development",
-      "keywords": [
-        "websocket",
-        "real-time",
-        "socket.io",
-        "ws"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "x-twitter-scraper",
-      "source": "./plugins/api-development/x-twitter-scraper",
-      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
-      "version": "0.1.0",
-      "category": "api-development",
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
-      "license": "MIT"
-    },
-    {
-      "name": "brand-strategy-framework",
-      "source": "./plugins/business-tools/brand-strategy-framework",
-      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
-      "version": "1.7.0",
-      "category": "business-tools",
-      "keywords": [
-        "brand-strategy",
-        "marketing",
-        "branding",
-        "positioning",
-        "messaging",
-        "brand-guidelines",
-        "audience-architecture",
-        "brand-identity"
-      ],
-      "author": {
-        "name": "Rowan Brooks",
-        "email": "rowanbrooks100@github.com"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills"
-    },
-    {
-      "name": "excel-analyst-pro",
-      "source": "./plugins/business-tools/excel-analyst-pro",
-      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
+      "name": "apm-dashboard-creator",
+      "source": "./plugins/performance/apm-dashboard-creator",
+      "description": "Create Application Performance Monitoring dashboards",
       "version": "1.21.0",
-      "category": "business-tools",
+      "category": "performance",
       "keywords": [
-        "excel",
-        "financial-modeling",
-        "dcf",
-        "lbo",
-        "valuation",
-        "variance-analysis",
-        "pivot-tables",
-        "investment-banking",
-        "private-equity",
-        "financial-analysis",
-        "skills",
-        "mcp"
-      ],
-      "author": {
-        "name": "ClaudeCodePlugins",
-        "email": "plugins@tonsofskills.com"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "executive-assistant-skills",
-      "source": "./plugins/business-tools/executive-assistant-skills",
-      "version": "1.8.0",
-      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
-      "author": {
-        "name": "Martin Gontovnikas",
-        "email": "gonto@hypergrowthpartners.com",
-        "url": "https://github.com/mgonto"
-      },
-      "category": "business-tools",
-      "keywords": [
-        "executive-assistant",
-        "meeting-prep",
-        "email",
-        "productivity",
-        "automation",
-        "todoist"
-      ],
-      "license": "MIT",
-      "repository": "https://github.com/mgonto/executive-assistant-skills"
-    },
-    {
-      "name": "openbb-terminal",
-      "source": "./plugins/business-tools/openbb-terminal",
-      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
-      "version": "1.6.0",
-      "category": "business-tools",
-      "keywords": [
-        "finance",
-        "investment",
-        "openbb",
-        "stocks",
-        "crypto",
-        "portfolio",
-        "trading",
-        "financial-analysis",
-        "market-data",
-        "equity-research",
-        "options",
-        "forex",
-        "macroeconomics",
-        "quant",
-        "ai-finance"
+        "apm",
+        "monitoring",
+        "dashboard",
+        "grafana",
+        "datadog"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -1479,936 +755,20 @@
       }
     },
     {
-      "name": "promptbook",
-      "source": "./plugins/business-tools/promptbook",
-      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
-      "version": "1.4.0",
-      "category": "business-tools",
-      "keywords": [
-        "analytics",
-        "telemetry",
-        "builds",
-        "portfolio",
-        "tracking",
-        "metrics",
-        "sessions"
-      ],
-      "author": {
-        "name": "Promptbook",
-        "email": "contact@promptbook.gg"
-      },
-      "homepage": "https://promptbook.gg",
-      "repository": "https://github.com/promptbookgg/claude-code-plugin",
-      "license": "MIT"
-    },
-    {
-      "name": "wondelai-blue-ocean-strategy",
-      "source": "./plugins/business-tools/wondelai-blue-ocean-strategy",
-      "description": "Blue Ocean Strategy framework for creating uncontested market space. Use the Strategy Canvas, Four Actions Framework (ERRC), and value innovation to break the value-cost trade-off.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "strategy",
-        "blue-ocean",
-        "value-innovation",
-        "market-creation",
-        "errc",
-        "strategy-canvas",
-        "competition",
-        "positioning"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-contagious",
-      "source": "./plugins/business-tools/wondelai-contagious",
-      "description": "Word-of-mouth and virality framework using the STEPPS model (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Engineer products and content that people naturally share.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "virality",
-        "word-of-mouth",
-        "stepps",
-        "social-currency",
-        "marketing",
-        "content-strategy",
-        "sharing",
-        "growth"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-cro-methodology",
-      "source": "./plugins/business-tools/wondelai-cro-methodology",
-      "description": "Customer-centric conversion rate optimization methodology. Audit landing pages, identify conversion blockers, write persuasive copy, design A/B tests, and optimize funnels.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "cro",
-        "conversion",
-        "optimization",
-        "landing-pages",
-        "ab-testing",
-        "copywriting",
-        "persuasion",
-        "funnels"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-crossing-the-chasm",
-      "source": "./plugins/business-tools/wondelai-crossing-the-chasm",
-      "description": "Technology adoption and go-to-market strategy for crossing from early adopters to mainstream market. Choose beachhead segments, build whole products, and position against incumbents.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "go-to-market",
-        "technology-adoption",
-        "chasm",
-        "beachhead",
-        "b2b",
-        "saas",
-        "market-strategy",
-        "positioning"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-drive-motivation",
-      "source": "./plugins/business-tools/wondelai-drive-motivation",
-      "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "motivation",
-        "autonomy",
-        "mastery",
-        "purpose",
-        "engagement",
-        "gamification",
-        "intrinsic-motivation",
-        "team-management"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-hundred-million-offers",
-      "source": "./plugins/business-tools/wondelai-hundred-million-offers",
-      "description": "Grand Slam Offer creation framework. Create irresistible offers using the Value Equation, stack bonuses, design risk-reversing guarantees, and apply ethical scarcity.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "offers",
-        "pricing",
-        "value-equation",
-        "guarantees",
-        "bonuses",
-        "scarcity",
-        "sales",
-        "hormozi"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-influence-psychology",
-      "source": "./plugins/business-tools/wondelai-influence-psychology",
-      "description": "Persuasion science framework based on Cialdini's six principles (Reciprocity, Commitment, Social Proof, Authority, Liking, Scarcity). Apply ethical persuasion to product design and marketing.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "persuasion",
-        "influence",
-        "cialdini",
-        "social-proof",
-        "reciprocity",
-        "scarcity",
-        "psychology",
-        "marketing"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-jobs-to-be-done",
-      "source": "./plugins/business-tools/wondelai-jobs-to-be-done",
-      "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "jtbd",
-        "jobs-to-be-done",
-        "product-strategy",
-        "customer-discovery",
-        "innovation",
-        "christensen",
-        "product-market-fit",
-        "interviews"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-made-to-stick",
-      "source": "./plugins/business-tools/wondelai-made-to-stick",
-      "description": "Sticky messaging framework using the SUCCESs model (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Make product messaging memorable and create compelling presentations.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "messaging",
-        "storytelling",
-        "success",
-        "sticky",
-        "communication",
-        "presentations",
-        "copywriting",
-        "branding"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-negotiation",
-      "source": "./plugins/business-tools/wondelai-negotiation",
-      "description": "Tactical negotiation framework based on Chris Voss's techniques. Use mirroring, labeling, calibrated questions, the Ackerman method, and accusation audits for business and salary negotiations.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "negotiation",
-        "chris-voss",
-        "mirroring",
-        "labeling",
-        "ackerman",
-        "salary",
-        "deals",
-        "conflict-resolution"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-obviously-awesome",
-      "source": "./plugins/business-tools/wondelai-obviously-awesome",
-      "description": "Product positioning framework for competitive differentiation. Define competitive alternatives, identify unique attributes, map value themes, and choose the right market category.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "positioning",
-        "differentiation",
-        "competitive-analysis",
-        "market-category",
-        "value-proposition",
-        "april-dunford",
-        "go-to-market",
-        "branding"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-one-page-marketing",
-      "source": "./plugins/business-tools/wondelai-one-page-marketing",
-      "description": "End-to-end marketing plan framework. Define target market, craft USP, choose channels, design lead capture and nurture sequences, optimize conversion, and build referral systems.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "marketing-plan",
-        "usp",
-        "lead-generation",
-        "nurture",
-        "referral",
-        "advertising",
-        "customer-lifetime-value",
-        "marketing-strategy"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-predictable-revenue",
-      "source": "./plugins/business-tools/wondelai-predictable-revenue",
-      "description": "Outbound sales methodology for scalable B2B pipeline. Implement Cold Calling 2.0, structure SDR/AE/CSM roles, design prospecting sequences, and build predictable revenue engines.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "sales",
-        "outbound",
-        "sdr",
-        "pipeline",
-        "b2b",
-        "saas",
-        "prospecting",
-        "cold-calling",
-        "revenue"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-scorecard-marketing",
-      "source": "./plugins/business-tools/wondelai-scorecard-marketing",
-      "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "lead-generation",
-        "quiz-funnel",
-        "assessment",
-        "scorecard",
-        "conversion",
-        "segmentation",
-        "lead-magnet",
-        "marketing-automation"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-storybrand-messaging",
-      "source": "./plugins/business-tools/wondelai-storybrand-messaging",
-      "description": "StoryBrand messaging framework that positions customer as hero. Create brand scripts, write website copy that converts, craft one-liners, and build narrative-driven landing pages.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "storybrand",
-        "messaging",
-        "brand-script",
-        "copywriting",
-        "narrative",
-        "website-copy",
-        "one-liner",
-        "donald-miller"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-traction-eos",
-      "source": "./plugins/business-tools/wondelai-traction-eos",
-      "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
-      "version": "1.0.0",
-      "category": "business-tools",
-      "keywords": [
-        "eos",
-        "traction",
-        "operating-system",
-        "rocks",
-        "l10-meetings",
-        "accountability",
-        "vision",
-        "execution"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "b12-claude-plugin",
-      "source": "./plugins/community/b12-claude-plugin",
-      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
-      "version": "1.9.0",
-      "category": "community",
-      "keywords": [
-        "website",
-        "b12",
-        "hosting",
-        "web-design",
-        "ai-website",
-        "website-generator",
-        "saas"
-      ],
-      "author": {
-        "name": "B12.io",
-        "url": "https://github.com/b12io"
-      }
-    },
-    {
-      "name": "boycott-filter",
-      "source": "./plugins/community/boycott-filter",
-      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
-      "version": "1.2.0",
-      "category": "community",
-      "keywords": [
-        "boycott",
-        "consumer",
-        "shopping",
-        "brands",
-        "chrome-extension",
-        "conversational",
-        "privacy",
-        "ethical-consumption"
-      ],
-      "author": {
-        "name": "Bubble Invest",
-        "email": "contact@bubbleinvest.com"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/vdk888/boycott-filter"
-    },
-    {
-      "name": "claude-never-forgets",
-      "source": "./plugins/community/claude-never-forgets",
-      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "name": "application-profiler",
+      "source": "./plugins/performance/application-profiler",
+      "description": "Profile application performance with CPU, memory, and execution time analysis",
       "version": "1.21.0",
-      "category": "community",
+      "category": "performance",
       "keywords": [
-        "memory",
-        "context",
-        "persistent",
-        "preferences",
-        "sessions",
-        "recall"
-      ],
-      "author": {
-        "name": "yldrmahmet",
-        "url": "https://github.com/yldrmahmet"
-      }
-    },
-    {
-      "name": "claude-reflect",
-      "source": "./plugins/community/claude-reflect",
-      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": [
-        "claude-code",
-        "self-learning",
-        "corrections",
-        "CLAUDE.md",
-        "memory",
-        "learnings",
-        "hooks",
-        "automation"
-      ],
-      "author": {
-        "name": "Bayram Annakov",
-        "url": "https://github.com/bayramannakov"
-      },
-      "repository": "https://github.com/bayramannakov/claude-reflect"
-    },
-    {
-      "name": "contributing-clanker",
-      "source": "./plugins/community/contributing-clanker",
-      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
-      "version": "0.8.0",
-      "category": "community",
-      "keywords": [
-        "oss",
-        "contributions",
-        "github",
-        "ai-slop-prevention",
-        "code-review",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
-      "repository": "https://github.com/jeremylongshore/contributing-clanker",
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-anti-deception",
-      "source": "./plugins/community/ejentum-anti-deception",
-      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-code",
-      "source": "./plugins/community/ejentum-code",
-      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-memory",
-      "source": "./plugins/community/ejentum-memory",
-      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "ejentum-reasoning",
-      "source": "./plugins/community/ejentum-reasoning",
-      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Ejentum",
-        "url": "https://github.com/ejentum",
-        "email": "info@ejentum.com"
-      },
-      "license": "MIT"
-    },
-    {
-      "name": "fairdb-ops-manager",
-      "source": "./plugins/community/fairdb-ops-manager",
-      "description": "Database operations management for FairDB PostgreSQL clusters",
-      "version": "1.12.0",
-      "category": "community",
-      "keywords": [
-        "database",
-        "postgresql",
-        "operations"
-      ],
-      "author": {
-        "name": "Community"
-      }
-    },
-    {
-      "name": "framecraft",
-      "source": "./plugins/community/framecraft",
-      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
-      "version": "1.3.0",
-      "category": "community",
-      "keywords": [
-        "demo-video",
-        "video-generation",
-        "playwright",
-        "ffmpeg",
-        "edge-tts",
-        "mcp"
-      ],
-      "author": {
-        "name": "vaddisrinivas",
-        "url": "https://github.com/vaddisrinivas"
-      }
-    },
-    {
-      "name": "gastown",
-      "source": "./plugins/community/gastown",
-      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "multi-agent",
-        "orchestration",
-        "automation",
-        "polecats",
-        "convoys",
-        "beads",
-        "work-tracking",
-        "ai-factory",
-        "gastown",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "research",
-        "games",
-        "accessibility",
         "performance",
-        "flask",
-        "react",
-        "godot",
-        "corpus-linguistics",
-        "mcp"
-      ],
-      "author": {
-        "name": "Luke Steuber",
-        "url": "https://github.com/lukeslp"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "mcp",
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "geepers",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Luke Steuber"
-      },
-      "homepage": "https://dr.eamer.dev/geepers/",
-      "repository": "https://github.com/lukeslp/geepers"
-    },
-    {
-      "name": "hermes-tweet",
-      "source": "./plugins/community/hermes-tweet",
-      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
-      "version": "0.1.6",
-      "category": "community",
-      "keywords": [
-        "hermes-agent",
-        "hermes-plugin",
-        "xquik",
-        "twitter",
-        "x",
-        "social-media",
-        "automation"
-      ],
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
-      "repository": "https://github.com/Xquik-dev/hermes-tweet",
-      "license": "MIT"
-    },
-    {
-      "name": "jeremy-firebase",
-      "source": "./plugins/community/jeremy-firebase",
-      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
-      "version": "2.23.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "vertex-ai",
-        "gemini",
-        "authentication",
-        "storage",
-        "hosting",
-        "cloud-functions",
-        "analytics",
-        "ai-integration",
-        "google-cloud",
-        "embeddings",
-        "model-deployment",
-        "ai-powered",
-        "production-ready"
+        "profiling",
+        "monitoring",
+        "optimization"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-firestore",
-      "source": "./plugins/community/jeremy-firestore",
-      "description": "Firestore database specialist for schema design, queries, and real-time sync",
-      "version": "2.20.0",
-      "category": "community",
-      "keywords": [
-        "firebase",
-        "firestore",
-        "database",
-        "crud",
-        "security-rules",
-        "cloud-functions",
-        "batch-operations",
-        "data-migration",
-        "performance",
-        "cost-optimization",
-        "nosql",
-        "google-cloud",
-        "a2a",
-        "agent-to-agent",
-        "mcp",
-        "cloud-run",
-        "vertex-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]",
-        "url": "https://intentsolutions.io"
-      }
-    },
-    {
-      "name": "llm-box",
-      "source": "./plugins/community/llm-box",
-      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
-      "version": "0.3.0",
-      "category": "community",
-      "keywords": [
-        "workflow",
-        "automation",
-        "terminal",
-        "cli",
-        "yaml",
-        "llm",
-        "mcp"
-      ],
-      "author": {
-        "name": "alib8b8",
-        "url": "https://github.com/alib8b8"
-      },
-      "homepage": "https://github.com/alib8b8/llm-box",
-      "repository": "https://github.com/alib8b8/llm-box",
-      "license": "MIT"
-    },
-    {
-      "name": "mnemos",
-      "source": "./plugins/community/mnemos",
-      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
-      "version": "0.9.0",
-      "category": "community",
-      "keywords": [
-        "memory",
-        "mcp",
-        "claude-code",
-        "persistent-memory",
-        "agent-memory",
-        "knowledge-graph",
-        "context",
-        "skill",
-        "observations",
-        "provenance",
-        "learning-loop",
-        "golang"
-      ],
-      "author": {
-        "name": "André Figueira",
-        "url": "https://polyxmedia.com",
-        "email": "andre@polyxmedia.com"
-      },
-      "homepage": "https://github.com/polyxmedia/mnemos",
-      "repository": "https://github.com/polyxmedia/mnemos",
-      "license": "MIT"
-    },
-    {
-      "name": "portaljs",
-      "source": "./plugins/community/portaljs",
-      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
-      "version": "0.1.0",
-      "category": "community",
-      "keywords": [
-        "portaljs",
-        "data-portal",
-        "ckan",
-        "nextjs",
-        "data-catalog"
-      ],
-      "author": {
-        "name": "Datopian",
-        "url": "https://www.datopian.com"
-      },
-      "homepage": "https://github.com/datopian/portaljs",
-      "repository": "https://github.com/datopian/portaljs",
-      "license": "MIT"
-    },
-    {
-      "name": "quit-sponsor",
-      "source": "./plugins/community/quit-sponsor",
-      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "metr0x",
-        "url": "https://github.com/metrox-eth"
-      },
-      "repository": "https://github.com/metrox-eth/quit-sponsor",
-      "license": "MIT"
-    },
-    {
-      "name": "skills-janitor",
-      "source": "./plugins/community/skills-janitor",
-      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
-      "version": "0.1.0",
-      "category": "community",
-      "keywords": [
-        "skills",
-        "cleanup",
-        "context-window",
-        "token-budget",
-        "maintenance",
-        "tui"
-      ],
-      "author": {
-        "name": "Krzysztof Hendzel",
-        "url": "https://github.com/khendzel",
-        "email": "krzysztoff.hendzel@gmail.com"
-      },
-      "repository": "https://github.com/khendzel/skills-janitor",
-      "license": "MIT"
-    },
-    {
-      "name": "sprint",
-      "source": "./plugins/community/sprint",
-      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
-      "version": "1.20.0",
-      "category": "community",
-      "keywords": [
-        "autonomous",
-        "agentic",
-        "yolo",
-        "self-iterating",
-        "multi-agent",
-        "hands-off",
-        "auto-pilot",
-        "orchestration",
-        "sprint",
-        "testing",
-        "qa",
-        "mcp"
-      ],
-      "author": {
-        "name": "Damien Laine",
-        "email": "damien.laine@gmail.com",
-        "url": "https://github.com/damienlaine"
-      }
-    },
-    {
-      "name": "walkie-talkie",
-      "source": "./plugins/community/walkie-talkie",
-      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
-      "version": "0.1.0",
-      "category": "community",
-      "author": {
-        "name": "Walkie-Talkie Maintainers",
-        "url": "https://github.com/walkie-talkie-skill"
-      },
-      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
-      "license": "MIT"
-    },
-    {
-      "name": "zai-cli",
-      "source": "./plugins/community/zai-cli",
-      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
-      "version": "1.0.0",
-      "category": "community",
-      "keywords": [
-        "vision",
-        "image-analysis",
-        "ocr",
-        "web-search",
-        "web-reader",
-        "github",
-        "mcp",
-        "z-ai",
-        "glm-4",
-        "multimodal"
-      ],
-      "author": {
-        "name": "Numman Ali",
-        "email": "numman.ali@gmail.com",
-        "url": "https://github.com/numman-ali"
-      }
-    },
-    {
-      "name": "aomi",
-      "source": "./plugins/crypto/aomi",
-      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
-      "version": "0.10.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "defi",
-        "web3",
-        "evm",
-        "ethereum",
-        "wallet",
-        "account-abstraction",
-        "trading",
-        "agent",
-        "mcp"
-      ],
-      "author": {
-        "name": "aomi-labs",
-        "url": "https://aomi.dev",
-        "email": "info@aomi.dev"
+        "email": "[email protected]"
       }
     },
     {
@@ -2430,6 +790,75 @@
       }
     },
     {
+      "name": "authentication-validator",
+      "source": "./plugins/security/authentication-validator",
+      "description": "Validate authentication implementations",
+      "version": "1.26.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "auto-scaling-configurator",
+      "source": "./plugins/devops/auto-scaling-configurator",
+      "description": "Configure auto-scaling policies for applications and infrastructure",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "autoscaling",
+        "scaling",
+        "hpa",
+        "kubernetes",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "automl-pipeline-builder",
+      "source": "./plugins/ai-ml/automl-pipeline-builder",
+      "description": "Build AutoML pipelines",
+      "version": "1.25.0",
+      "category": "ai-ml",
+      "keywords": [
+        "automl",
+        "automated",
+        "pipeline",
+        "h2o",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "backup-strategy-implementor",
+      "source": "./plugins/devops/backup-strategy-implementor",
+      "description": "Implement backup strategies for databases and applications",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "backup",
+        "disaster-recovery",
+        "restoration",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "blockchain-explorer-cli",
       "source": "./plugins/crypto/blockchain-explorer-cli",
       "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
@@ -2442,6 +871,381 @@
         "transactions",
         "addresses",
         "contracts"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "bottleneck-detector",
+      "source": "./plugins/performance/bottleneck-detector",
+      "description": "Detect and resolve performance bottlenecks",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "bottleneck",
+        "performance",
+        "optimization",
+        "profiling"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "browser-compatibility-tester",
+      "source": "./plugins/testing/browser-compatibility-tester",
+      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
+      "version": "2.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "cross-browser",
+        "browserstack",
+        "selenium",
+        "playwright",
+        "compatibility"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cache-performance-optimizer",
+      "source": "./plugins/performance/cache-performance-optimizer",
+      "description": "Optimize caching strategies for improved performance",
+      "version": "1.19.0",
+      "category": "performance",
+      "keywords": [
+        "cache",
+        "performance",
+        "optimization",
+        "redis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "calendar-to-workflow",
+      "source": "./plugins/skill-enhancers/calendar-to-workflow",
+      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "calendar",
+        "automation",
+        "meetings",
+        "productivity"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "capacity-planning-analyzer",
+      "source": "./plugins/performance/capacity-planning-analyzer",
+      "description": "Analyze and plan for capacity requirements",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "capacity-planning",
+        "scaling",
+        "forecasting",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "chaos-engineering-toolkit",
+      "source": "./plugins/testing/chaos-engineering-toolkit",
+      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "chaos-engineering",
+        "resilience",
+        "failure-injection",
+        "fault-tolerance",
+        "reliability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "ci-cd-pipeline-builder",
+      "source": "./plugins/devops/ci-cd-pipeline-builder",
+      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "ci-cd",
+        "github-actions",
+        "gitlab-ci",
+        "jenkins",
+        "devops",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "classification-model-builder",
+      "source": "./plugins/ai-ml/classification-model-builder",
+      "description": "Build classification models",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "classification",
+        "supervised",
+        "predictor",
+        "labels",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cloud-cost-optimizer",
+      "source": "./plugins/devops/cloud-cost-optimizer",
+      "description": "Optimize cloud costs and generate cost reports",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "cost",
+        "optimization",
+        "finops",
+        "cloud",
+        "aws",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "clustering-algorithm-runner",
+      "source": "./plugins/ai-ml/clustering-algorithm-runner",
+      "description": "Run clustering algorithms on datasets",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "clustering",
+        "kmeans",
+        "dbscan",
+        "hierarchical",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "compliance-checker",
+      "source": "./plugins/devops/compliance-checker",
+      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
+      "version": "1.26.0",
+      "category": "devops",
+      "keywords": [
+        "compliance",
+        "security",
+        "audit",
+        "soc2",
+        "hipaa",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "compliance-report-generator",
+      "source": "./plugins/security/compliance-report-generator",
+      "description": "Generate compliance reports",
+      "version": "1.25.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "computer-vision-processor",
+      "source": "./plugins/ai-ml/computer-vision-processor",
+      "description": "Computer vision image processing and analysis",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "cv",
+        "vision",
+        "images",
+        "detection",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "container-registry-manager",
+      "source": "./plugins/devops/container-registry-manager",
+      "description": "Manage container registries (ECR, GCR, Harbor)",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "registry",
+        "containers",
+        "docker",
+        "ecr",
+        "gcr",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "container-security-scanner",
+      "source": "./plugins/devops/container-security-scanner",
+      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
+      "version": "1.27.0",
+      "category": "devops",
+      "keywords": [
+        "security",
+        "containers",
+        "scanning",
+        "vulnerabilities",
+        "trivy",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "contract-test-validator",
+      "source": "./plugins/testing/contract-test-validator",
+      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "contract-testing",
+        "pact",
+        "openapi",
+        "api",
+        "microservices",
+        "consumer-driven"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "conversational-api-debugger",
+      "source": "./plugins/mcp/conversational-api-debugger",
+      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "api",
+        "debugging",
+        "openapi",
+        "har",
+        "rest",
+        "curl",
+        "http"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cors-policy-validator",
+      "source": "./plugins/security/cors-policy-validator",
+      "description": "Validate CORS policies",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "cpu-usage-monitor",
+      "source": "./plugins/performance/cpu-usage-monitor",
+      "description": "Monitor and analyze CPU usage patterns in applications",
+      "version": "1.23.0",
+      "category": "performance",
+      "keywords": [
+        "cpu",
+        "monitoring",
+        "performance",
+        "optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "creator-studio-pack",
+      "source": "./plugins/packages/creator-studio-pack",
+      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
+      "version": "1.16.0",
+      "category": "packages",
+      "keywords": [
+        "video",
+        "content-creation",
+        "youtube",
+        "filmmaking",
+        "creator",
+        "documentation",
+        "screencast",
+        "tutorial",
+        "video-editing",
+        "content-strategy",
+        "distribution",
+        "thumbnails",
+        "subtitles",
+        "repurposing",
+        "batch-recording",
+        "analytics",
+        "package",
+        "premium"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2566,19 +1370,15 @@
       }
     },
     {
-      "name": "defi-yield-optimizer",
-      "source": "./plugins/crypto/defi-yield-optimizer",
-      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
-      "version": "1.28.0",
-      "category": "crypto",
+      "name": "csrf-protection-validator",
+      "source": "./plugins/security/csrf-protection-validator",
+      "description": "Validate CSRF protection",
+      "version": "1.26.0",
+      "category": "security",
       "keywords": [
-        "defi",
-        "yield",
-        "farming",
-        "liquidity",
-        "apy",
-        "optimization",
-        "crypto"
+        "security",
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2586,77 +1386,17 @@
       }
     },
     {
-      "name": "dex-aggregator-router",
-      "source": "./plugins/crypto/dex-aggregator-router",
-      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": [
-        "dex",
-        "swap",
-        "trading",
-        "defi",
-        "aggregator",
-        "routing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "flash-loan-simulator",
-      "source": "./plugins/crypto/flash-loan-simulator",
-      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "flash-loans",
-        "defi",
-        "aave",
-        "arbitrage",
-        "liquidation",
-        "ethereum",
-        "simulation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "gas-fee-optimizer",
-      "source": "./plugins/crypto/gas-fee-optimizer",
-      "description": "Optimize transaction gas fees with timing and routing recommendations",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "gas",
-        "fees",
-        "ethereum",
-        "optimization",
-        "transaction",
-        "l2"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "liquidity-pool-analyzer",
-      "source": "./plugins/crypto/liquidity-pool-analyzer",
-      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
+      "name": "data-preprocessing-pipeline",
+      "source": "./plugins/ai-ml/data-preprocessing-pipeline",
+      "description": "Automated data preprocessing and cleaning pipelines",
       "version": "1.23.0",
-      "category": "crypto",
+      "category": "ai-ml",
       "keywords": [
-        "liquidity",
-        "pool",
-        "defi",
-        "impermanent",
-        "loss",
-        "apy"
+        "preprocessing",
+        "cleaning",
+        "etl",
+        "pipeline",
+        "data"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2664,249 +1404,15 @@
       }
     },
     {
-      "name": "market-movers-scanner",
-      "source": "./plugins/crypto/market-movers-scanner",
-      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
-      "version": "1.27.0",
-      "category": "crypto",
+      "name": "data-privacy-scanner",
+      "source": "./plugins/security/data-privacy-scanner",
+      "description": "Scan for data privacy issues",
+      "version": "1.23.0",
+      "category": "security",
       "keywords": [
-        "market",
-        "scanner",
-        "movers",
-        "gainers",
-        "losers",
-        "volume",
-        "trading"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "market-price-tracker",
-      "source": "./plugins/crypto/market-price-tracker",
-      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
-      "version": "1.27.0",
-      "category": "crypto",
-      "keywords": [
-        "market",
-        "price",
-        "tracking",
-        "trading",
-        "crypto",
-        "stocks",
-        "forex"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "market-sentiment-analyzer",
-      "source": "./plugins/crypto/market-sentiment-analyzer",
-      "description": "Analyze market sentiment from social media, news, and on-chain data",
-      "version": "1.24.0",
-      "category": "crypto",
-      "keywords": [
-        "sentiment",
-        "analysis",
-        "social",
-        "news",
-        "market",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "mempool-analyzer",
-      "source": "./plugins/crypto/mempool-analyzer",
-      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
-      "version": "1.32.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "mempool",
-        "mev",
-        "ethereum",
-        "blockchain",
-        "gas",
-        "pending-transactions",
-        "arbitrage"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "nft-rarity-analyzer",
-      "source": "./plugins/crypto/nft-rarity-analyzer",
-      "description": "Analyze NFT rarity scores and valuations across collections",
-      "version": "1.25.0",
-      "category": "crypto",
-      "keywords": [
-        "nft",
-        "rarity",
-        "valuation",
-        "traits",
-        "opensea",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "on-chain-analytics",
-      "source": "./plugins/crypto/on-chain-analytics",
-      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "on-chain",
-        "analytics",
-        "whale",
-        "metrics",
-        "blockchain"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "options-flow-analyzer",
-      "source": "./plugins/crypto/options-flow-analyzer",
-      "description": "Track institutional options flow, unusual activity, and smart money movements",
-      "version": "1.29.0",
-      "category": "crypto",
-      "keywords": [
-        "options",
-        "flow",
-        "institutional",
-        "trading",
-        "derivatives",
-        "smart money"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "staking-rewards-optimizer",
-      "source": "./plugins/crypto/staking-rewards-optimizer",
-      "description": "Optimize staking rewards across multiple protocols and chains",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "staking",
-        "defi",
-        "yield",
-        "optimization",
-        "rewards"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "token-launch-tracker",
-      "source": "./plugins/crypto/token-launch-tracker",
-      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
-      "version": "1.30.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "token-launch",
-        "rugpull",
         "security",
-        "scam-detection",
-        "contract-analysis",
-        "defi",
-        "new-tokens"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "trading-strategy-backtester",
-      "source": "./plugins/crypto/trading-strategy-backtester",
-      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
-      "version": "1.28.0",
-      "category": "crypto",
-      "keywords": [
-        "trading",
-        "backtesting",
-        "strategy",
-        "historical",
-        "performance",
-        "risk"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "wallet-portfolio-tracker",
-      "source": "./plugins/crypto/wallet-portfolio-tracker",
-      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
-      "version": "1.12.0",
-      "category": "crypto",
-      "keywords": [
-        "wallet",
-        "portfolio",
-        "tracking",
-        "blockchain",
-        "defi",
-        "crypto"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "wallet-security-auditor",
-      "source": "./plugins/crypto/wallet-security-auditor",
-      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
-      "version": "1.17.0",
-      "category": "crypto",
-      "keywords": [
-        "crypto",
-        "wallet",
-        "security",
-        "audit",
-        "web3"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "whale-alert-monitor",
-      "source": "./plugins/crypto/whale-alert-monitor",
-      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
-      "version": "1.26.0",
-      "category": "crypto",
-      "keywords": [
-        "whale",
-        "alert",
-        "monitor",
-        "large",
-        "transactions"
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -2941,6 +1447,24 @@
         "database",
         "backend",
         "validation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "data-visualization-creator",
+      "source": "./plugins/ai-ml/data-visualization-creator",
+      "description": "Create data visualizations and plots",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "visualization",
+        "plots",
+        "charts",
+        "graphs",
+        "analytics"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3147,6 +1671,24 @@
       }
     },
     {
+      "name": "database-query-profiler",
+      "source": "./plugins/performance/database-query-profiler",
+      "description": "Profile and optimize database queries for performance",
+      "version": "1.9.0",
+      "category": "performance",
+      "keywords": [
+        "database",
+        "query",
+        "profiling",
+        "optimization",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "database-recovery-manager",
       "source": "./plugins/database/database-recovery-manager",
       "description": "Database plugin for database-recovery-manager",
@@ -3231,6 +1773,26 @@
       }
     },
     {
+      "name": "database-test-manager",
+      "source": "./plugins/testing/database-test-manager",
+      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "database",
+        "sql",
+        "test-data",
+        "fixtures",
+        "migrations",
+        "transactions"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "database-transaction-monitor",
       "source": "./plugins/database/database-transaction-monitor",
       "description": "Database plugin for database-transaction-monitor",
@@ -3247,36 +1809,17 @@
       }
     },
     {
-      "name": "freshie-inventory-manager",
-      "source": "./plugins/database/freshie-inventory-manager",
-      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
-      "version": "1.5.0",
-      "category": "database",
+      "name": "dataset-splitter",
+      "source": "./plugins/ai-ml/dataset-splitter",
+      "description": "Split datasets for training, validation, and testing",
+      "version": "1.22.0",
+      "category": "ai-ml",
       "keywords": [
-        "database",
-        "inventory",
-        "freshie",
-        "compliance",
-        "sqlite",
-        "ecosystem",
-        "audit",
-        "subagents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "nosql-data-modeler",
-      "source": "./plugins/database/nosql-data-modeler",
-      "description": "Database plugin for nosql-data-modeler",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "data"
+        "split",
+        "train-test",
+        "validation",
+        "stratify",
+        "ml"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3284,35 +1827,37 @@
       }
     },
     {
-      "name": "orm-code-generator",
-      "source": "./plugins/database/orm-code-generator",
-      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
+      "name": "deep-learning-optimizer",
+      "source": "./plugins/ai-ml/deep-learning-optimizer",
+      "description": "Deep learning optimization techniques",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "optimization",
+        "adam",
+        "sgd",
+        "learning-rate",
+        "deep-learning"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "defi-yield-optimizer",
+      "source": "./plugins/crypto/defi-yield-optimizer",
+      "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
       "version": "1.28.0",
-      "category": "database",
+      "category": "crypto",
       "keywords": [
-        "orm",
-        "models",
-        "code-generation",
-        "database",
-        "backend"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "query-performance-analyzer",
-      "source": "./plugins/database/query-performance-analyzer",
-      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
-      "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "performance",
-        "query",
+        "defi",
+        "yield",
+        "farming",
+        "liquidity",
+        "apy",
         "optimization",
-        "explain",
-        "database"
+        "crypto"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3320,365 +1865,18 @@
       }
     },
     {
-      "name": "sql-query-optimizer",
-      "source": "./plugins/database/sql-query-optimizer",
-      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
+      "name": "dependency-checker",
+      "source": "./plugins/security/dependency-checker",
+      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
       "version": "1.27.0",
-      "category": "database",
-      "keywords": [
-        "sql",
-        "optimization",
-        "performance",
-        "database",
-        "query"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "stored-procedure-generator",
-      "source": "./plugins/database/stored-procedure-generator",
-      "description": "Database plugin for stored-procedure-generator",
-      "version": "1.29.0",
-      "category": "database",
-      "keywords": [
-        "database",
-        "backend",
-        "procedure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "brand-forge",
-      "source": "./plugins/design/brand-forge",
-      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
-      "version": "0.5.1",
-      "category": "design",
-      "keywords": [
-        "branding",
-        "logo",
-        "brand-identity",
-        "design",
-        "svg",
-        "templates",
-        "image-generation"
-      ],
-      "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
-      },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
-      "repository": "https://github.com/localplugins/plugins",
-      "license": "MIT"
-    },
-    {
-      "name": "wondelai-design-everyday-things",
-      "source": "./plugins/design/wondelai-design-everyday-things",
-      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "design",
-        "ux",
-        "affordances",
-        "signifiers",
-        "human-centered-design",
-        "usability",
-        "don-norman",
-        "hcd"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-hooked-ux",
-      "source": "./plugins/design/wondelai-hooked-ux",
-      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "habits",
-        "engagement",
-        "retention",
-        "hook-model",
-        "triggers",
-        "rewards",
-        "onboarding",
-        "ux"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-ios-hig-design",
-      "source": "./plugins/design/wondelai-ios-hig-design",
-      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ios",
-        "apple",
-        "hig",
-        "swiftui",
-        "uikit",
-        "mobile-design",
-        "accessibility",
-        "interface-guidelines"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-refactoring-ui",
-      "source": "./plugins/design/wondelai-refactoring-ui",
-      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ui-design",
-        "visual-hierarchy",
-        "typography",
-        "color-palette",
-        "tailwind",
-        "shadows",
-        "spacing",
-        "refactoring-ui"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-top-design",
-      "source": "./plugins/design/wondelai-top-design",
-      "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "web-design",
-        "awwwards",
-        "animations",
-        "typography",
-        "scroll-effects",
-        "brand-website",
-        "premium-design",
-        "motion"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-ux-heuristics",
-      "source": "./plugins/design/wondelai-ux-heuristics",
-      "description": "Usability heuristics and UX audit framework based on Nielsen and Krug. Conduct heuristic evaluations, identify usability problems, and prioritize fixes by severity.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "ux",
-        "usability",
-        "heuristics",
-        "nielsen",
-        "krug",
-        "ux-audit",
-        "evaluation",
-        "accessibility"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "wondelai-web-typography",
-      "source": "./plugins/design/wondelai-web-typography",
-      "description": "Web typography framework for readable, beautiful type. Select and pair typefaces, set optimal line length and height, implement responsive typography, and optimize web font loading.",
-      "version": "1.0.0",
-      "category": "design",
-      "keywords": [
-        "typography",
-        "web-fonts",
-        "typeface",
-        "font-pairing",
-        "readability",
-        "responsive-typography",
-        "css",
-        "type-hierarchy"
-      ],
-      "author": {
-        "name": "Wondel.ai",
-        "url": "https://github.com/wondelai"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/wondelai/skills"
-    },
-    {
-      "name": "ansible-playbook-creator",
-      "source": "./plugins/devops/ansible-playbook-creator",
-      "description": "Create Ansible playbooks for configuration management",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "ansible",
-        "automation",
-        "configuration",
-        "playbooks",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "auto-scaling-configurator",
-      "source": "./plugins/devops/auto-scaling-configurator",
-      "description": "Configure auto-scaling policies for applications and infrastructure",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "autoscaling",
-        "scaling",
-        "hpa",
-        "kubernetes",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "backup-strategy-implementor",
-      "source": "./plugins/devops/backup-strategy-implementor",
-      "description": "Implement backup strategies for databases and applications",
-      "version": "1.25.0",
-      "category": "devops",
-      "keywords": [
-        "backup",
-        "disaster-recovery",
-        "restoration",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ci-cd-pipeline-builder",
-      "source": "./plugins/devops/ci-cd-pipeline-builder",
-      "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "ci-cd",
-        "github-actions",
-        "gitlab-ci",
-        "jenkins",
-        "devops",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cloud-cost-optimizer",
-      "source": "./plugins/devops/cloud-cost-optimizer",
-      "description": "Optimize cloud costs and generate cost reports",
-      "version": "1.27.0",
-      "category": "devops",
-      "keywords": [
-        "cost",
-        "optimization",
-        "finops",
-        "cloud",
-        "aws",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "compliance-checker",
-      "source": "./plugins/devops/compliance-checker",
-      "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
-      "version": "1.26.0",
-      "category": "devops",
-      "keywords": [
-        "compliance",
-        "security",
-        "audit",
-        "soc2",
-        "hipaa",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "container-registry-manager",
-      "source": "./plugins/devops/container-registry-manager",
-      "description": "Manage container registries (ECR, GCR, Harbor)",
-      "version": "1.24.0",
-      "category": "devops",
-      "keywords": [
-        "registry",
-        "containers",
-        "docker",
-        "ecr",
-        "gcr",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "container-security-scanner",
-      "source": "./plugins/devops/container-security-scanner",
-      "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
-      "version": "1.27.0",
-      "category": "devops",
+      "category": "security",
       "keywords": [
         "security",
-        "containers",
-        "scanning",
-        "vulnerabilities",
-        "trivy",
-        "devops"
+        "dependencies",
+        "npm",
+        "pip",
+        "composer",
+        "vulnerabilities"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3722,6 +1920,68 @@
       }
     },
     {
+      "name": "design-to-code",
+      "source": "./plugins/mcp/design-to-code",
+      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
+      "version": "1.14.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "design",
+        "figma",
+        "react",
+        "svelte",
+        "vue",
+        "accessibility",
+        "component-generation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "devops-automation-pack",
+      "source": "./plugins/packages/devops-automation-pack",
+      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
+      "version": "1.30.0",
+      "category": "packages",
+      "keywords": [
+        "devops",
+        "ci-cd",
+        "docker",
+        "kubernetes",
+        "terraform",
+        "deployment",
+        "infrastructure",
+        "automation",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "dex-aggregator-router",
+      "source": "./plugins/crypto/dex-aggregator-router",
+      "description": "Find optimal DEX routes for token swaps across multiple exchanges",
+      "version": "1.25.0",
+      "category": "crypto",
+      "keywords": [
+        "dex",
+        "swap",
+        "trading",
+        "defi",
+        "aggregator",
+        "routing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "disaster-recovery-planner",
       "source": "./plugins/devops/disaster-recovery-planner",
       "description": "Plan and implement disaster recovery procedures",
@@ -3732,6 +1992,41 @@
         "dr",
         "business-continuity",
         "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "discovery-questionnaire",
+      "source": "./plugins/ai-agency/discovery-questionnaire",
+      "description": "Generate custom discovery questionnaires for AI agency prospects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "discovery",
+        "questionnaire",
+        "client",
+        "sales",
+        "agency",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "distributed-tracing-setup",
+      "source": "./plugins/performance/distributed-tracing-setup",
+      "description": "Set up distributed tracing for microservices",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "tracing",
+        "observability",
+        "microservices",
+        "opentelemetry"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3750,6 +2045,82 @@
         "containers",
         "orchestration",
         "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "domain-memory-agent",
+      "source": "./plugins/mcp/domain-memory-agent",
+      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
+      "version": "1.17.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "knowledge-base",
+        "semantic-search",
+        "tfidf",
+        "summarization",
+        "rag",
+        "documentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "lumera-agent-memory",
+      "source": "./plugins/mcp/lumera-agent-memory",
+      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
+      "version": "1.7.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "memory",
+        "cascade",
+        "storage",
+        "encryption",
+        "search",
+        "fts",
+        "agent"
+      ],
+      "author": {
+        "name": "Intent Solutions IO",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "e2e-test-framework",
+      "source": "./plugins/testing/e2e-test-framework",
+      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "e2e",
+        "playwright",
+        "cypress",
+        "selenium",
+        "browser-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "encryption-tool",
+      "source": "./plugins/security/encryption-tool",
+      "description": "Encrypt and decrypt data with various algorithms",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3799,6 +2170,89 @@
       }
     },
     {
+      "name": "error-rate-monitor",
+      "source": "./plugins/performance/error-rate-monitor",
+      "description": "Monitor and analyze application error rates",
+      "version": "1.22.0",
+      "category": "performance",
+      "keywords": [
+        "errors",
+        "monitoring",
+        "reliability",
+        "sre"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "excel-analyst-pro",
+      "source": "./plugins/business-tools/excel-analyst-pro",
+      "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
+      "version": "1.21.0",
+      "category": "business-tools",
+      "keywords": [
+        "excel",
+        "financial-modeling",
+        "dcf",
+        "lbo",
+        "valuation",
+        "variance-analysis",
+        "pivot-tables",
+        "investment-banking",
+        "private-equity",
+        "financial-analysis",
+        "skills",
+        "mcp"
+      ],
+      "author": {
+        "name": "ClaudeCodePlugins",
+        "email": "plugins@tonsofskills.com"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
+      "name": "brand-strategy-framework",
+      "source": "./plugins/business-tools/brand-strategy-framework",
+      "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
+      "version": "1.7.0",
+      "category": "business-tools",
+      "keywords": [
+        "brand-strategy",
+        "marketing",
+        "branding",
+        "positioning",
+        "messaging",
+        "brand-guidelines",
+        "audience-architecture",
+        "brand-identity"
+      ],
+      "author": {
+        "name": "Rowan Brooks",
+        "email": "rowanbrooks100@github.com"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills"
+    },
+    {
+      "name": "experiment-tracking-setup",
+      "source": "./plugins/ai-ml/experiment-tracking-setup",
+      "description": "Set up ML experiment tracking",
+      "version": "1.19.0",
+      "category": "ai-ml",
+      "keywords": [
+        "experiments",
+        "mlflow",
+        "wandb",
+        "tracking",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "fairdb-operations-kit",
       "source": "./plugins/devops/fairdb-operations-kit",
       "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
@@ -3827,23 +2281,162 @@
       "repository": "https://github.com/jeremylongshore/claude-code-plugins"
     },
     {
-      "name": "gh-dash",
-      "source": "./plugins/devops/gh-dash",
-      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
-      "version": "1.6.0",
-      "category": "devops",
+      "name": "fairdb-ops-manager",
+      "source": "./plugins/community/fairdb-ops-manager",
+      "description": "Database operations management for FairDB PostgreSQL clusters",
+      "version": "1.12.0",
+      "category": "community",
       "keywords": [
-        "github",
-        "pull-request",
-        "ci-cd",
-        "dashboard",
-        "devops",
-        "merge",
-        "code-review"
+        "database",
+        "postgresql",
+        "operations"
       ],
       "author": {
-        "name": "Jake Kozloski",
-        "email": "jakozloski@gmail.com"
+        "name": "Community"
+      }
+    },
+    {
+      "name": "feature-engineering-toolkit",
+      "source": "./plugins/ai-ml/feature-engineering-toolkit",
+      "description": "Feature creation, selection, and transformation tools",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "features",
+        "engineering",
+        "selection",
+        "transformation",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "file-to-code",
+      "source": "./plugins/skill-enhancers/file-to-code",
+      "description": "Converts file references into executable code implementations",
+      "version": "0.16.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "files",
+        "automation",
+        "code-generation"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "flash-loan-simulator",
+      "source": "./plugins/crypto/flash-loan-simulator",
+      "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
+      "version": "1.30.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "flash-loans",
+        "defi",
+        "aave",
+        "arbitrage",
+        "liquidation",
+        "ethereum",
+        "simulation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "formatter",
+      "source": "./plugins/examples/formatter",
+      "description": "Code formatting plugin using hooks to auto-format on save",
+      "version": "2.26.0",
+      "category": "examples",
+      "keywords": [
+        "formatting",
+        "hooks",
+        "automation"
+      ]
+    },
+    {
+      "name": "freshie-inventory-manager",
+      "source": "./plugins/database/freshie-inventory-manager",
+      "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+      "version": "1.5.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "inventory",
+        "freshie",
+        "compliance",
+        "sqlite",
+        "ecosystem",
+        "audit",
+        "subagents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "fullstack-starter-pack",
+      "source": "./plugins/packages/fullstack-starter-pack",
+      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
+      "version": "1.21.0",
+      "category": "packages",
+      "keywords": [
+        "fullstack",
+        "react",
+        "express",
+        "fastapi",
+        "postgresql",
+        "prisma",
+        "typescript",
+        "mvp",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "gas-fee-optimizer",
+      "source": "./plugins/crypto/gas-fee-optimizer",
+      "description": "Optimize transaction gas fees with timing and routing recommendations",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "gas",
+        "fees",
+        "ethereum",
+        "optimization",
+        "transaction",
+        "l2"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "gdpr-compliance-scanner",
+      "source": "./plugins/security/gdpr-compliance-scanner",
+      "description": "Scan for GDPR compliance issues",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
       }
     },
     {
@@ -3885,6 +2478,57 @@
       }
     },
     {
+      "name": "graphql-server-builder",
+      "source": "./plugins/api-development/graphql-server-builder",
+      "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
+      "version": "1.22.0",
+      "category": "api-development",
+      "keywords": [
+        "graphql",
+        "api",
+        "server",
+        "apollo",
+        "schema",
+        "resolvers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "grpc-service-generator",
+      "source": "./plugins/api-development/grpc-service-generator",
+      "description": "Generate gRPC services with Protocol Buffers and streaming support",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": [
+        "grpc",
+        "protobuf",
+        "microservices",
+        "streaming"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "hello-world",
+      "source": "./plugins/examples/hello-world",
+      "description": "Simple example plugin demonstrating basic slash commands",
+      "version": "1.12.0",
+      "category": "examples",
+      "keywords": [
+        "example",
+        "tutorial",
+        "beginner"
+      ],
+      "author": {
+        "name": "Jeremy Longshore"
+      }
+    },
+    {
       "name": "helm-chart-generator",
       "source": "./plugins/devops/helm-chart-generator",
       "description": "Generate Helm charts for Kubernetes applications",
@@ -3896,6 +2540,40 @@
         "packaging",
         "charts",
         "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "hipaa-compliance-checker",
+      "source": "./plugins/security/hipaa-compliance-checker",
+      "description": "Check HIPAA compliance",
+      "version": "1.23.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "hyperparameter-tuner",
+      "source": "./plugins/ai-ml/hyperparameter-tuner",
+      "description": "Optimize hyperparameters using grid/random/bayesian search",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "hyperparameters",
+        "optimization",
+        "tuning",
+        "search",
+        "ml"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -3940,83 +2618,77 @@
       }
     },
     {
-      "name": "jeremy-adk-terraform",
-      "source": "./plugins/devops/jeremy-adk-terraform",
-      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
-      "version": "2.22.0",
-      "category": "devops",
+      "name": "infrastructure-metrics-collector",
+      "source": "./plugins/performance/infrastructure-metrics-collector",
+      "description": "Collect comprehensive infrastructure performance metrics",
+      "version": "1.20.0",
+      "category": "performance",
       "keywords": [
-        "terraform",
-        "adk",
-        "agent-engine",
-        "vertex-ai",
         "infrastructure",
-        "vpc-sc"
+        "metrics",
+        "monitoring",
+        "observability"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "email": "[email protected]"
       }
     },
     {
-      "name": "jeremy-genkit-terraform",
-      "source": "./plugins/devops/jeremy-genkit-terraform",
-      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
-      "version": "2.21.0",
-      "category": "devops",
+      "name": "input-validation-scanner",
+      "source": "./plugins/security/input-validation-scanner",
+      "description": "Scan input validation practices",
+      "version": "1.25.0",
+      "category": "security",
       "keywords": [
-        "terraform",
-        "genkit",
-        "firebase",
-        "cloud-run",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "jeremy-github-actions-gcp",
-      "source": "./plugins/devops/jeremy-github-actions-gcp",
-      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
-      "version": "2.27.0",
-      "category": "devops",
-      "keywords": [
-        "github-actions",
-        "google-cloud",
-        "workload-identity-federation",
-        "wif",
-        "vertex-ai",
-        "agent-engine",
-        "deployment",
-        "ci-cd",
         "security",
-        "best-practices",
-        "oidc",
-        "iam"
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "email": "[email protected]"
       }
     },
     {
-      "name": "jeremy-vertex-terraform",
-      "source": "./plugins/devops/jeremy-vertex-terraform",
-      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
-      "version": "2.22.0",
-      "category": "devops",
+      "name": "integration-test-runner",
+      "source": "./plugins/testing/integration-test-runner",
+      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
+      "version": "1.22.0",
+      "category": "testing",
       "keywords": [
-        "terraform",
-        "vertex-ai",
-        "gemini",
-        "model-garden",
-        "infrastructure"
+        "testing",
+        "integration-tests",
+        "test-runner",
+        "e2e",
+        "api-testing"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "kobiton-automate",
+      "source": "./plugins/testing/kobiton-automate",
+      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
+      "version": "1.0.2",
+      "category": "testing",
+      "keywords": [
+        "mobile",
+        "testing",
+        "appium",
+        "automation",
+        "devices",
+        "ios",
+        "android",
+        "real-device",
+        "mcp",
+        "kobiton"
+      ],
+      "author": {
+        "name": "Kobiton Inc.",
+        "url": "https://github.com/kobiton"
       }
     },
     {
@@ -4031,6 +2703,25 @@
         "deployment",
         "orchestration",
         "containers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "liquidity-pool-analyzer",
+      "source": "./plugins/crypto/liquidity-pool-analyzer",
+      "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
+      "version": "1.23.0",
+      "category": "crypto",
+      "keywords": [
+        "liquidity",
+        "pool",
+        "defi",
+        "impermanent",
+        "loss",
+        "apy"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4057,6 +2748,41 @@
       }
     },
     {
+      "name": "load-balancer-tester",
+      "source": "./plugins/testing/load-balancer-tester",
+      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "load-balancer",
+        "traffic-distribution",
+        "failover",
+        "high-availability"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "load-test-runner",
+      "source": "./plugins/performance/load-test-runner",
+      "description": "Create and execute load tests for performance validation",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "load-testing",
+        "performance",
+        "stress-test",
+        "k6"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "log-aggregation-setup",
       "source": "./plugins/devops/log-aggregation-setup",
       "description": "Set up log aggregation (ELK, Loki, Splunk)",
@@ -4076,23 +2802,263 @@
       }
     },
     {
-      "name": "mattyp-changelog",
-      "source": "./plugins/devops/mattyp-changelog",
-      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
-      "version": "0.3.0",
-      "category": "devops",
+      "name": "log-analysis-tool",
+      "source": "./plugins/performance/log-analysis-tool",
+      "description": "Analyze logs for performance insights and issues",
+      "version": "1.24.0",
+      "category": "performance",
       "keywords": [
-        "changelog",
-        "release-notes",
-        "weekly-update",
-        "git",
-        "github",
-        "automation"
+        "logs",
+        "analysis",
+        "performance",
+        "debugging"
       ],
       "author": {
-        "name": "Mattyp",
-        "email": "mattyp@tonsofskills.com",
-        "url": "https://tonsofskills.com"
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "make-scenario-builder",
+      "source": "./plugins/ai-agency/make-scenario-builder",
+      "description": "Create Make.com (Integromat) scenarios with AI assistance",
+      "version": "1.15.0",
+      "category": "ai-agency",
+      "keywords": [
+        "make",
+        "integromat",
+        "automation",
+        "scenarios",
+        "workflow",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "market-movers-scanner",
+      "source": "./plugins/crypto/market-movers-scanner",
+      "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "market",
+        "scanner",
+        "movers",
+        "gainers",
+        "losers",
+        "volume",
+        "trading"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "market-price-tracker",
+      "source": "./plugins/crypto/market-price-tracker",
+      "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
+      "version": "1.27.0",
+      "category": "crypto",
+      "keywords": [
+        "market",
+        "price",
+        "tracking",
+        "trading",
+        "crypto",
+        "stocks",
+        "forex"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "market-sentiment-analyzer",
+      "source": "./plugins/crypto/market-sentiment-analyzer",
+      "description": "Analyze market sentiment from social media, news, and on-chain data",
+      "version": "1.24.0",
+      "category": "crypto",
+      "keywords": [
+        "sentiment",
+        "analysis",
+        "social",
+        "news",
+        "market",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "memory-leak-detector",
+      "source": "./plugins/performance/memory-leak-detector",
+      "description": "Detect memory leaks and analyze memory usage patterns",
+      "version": "1.24.0",
+      "category": "performance",
+      "keywords": [
+        "memory",
+        "leak",
+        "detection",
+        "performance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "mempool-analyzer",
+      "source": "./plugins/crypto/mempool-analyzer",
+      "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
+      "version": "1.32.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "mempool",
+        "mev",
+        "ethereum",
+        "blockchain",
+        "gas",
+        "pending-transactions",
+        "arbitrage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "metrics-aggregator",
+      "source": "./plugins/performance/metrics-aggregator",
+      "description": "Aggregate and centralize performance metrics",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "metrics",
+        "aggregation",
+        "prometheus",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "ml-model-trainer",
+      "source": "./plugins/ai-ml/ml-model-trainer",
+      "description": "Train and optimize machine learning models with automated workflows",
+      "version": "1.23.0",
+      "category": "ai-ml",
+      "keywords": [
+        "ml",
+        "machine-learning",
+        "training",
+        "models",
+        "ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "mobile-app-tester",
+      "source": "./plugins/testing/mobile-app-tester",
+      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mobile",
+        "appium",
+        "detox",
+        "xcuitest",
+        "espresso",
+        "ios",
+        "android"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-deployment-helper",
+      "source": "./plugins/ai-ml/model-deployment-helper",
+      "description": "Deploy ML models to production",
+      "version": "1.19.0",
+      "category": "ai-ml",
+      "keywords": [
+        "deployment",
+        "serving",
+        "production",
+        "api",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-evaluation-suite",
+      "source": "./plugins/ai-ml/model-evaluation-suite",
+      "description": "Comprehensive model evaluation with multiple metrics",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "evaluation",
+        "metrics",
+        "testing",
+        "validation",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-explainability-tool",
+      "source": "./plugins/ai-ml/model-explainability-tool",
+      "description": "Model interpretability and explainability",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "explainability",
+        "shap",
+        "lime",
+        "interpretability",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "model-versioning-tracker",
+      "source": "./plugins/ai-ml/model-versioning-tracker",
+      "description": "Track and manage model versions",
+      "version": "1.24.0",
+      "category": "ai-ml",
+      "keywords": [
+        "versioning",
+        "mlflow",
+        "tracking",
+        "registry",
+        "mlops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
       }
     },
     {
@@ -4107,6 +3073,60 @@
         "grafana",
         "observability",
         "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "mutation-test-runner",
+      "source": "./plugins/testing/mutation-test-runner",
+      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
+      "version": "1.27.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mutation-testing",
+        "test-quality",
+        "stryker",
+        "pitest"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "n8n-workflow-designer",
+      "source": "./plugins/ai-agency/n8n-workflow-designer",
+      "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
+      "version": "1.13.0",
+      "category": "ai-agency",
+      "keywords": [
+        "n8n",
+        "workflow",
+        "automation",
+        "self-hosted",
+        "open-source",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "url": "https://github.com/jeremylongshore/claude-code-plugins"
+      }
+    },
+    {
+      "name": "network-latency-analyzer",
+      "source": "./plugins/performance/network-latency-analyzer",
+      "description": "Analyze network latency and optimize request patterns",
+      "version": "1.21.0",
+      "category": "performance",
+      "keywords": [
+        "network",
+        "latency",
+        "performance",
+        "api"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4132,18 +3152,36 @@
       }
     },
     {
-      "name": "secrets-manager-integrator",
-      "source": "./plugins/devops/secrets-manager-integrator",
-      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
+      "name": "neural-network-builder",
+      "source": "./plugins/ai-ml/neural-network-builder",
+      "description": "Build and configure neural network architectures",
+      "version": "1.20.0",
+      "category": "ai-ml",
+      "keywords": [
+        "neural-networks",
+        "deep-learning",
+        "architecture",
+        "pytorch",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "nft-rarity-analyzer",
+      "source": "./plugins/crypto/nft-rarity-analyzer",
+      "description": "Analyze NFT rarity scores and valuations across collections",
       "version": "1.25.0",
-      "category": "devops",
+      "category": "crypto",
       "keywords": [
-        "secrets",
-        "vault",
-        "aws",
-        "security",
-        "credentials",
-        "devops"
+        "nft",
+        "rarity",
+        "valuation",
+        "traits",
+        "opensea",
+        "crypto"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4151,17 +3189,17 @@
       }
     },
     {
-      "name": "service-mesh-configurator",
-      "source": "./plugins/devops/service-mesh-configurator",
-      "description": "Configure service mesh (Istio, Linkerd) for microservices",
-      "version": "1.24.0",
-      "category": "devops",
+      "name": "nlp-text-analyzer",
+      "source": "./plugins/ai-ml/nlp-text-analyzer",
+      "description": "Natural language processing and text analysis",
+      "version": "1.22.0",
+      "category": "ai-ml",
       "keywords": [
-        "service-mesh",
-        "istio",
-        "linkerd",
-        "microservices",
-        "devops"
+        "nlp",
+        "text",
+        "analysis",
+        "tokenization",
+        "ml"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4169,41 +3207,37 @@
       }
     },
     {
-      "name": "sugar",
-      "source": "./plugins/devops/sugar",
-      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
-      "version": "2.0.0",
-      "category": "devops",
+      "name": "ollama-local-ai",
+      "source": "./plugins/ai-ml/ollama-local-ai",
+      "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
+      "version": "1.18.0",
+      "category": "ai-ml",
       "keywords": [
-        "autonomous",
-        "development",
-        "ai",
-        "task-management",
-        "automation",
-        "agents",
-        "enterprise",
-        "workflow",
-        "productivity",
-        "mcp"
+        "ollama",
+        "local-llm",
+        "free-ai",
+        "self-hosted",
+        "llama",
+        "mistral",
+        "privacy",
+        "zero-cost",
+        "openai-alternative"
       ],
       "author": {
-        "name": "Steven Leggett",
-        "email": "contact@roboticforce.io"
-      },
-      "repository": "https://github.com/cdnsteve/sugar"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
     },
     {
-      "name": "terraform-module-builder",
-      "source": "./plugins/devops/terraform-module-builder",
-      "description": "Build reusable Terraform modules",
-      "version": "1.23.0",
-      "category": "devops",
+      "name": "nosql-data-modeler",
+      "source": "./plugins/database/nosql-data-modeler",
+      "description": "Database plugin for nosql-data-modeler",
+      "version": "1.29.0",
+      "category": "database",
       "keywords": [
-        "terraform",
-        "iac",
-        "modules",
-        "infrastructure",
-        "devops"
+        "database",
+        "backend",
+        "data"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4211,190 +3245,17 @@
       }
     },
     {
-      "name": "tweetclaw",
-      "source": "./plugins/devops/tweetclaw",
-      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
-      "version": "1.5.3",
-      "category": "devops",
-      "keywords": [
-        "twitter",
-        "x",
-        "automation",
-        "social-media",
-        "tweets",
-        "monitoring",
-        "giveaway",
-        "scraping"
-      ],
-      "author": {
-        "name": "Burak Bayir",
-        "email": "burak@xquik.com",
-        "url": "https://xquik.com"
-      },
-      "repository": "https://github.com/Xquik-dev/tweetclaw",
-      "homepage": "https://xquik.com",
-      "license": "MIT"
-    },
-    {
-      "name": "formatter",
-      "source": "./plugins/examples/formatter",
-      "description": "Code formatting plugin using hooks to auto-format on save",
-      "version": "2.26.0",
-      "category": "examples",
-      "keywords": [
-        "formatting",
-        "hooks",
-        "automation"
-      ]
-    },
-    {
-      "name": "hello-world",
-      "source": "./plugins/examples/hello-world",
-      "description": "Simple example plugin demonstrating basic slash commands",
-      "version": "1.12.0",
-      "category": "examples",
-      "keywords": [
-        "example",
-        "tutorial",
-        "beginner"
-      ],
-      "author": {
-        "name": "Jeremy Longshore"
-      }
-    },
-    {
-      "name": "jeremy-plugin-tool",
-      "source": "./plugins/examples/jeremy-plugin-tool",
-      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
-      "version": "2.19.0",
-      "category": "examples",
-      "keywords": [
-        "skills",
-        "agent-skills",
-        "plugin-management",
-        "marketplace",
-        "validation",
-        "audit",
-        "versioning",
-        "meta-plugin",
-        "repository-tools"
-      ],
-      "author": {
-        "name": "Claude Code Plugins",
-        "email": "[email protected]"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "pi-pathfinder",
-      "source": "./plugins/examples/pi-pathfinder",
-      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
-      "version": "1.24.0",
-      "category": "examples",
-      "keywords": [
-        "agent-skills",
-        "pi",
-        "pathfinder",
-        "plugin-intelligence",
-        "task-router",
-        "auto-selector",
-        "skill-extraction",
-        "easy-mode",
-        "automatic",
-        "no-thinking-required"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "security-agent",
-      "source": "./plugins/examples/security-agent",
-      "description": "Security review subagent for code analysis",
+      "name": "on-chain-analytics",
+      "source": "./plugins/crypto/on-chain-analytics",
+      "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
       "version": "1.28.0",
-      "category": "examples",
+      "category": "crypto",
       "keywords": [
-        "security",
-        "agent",
-        "code-review"
-      ]
-    },
-    {
-      "name": "a2a-client",
-      "source": "./plugins/mcp/a2a-client",
-      "description": "Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "a2a",
-        "agent2agent",
-        "agent-card",
-        "multi-agent",
-        "interoperability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "ai-experiment-logger",
-      "source": "./plugins/mcp/ai-experiment-logger",
-      "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
-      "version": "1.12.0",
-      "category": "mcp",
-      "keywords": [
-        "ai",
-        "experiments",
-        "logging",
-        "mcp"
-      ],
-      "author": {
-        "name": "Claude Code Plugins"
-      }
-    },
-    {
-      "name": "beads-dolt",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "beads",
-        "bd",
-        "dolt",
-        "dolthub",
-        "task-tracking",
-        "mcp",
-        "version-control",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "conversational-api-debugger",
-      "source": "./plugins/mcp/conversational-api-debugger",
-      "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "api",
-        "debugging",
-        "openapi",
-        "har",
-        "rest",
-        "curl",
-        "http"
+        "on-chain",
+        "analytics",
+        "whale",
+        "metrics",
+        "blockchain"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4402,44 +3263,27 @@
       }
     },
     {
-      "name": "databricks-workspace-mcp",
-      "source": "./plugins/mcp/databricks-workspace-mcp",
-      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
-      "version": "0.1.0",
-      "category": "mcp",
+      "name": "openbb-terminal",
+      "source": "./plugins/business-tools/openbb-terminal",
+      "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
+      "version": "1.6.0",
+      "category": "business-tools",
       "keywords": [
-        "mcp",
-        "model-context-protocol",
-        "databricks",
-        "lakehouse",
-        "unity-catalog",
-        "clusters",
-        "dlt",
-        "finops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://tonsofskills.com/learn/databricks/",
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
-      "license": "MIT"
-    },
-    {
-      "name": "design-to-code",
-      "source": "./plugins/mcp/design-to-code",
-      "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
-      "version": "1.14.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "design",
-        "figma",
-        "react",
-        "svelte",
-        "vue",
-        "accessibility",
-        "component-generation"
+        "finance",
+        "investment",
+        "openbb",
+        "stocks",
+        "crypto",
+        "portfolio",
+        "trading",
+        "financial-analysis",
+        "market-data",
+        "equity-research",
+        "options",
+        "forex",
+        "macroeconomics",
+        "quant",
+        "ai-finance"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4447,46 +3291,18 @@
       }
     },
     {
-      "name": "dolt-mcp-vcs",
-      "source": "./plugins/mcp/dolt-mcp-vcs",
-      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
-      "version": "0.1.0",
-      "category": "mcp",
+      "name": "options-flow-analyzer",
+      "source": "./plugins/crypto/options-flow-analyzer",
+      "description": "Track institutional options flow, unusual activity, and smart money movements",
+      "version": "1.29.0",
+      "category": "crypto",
       "keywords": [
-        "dolt-mcp-vcs",
-        "dolt",
-        "dolthub",
-        "dolt-mcp",
-        "version-control",
-        "vcs",
-        "mcp",
-        "sql",
-        "beads",
-        "bd"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "url": "https://github.com/jeremylongshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "domain-memory-agent",
-      "source": "./plugins/mcp/domain-memory-agent",
-      "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
-      "version": "1.17.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "knowledge-base",
-        "semantic-search",
-        "tfidf",
-        "summarization",
-        "rag",
-        "documentation"
+        "options",
+        "flow",
+        "institutional",
+        "trading",
+        "derivatives",
+        "smart money"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4494,322 +3310,56 @@
       }
     },
     {
-      "name": "governed-second-brain",
-      "source": "./plugins/mcp/governed-second-brain",
-      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
-      "version": "1.1.2",
-      "category": "mcp",
+      "name": "orm-code-generator",
+      "source": "./plugins/database/orm-code-generator",
+      "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
+      "version": "1.28.0",
+      "category": "database",
       "keywords": [
-        "memory",
-        "knowledge",
-        "governance",
-        "qmd",
-        "brain",
-        "citations",
-        "local-first",
-        "second-brain"
+        "orm",
+        "models",
+        "code-generation",
+        "database",
+        "backend"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
-      "license": "Apache-2.0"
+        "email": "[email protected]"
+      }
     },
     {
-      "name": "lumera-agent-memory",
-      "source": "./plugins/mcp/lumera-agent-memory",
-      "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
-      "version": "1.7.0",
-      "category": "mcp",
+      "name": "overnight-dev",
+      "source": "./plugins/productivity/overnight-dev",
+      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
+      "version": "1.29.0",
+      "category": "productivity",
       "keywords": [
-        "mcp",
-        "memory",
-        "cascade",
-        "storage",
-        "encryption",
-        "search",
-        "fts",
-        "agent"
+        "overnight",
+        "autonomous",
+        "tdd",
+        "testing",
+        "git-hooks",
+        "automation",
+        "continuous-integration",
+        "test-driven-development",
+        "productivity"
       ],
       "author": {
         "name": "Intent Solutions IO",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "pr-to-spec",
-      "source": "./plugins/mcp/pr-to-spec",
-      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
-      "version": "0.8.0",
-      "category": "mcp",
-      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "license": "MIT",
-      "keywords": [
-        "mcp",
-        "pr-analysis",
-        "intent-drift",
-        "code-review",
-        "agent-protocol"
-      ]
-    },
-    {
-      "name": "project-health-auditor",
-      "source": "./plugins/mcp/project-health-auditor",
-      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
-      "version": "1.18.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "code-quality",
-        "technical-debt",
-        "complexity",
-        "git-churn",
-        "test-coverage",
-        "analytics"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
+        "url": "https://intentsolutions.io",
         "email": "[email protected]"
       }
     },
     {
-      "name": "servicegraph",
-      "source": "./plugins/mcp/servicegraph",
-      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
-      "version": "0.2.0",
-      "category": "mcp",
-      "keywords": [
-        "servicegraph",
-        "service-providers",
-        "agencies",
-        "law-firms",
-        "consulting",
-        "accounting",
-        "marketing",
-        "lead-generation",
-        "professional-services",
-        "us-firms",
-        "product-directories",
-        "saas-directories",
-        "mcp-directories",
-        "ai-directories",
-        "product-launch",
-        "backlinks"
-      ],
-      "author": {
-        "name": "Artur Briugeman",
-        "url": "https://servicegraph.co",
-        "email": "artur@nostr.band"
-      },
-      "homepage": "https://servicegraph.co",
-      "repository": "https://github.com/nostrband/servicegraph",
-      "license": "MIT"
-    },
-    {
-      "name": "slack-channel",
-      "source": "./plugins/mcp/slack-channel",
-      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
-      "version": "0.1.0",
-      "category": "mcp",
-      "keywords": [
-        "slack",
-        "channel",
-        "mcp",
-        "socket-mode",
-        "chatops",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT"
-    },
-    {
-      "name": "workflow-orchestrator",
-      "source": "./plugins/mcp/workflow-orchestrator",
-      "description": "DAG-based workflow automation with parallel task execution and dependency management",
-      "version": "1.15.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "workflow",
-        "dag",
-        "automation",
-        "orchestration",
-        "cicd",
-        "parallel-execution"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "x-bug-triage",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "keywords": [
-        "mcp",
-        "triage",
-        "x-api",
-        "bug-tracking",
-        "clustering"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "license": "MIT"
-    },
-    {
-      "name": "x-bug-triage-plugin",
-      "source": "./plugins/mcp/x-bug-triage",
-      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-      "version": "0.3.0",
-      "category": "mcp",
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      },
-      "keywords": [
-        "bug-triage",
-        "x-twitter",
-        "slack",
-        "devops",
-        "mcp"
-      ],
-      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT"
-    },
-    {
-      "name": "ai-ml-engineering-pack",
-      "source": "./plugins/packages/ai-ml-engineering-pack",
-      "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "ai",
-        "ml",
-        "llm",
-        "prompt-engineering",
-        "rag",
-        "vector-database",
-        "ai-safety",
-        "openai",
-        "anthropic",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "creator-studio-pack",
-      "source": "./plugins/packages/creator-studio-pack",
-      "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
-      "version": "1.16.0",
-      "category": "packages",
-      "keywords": [
-        "video",
-        "content-creation",
-        "youtube",
-        "filmmaking",
-        "creator",
-        "documentation",
-        "screencast",
-        "tutorial",
-        "video-editing",
-        "content-strategy",
-        "distribution",
-        "thumbnails",
-        "subtitles",
-        "repurposing",
-        "batch-recording",
-        "analytics",
-        "package",
-        "premium"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "devops-automation-pack",
-      "source": "./plugins/packages/devops-automation-pack",
-      "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
-      "version": "1.30.0",
-      "category": "packages",
-      "keywords": [
-        "devops",
-        "ci-cd",
-        "docker",
-        "kubernetes",
-        "terraform",
-        "deployment",
-        "infrastructure",
-        "automation",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "fullstack-starter-pack",
-      "source": "./plugins/packages/fullstack-starter-pack",
-      "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
-      "version": "1.21.0",
-      "category": "packages",
-      "keywords": [
-        "fullstack",
-        "react",
-        "express",
-        "fastapi",
-        "postgresql",
-        "prisma",
-        "typescript",
-        "mvp",
-        "package"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-pro-pack",
-      "source": "./plugins/packages/security-pro-pack",
-      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
-      "version": "1.31.0",
-      "category": "packages",
+      "name": "owasp-compliance-checker",
+      "source": "./plugins/security/owasp-compliance-checker",
+      "description": "Check OWASP Top 10 compliance",
+      "version": "1.28.0",
+      "category": "security",
       "keywords": [
         "security",
-        "vulnerability-scanning",
         "compliance",
-        "HIPAA",
-        "PCI-DSS",
-        "GDPR",
-        "SOC2",
-        "cryptography",
-        "devsecops",
-        "package"
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -4817,222 +3367,15 @@
       }
     },
     {
-      "name": "alerting-rule-creator",
-      "source": "./plugins/performance/alerting-rule-creator",
-      "description": "Create intelligent alerting rules for performance monitoring",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "alerting",
-        "monitoring",
-        "sre",
-        "observability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "apm-dashboard-creator",
-      "source": "./plugins/performance/apm-dashboard-creator",
-      "description": "Create Application Performance Monitoring dashboards",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "apm",
-        "monitoring",
-        "dashboard",
-        "grafana",
-        "datadog"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "application-profiler",
-      "source": "./plugins/performance/application-profiler",
-      "description": "Profile application performance with CPU, memory, and execution time analysis",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "performance",
-        "profiling",
-        "monitoring",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "bottleneck-detector",
-      "source": "./plugins/performance/bottleneck-detector",
-      "description": "Detect and resolve performance bottlenecks",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "bottleneck",
-        "performance",
-        "optimization",
-        "profiling"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cache-performance-optimizer",
-      "source": "./plugins/performance/cache-performance-optimizer",
-      "description": "Optimize caching strategies for improved performance",
-      "version": "1.19.0",
-      "category": "performance",
-      "keywords": [
-        "cache",
-        "performance",
-        "optimization",
-        "redis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "capacity-planning-analyzer",
-      "source": "./plugins/performance/capacity-planning-analyzer",
-      "description": "Analyze and plan for capacity requirements",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "capacity-planning",
-        "scaling",
-        "forecasting",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cpu-usage-monitor",
-      "source": "./plugins/performance/cpu-usage-monitor",
-      "description": "Monitor and analyze CPU usage patterns in applications",
-      "version": "1.23.0",
-      "category": "performance",
-      "keywords": [
-        "cpu",
-        "monitoring",
-        "performance",
-        "optimization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "database-query-profiler",
-      "source": "./plugins/performance/database-query-profiler",
-      "description": "Profile and optimize database queries for performance",
-      "version": "1.9.0",
-      "category": "performance",
-      "keywords": [
-        "database",
-        "query",
-        "profiling",
-        "optimization",
-        "sql"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "distributed-tracing-setup",
-      "source": "./plugins/performance/distributed-tracing-setup",
-      "description": "Set up distributed tracing for microservices",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "tracing",
-        "observability",
-        "microservices",
-        "opentelemetry"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "error-rate-monitor",
-      "source": "./plugins/performance/error-rate-monitor",
-      "description": "Monitor and analyze application error rates",
-      "version": "1.22.0",
-      "category": "performance",
-      "keywords": [
-        "errors",
-        "monitoring",
-        "reliability",
-        "sre"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "infrastructure-metrics-collector",
-      "source": "./plugins/performance/infrastructure-metrics-collector",
-      "description": "Collect comprehensive infrastructure performance metrics",
-      "version": "1.20.0",
-      "category": "performance",
-      "keywords": [
-        "infrastructure",
-        "metrics",
-        "monitoring",
-        "observability"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "load-test-runner",
-      "source": "./plugins/performance/load-test-runner",
-      "description": "Create and execute load tests for performance validation",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "load-testing",
-        "performance",
-        "stress-test",
-        "k6"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "log-analysis-tool",
-      "source": "./plugins/performance/log-analysis-tool",
-      "description": "Analyze logs for performance insights and issues",
+      "name": "pci-dss-validator",
+      "source": "./plugins/security/pci-dss-validator",
+      "description": "Validate PCI DSS compliance",
       "version": "1.24.0",
-      "category": "performance",
+      "category": "security",
       "keywords": [
-        "logs",
-        "analysis",
-        "performance",
-        "debugging"
+        "security",
+        "compliance",
+        "auditing"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -5040,50 +3383,22 @@
       }
     },
     {
-      "name": "memory-leak-detector",
-      "source": "./plugins/performance/memory-leak-detector",
-      "description": "Detect memory leaks and analyze memory usage patterns",
-      "version": "1.24.0",
-      "category": "performance",
+      "name": "penetration-tester",
+      "source": "./plugins/security/penetration-tester",
+      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
+      "version": "3.30.0",
+      "category": "security",
       "keywords": [
-        "memory",
-        "leak",
-        "detection",
-        "performance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "metrics-aggregator",
-      "source": "./plugins/performance/metrics-aggregator",
-      "description": "Aggregate and centralize performance metrics",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "metrics",
-        "aggregation",
-        "prometheus",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "network-latency-analyzer",
-      "source": "./plugins/performance/network-latency-analyzer",
-      "description": "Analyze network latency and optimize request patterns",
-      "version": "1.21.0",
-      "category": "performance",
-      "keywords": [
-        "network",
-        "latency",
-        "performance",
-        "api"
+        "security",
+        "penetration-testing",
+        "pentesting",
+        "owasp",
+        "owasp-top-10",
+        "vulnerability-scanning",
+        "dependency-audit",
+        "license-compliance",
+        "engagement-governance",
+        "chain-of-custody"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -5142,6 +3457,133 @@
       }
     },
     {
+      "name": "performance-test-suite",
+      "source": "./plugins/testing/performance-test-suite",
+      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
+      "version": "1.30.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "performance",
+        "load-testing",
+        "benchmarking",
+        "stress-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "pi-pathfinder",
+      "source": "./plugins/examples/pi-pathfinder",
+      "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
+      "version": "1.24.0",
+      "category": "examples",
+      "keywords": [
+        "agent-skills",
+        "pi",
+        "pathfinder",
+        "plugin-intelligence",
+        "task-router",
+        "auto-selector",
+        "skill-extraction",
+        "easy-mode",
+        "automatic",
+        "no-thinking-required"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
+      "name": "code-cleanup",
+      "source": "./plugins/testing/code-cleanup",
+      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+      "version": "1.7.0",
+      "category": "testing",
+      "keywords": [
+        "code-quality",
+        "cleanup",
+        "refactoring",
+        "dead-code",
+        "deduplication",
+        "type-safety",
+        "security",
+        "performance",
+        "async",
+        "tech-debt",
+        "code-review"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "project-health-auditor",
+      "source": "./plugins/mcp/project-health-auditor",
+      "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
+      "version": "1.18.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "code-quality",
+        "technical-debt",
+        "complexity",
+        "git-churn",
+        "test-coverage",
+        "analytics"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "promptbook",
+      "source": "./plugins/business-tools/promptbook",
+      "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
+      "version": "1.4.0",
+      "category": "business-tools",
+      "keywords": [
+        "analytics",
+        "telemetry",
+        "builds",
+        "portfolio",
+        "tracking",
+        "metrics",
+        "sessions"
+      ],
+      "author": {
+        "name": "Promptbook",
+        "email": "contact@promptbook.gg"
+      },
+      "homepage": "https://promptbook.gg",
+      "repository": "https://github.com/promptbookgg/claude-code-plugin",
+      "license": "MIT"
+    },
+    {
+      "name": "query-performance-analyzer",
+      "source": "./plugins/database/query-performance-analyzer",
+      "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "performance",
+        "query",
+        "optimization",
+        "explain",
+        "database"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
       "name": "real-user-monitoring",
       "source": "./plugins/performance/real-user-monitoring",
       "description": "Implement Real User Monitoring for actual performance data",
@@ -5156,6 +3598,75 @@
       "author": {
         "name": "Jeremy Longshore",
         "email": "[email protected]"
+      }
+    },
+    {
+      "name": "recommendation-engine",
+      "source": "./plugins/ai-ml/recommendation-engine",
+      "description": "Build recommendation systems and engines",
+      "version": "1.21.0",
+      "category": "ai-ml",
+      "keywords": [
+        "recommendations",
+        "collaborative",
+        "content-based",
+        "ranking",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "regression-analysis-tool",
+      "source": "./plugins/ai-ml/regression-analysis-tool",
+      "description": "Regression analysis and modeling",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "regression",
+        "prediction",
+        "linear",
+        "polynomial",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "regression-test-tracker",
+      "source": "./plugins/testing/regression-test-tracker",
+      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
+      "version": "1.26.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "regression-testing",
+        "test-tracking",
+        "ci-cd",
+        "quality-assurance"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "research-to-deploy",
+      "source": "./plugins/skill-enhancers/research-to-deploy",
+      "description": "Transforms research findings into deployed solutions automatically",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "research",
+        "automation",
+        "deployment"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
       }
     },
     {
@@ -5193,6 +3704,309 @@
       }
     },
     {
+      "name": "rest-api-generator",
+      "source": "./plugins/api-development/rest-api-generator",
+      "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
+      "version": "1.23.0",
+      "category": "api-development",
+      "keywords": [
+        "api",
+        "rest",
+        "generator",
+        "openapi",
+        "swagger",
+        "backend"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "roi-calculator",
+      "source": "./plugins/ai-agency/roi-calculator",
+      "description": "Calculate and present ROI for AI automation projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "roi",
+        "return on investment",
+        "calculator",
+        "sales",
+        "value",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "search-to-slack",
+      "source": "./plugins/skill-enhancers/search-to-slack",
+      "description": "Automatically posts search results to Slack channels",
+      "version": "0.14.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "search",
+        "slack",
+        "automation",
+        "integration"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team"
+      }
+    },
+    {
+      "name": "secret-scanner",
+      "source": "./plugins/security/secret-scanner",
+      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "secrets",
+        "api-keys",
+        "credentials",
+        "passwords"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "severity1-marketplace",
+      "source": "./plugins/security/severity1-marketplace",
+      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
+      "version": "1.6.0",
+      "category": "security",
+      "keywords": [
+        "severity",
+        "classification",
+        "prompt-improvement",
+        "marketplace",
+        "security",
+        "quality",
+        "triage",
+        "agent-skills"
+      ],
+      "author": {
+        "name": "severity1",
+        "email": "severity1@intentsolutions.io"
+      }
+    },
+    {
+      "name": "secrets-manager-integrator",
+      "source": "./plugins/devops/secrets-manager-integrator",
+      "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
+      "version": "1.25.0",
+      "category": "devops",
+      "keywords": [
+        "secrets",
+        "vault",
+        "aws",
+        "security",
+        "credentials",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-agent",
+      "source": "./plugins/examples/security-agent",
+      "description": "Security review subagent for code analysis",
+      "version": "1.28.0",
+      "category": "examples",
+      "keywords": [
+        "security",
+        "agent",
+        "code-review"
+      ]
+    },
+    {
+      "name": "security-audit-reporter",
+      "source": "./plugins/security/security-audit-reporter",
+      "description": "Generate comprehensive security audit reports",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-headers-analyzer",
+      "source": "./plugins/security/security-headers-analyzer",
+      "description": "Analyze HTTP security headers",
+      "version": "1.28.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-incident-responder",
+      "source": "./plugins/security/security-incident-responder",
+      "description": "Assist with security incident response",
+      "version": "1.32.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-misconfiguration-finder",
+      "source": "./plugins/security/security-misconfiguration-finder",
+      "description": "Find security misconfigurations",
+      "version": "1.29.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-pro-pack",
+      "source": "./plugins/packages/security-pro-pack",
+      "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
+      "version": "1.31.0",
+      "category": "packages",
+      "keywords": [
+        "security",
+        "vulnerability-scanning",
+        "compliance",
+        "HIPAA",
+        "PCI-DSS",
+        "GDPR",
+        "SOC2",
+        "cryptography",
+        "devsecops",
+        "package"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "security-test-scanner",
+      "source": "./plugins/testing/security-test-scanner",
+      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
+      "version": "1.29.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "security",
+        "vulnerabilities",
+        "owasp",
+        "penetration-testing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "sentiment-analysis-tool",
+      "source": "./plugins/ai-ml/sentiment-analysis-tool",
+      "description": "Sentiment analysis on text data",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "sentiment",
+        "opinion",
+        "emotion",
+        "polarity",
+        "nlp"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "service-mesh-configurator",
+      "source": "./plugins/devops/service-mesh-configurator",
+      "description": "Configure service mesh (Istio, Linkerd) for microservices",
+      "version": "1.24.0",
+      "category": "devops",
+      "keywords": [
+        "service-mesh",
+        "istio",
+        "linkerd",
+        "microservices",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "session-security-checker",
+      "source": "./plugins/security/session-security-checker",
+      "description": "Check session security implementation",
+      "version": "1.27.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "jeremy-plugin-tool",
+      "source": "./plugins/examples/jeremy-plugin-tool",
+      "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
+      "version": "2.19.0",
+      "category": "examples",
+      "keywords": [
+        "skills",
+        "agent-skills",
+        "plugin-management",
+        "marketplace",
+        "validation",
+        "audit",
+        "versioning",
+        "meta-plugin",
+        "repository-tools"
+      ],
+      "author": {
+        "name": "Claude Code Plugins",
+        "email": "[email protected]"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
       "name": "sla-sli-tracker",
       "source": "./plugins/performance/sla-sli-tracker",
       "description": "Track SLAs, SLIs, and SLOs for service reliability",
@@ -5211,6 +4025,217 @@
       }
     },
     {
+      "name": "smoke-test-runner",
+      "source": "./plugins/testing/smoke-test-runner",
+      "description": "Quick smoke test suites to verify critical functionality after deployments",
+      "version": "1.20.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "smoke-tests",
+        "deployment",
+        "sanity-check",
+        "critical-path"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "snapshot-test-manager",
+      "source": "./plugins/testing/snapshot-test-manager",
+      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "snapshot",
+        "jest",
+        "vitest",
+        "diff-analysis",
+        "test-management"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "soc2-audit-helper",
+      "source": "./plugins/security/soc2-audit-helper",
+      "description": "Assist with SOC2 audit preparation",
+      "version": "1.30.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "sow-generator",
+      "source": "./plugins/ai-agency/sow-generator",
+      "description": "Generate professional Statements of Work for AI projects",
+      "version": "1.9.0",
+      "category": "ai-agency",
+      "keywords": [
+        "sow",
+        "statement of work",
+        "contract",
+        "proposal",
+        "agency",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "sql-injection-detector",
+      "source": "./plugins/security/sql-injection-detector",
+      "description": "Detect SQL injection vulnerabilities",
+      "version": "1.31.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "sql-query-optimizer",
+      "source": "./plugins/database/sql-query-optimizer",
+      "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
+      "version": "1.27.0",
+      "category": "database",
+      "keywords": [
+        "sql",
+        "optimization",
+        "performance",
+        "database",
+        "query"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "ssl-certificate-manager",
+      "source": "./plugins/security/ssl-certificate-manager",
+      "description": "Manage and monitor SSL/TLS certificates",
+      "version": "1.21.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "staking-rewards-optimizer",
+      "source": "./plugins/crypto/staking-rewards-optimizer",
+      "description": "Optimize staking rewards across multiple protocols and chains",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "staking",
+        "defi",
+        "yield",
+        "optimization",
+        "rewards"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "stored-procedure-generator",
+      "source": "./plugins/database/stored-procedure-generator",
+      "description": "Database plugin for stored-procedure-generator",
+      "version": "1.29.0",
+      "category": "database",
+      "keywords": [
+        "database",
+        "backend",
+        "procedure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "jeremy-firestore",
+      "source": "./plugins/community/jeremy-firestore",
+      "description": "Firestore database specialist for schema design, queries, and real-time sync",
+      "version": "2.20.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "firestore",
+        "database",
+        "crud",
+        "security-rules",
+        "cloud-functions",
+        "batch-operations",
+        "data-migration",
+        "performance",
+        "cost-optimization",
+        "nosql",
+        "google-cloud",
+        "a2a",
+        "agent-to-agent",
+        "mcp",
+        "cloud-run",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]",
+        "url": "https://intentsolutions.io"
+      }
+    },
+    {
+      "name": "sugar",
+      "source": "./plugins/devops/sugar",
+      "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
+      "version": "2.0.0",
+      "category": "devops",
+      "keywords": [
+        "autonomous",
+        "development",
+        "ai",
+        "task-management",
+        "automation",
+        "agents",
+        "enterprise",
+        "workflow",
+        "productivity",
+        "mcp"
+      ],
+      "author": {
+        "name": "Steven Leggett",
+        "email": "contact@roboticforce.io"
+      },
+      "repository": "https://github.com/cdnsteve/sugar"
+    },
+    {
       "name": "synthetic-monitoring-setup",
       "source": "./plugins/performance/synthetic-monitoring-setup",
       "description": "Set up synthetic monitoring for proactive performance tracking",
@@ -5224,6 +4249,138 @@
       ],
       "author": {
         "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "terraform-module-builder",
+      "source": "./plugins/devops/terraform-module-builder",
+      "description": "Build reusable Terraform modules",
+      "version": "1.23.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "iac",
+        "modules",
+        "infrastructure",
+        "devops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-coverage-analyzer",
+      "source": "./plugins/testing/test-coverage-analyzer",
+      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "coverage",
+        "code-coverage",
+        "metrics",
+        "analysis"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-data-generator",
+      "source": "./plugins/testing/test-data-generator",
+      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
+      "version": "1.24.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "test-data",
+        "fake-data",
+        "fixtures",
+        "factory"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-doubles-generator",
+      "source": "./plugins/testing/test-doubles-generator",
+      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
+      "version": "1.22.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "mocks",
+        "stubs",
+        "spies",
+        "fakes",
+        "test-doubles",
+        "jest",
+        "sinon"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-environment-manager",
+      "source": "./plugins/testing/test-environment-manager",
+      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "environment",
+        "docker",
+        "testcontainers",
+        "isolation",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-orchestrator",
+      "source": "./plugins/testing/test-orchestrator",
+      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "orchestration",
+        "workflow",
+        "parallel",
+        "test-selection",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "test-report-generator",
+      "source": "./plugins/testing/test-report-generator",
+      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
+      "version": "1.23.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "reporting",
+        "coverage",
+        "metrics",
+        "dashboard",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
         "email": "[email protected]"
       }
     },
@@ -5245,92 +4402,324 @@
       }
     },
     {
-      "name": "000-jeremy-content-consistency-validator",
-      "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
-      "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
-      "version": "3.29.0",
-      "category": "productivity",
+      "name": "time-series-forecaster",
+      "source": "./plugins/ai-ml/time-series-forecaster",
+      "description": "Time series forecasting and analysis",
+      "version": "1.23.0",
+      "category": "ai-ml",
       "keywords": [
-        "documentation",
-        "consistency",
-        "validation",
-        "drift-detection",
-        "source-of-truth",
-        "authority-registry",
-        "content-audit",
-        "quality-assurance",
-        "release-gate",
-        "standards"
+        "time-series",
+        "forecasting",
+        "arima",
+        "prophet",
+        "ml"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "email": "[email protected]"
       }
     },
     {
-      "name": "002-jeremy-yaml-master-agent",
-      "source": "./plugins/productivity/002-jeremy-yaml-master-agent",
-      "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
-      "version": "2.21.0",
-      "category": "productivity",
+      "name": "token-launch-tracker",
+      "source": "./plugins/crypto/token-launch-tracker",
+      "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
+      "version": "1.30.0",
+      "category": "crypto",
       "keywords": [
-        "yaml",
-        "validation",
-        "linting",
-        "schema",
-        "json",
-        "conversion",
-        "parsing",
-        "agent-skills"
+        "crypto",
+        "token-launch",
+        "rugpull",
+        "security",
+        "scam-detection",
+        "contract-analysis",
+        "defi",
+        "new-tokens"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
+        "email": "[email protected]"
       }
     },
     {
-      "name": "003-jeremy-vertex-ai-media-master",
-      "source": "./plugins/productivity/003-jeremy-vertex-ai-media-master",
-      "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
-      "version": "2.25.0",
+      "name": "trading-strategy-backtester",
+      "source": "./plugins/crypto/trading-strategy-backtester",
+      "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
+      "version": "1.28.0",
+      "category": "crypto",
+      "keywords": [
+        "trading",
+        "backtesting",
+        "strategy",
+        "historical",
+        "performance",
+        "risk"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "transfer-learning-adapter",
+      "source": "./plugins/ai-ml/transfer-learning-adapter",
+      "description": "Transfer learning adaptation",
+      "version": "1.22.0",
+      "category": "ai-ml",
+      "keywords": [
+        "transfer-learning",
+        "fine-tuning",
+        "pretrained",
+        "adapters",
+        "ml"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "travel-assistant",
+      "source": "./plugins/productivity/travel-assistant",
+      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
+      "version": "1.15.0",
       "category": "productivity",
       "keywords": [
-        "vertex-ai",
+        "travel",
+        "weather",
+        "currency",
+        "timezone",
+        "itinerary",
+        "vacation",
+        "trip-planning",
+        "ai-travel",
+        "real-time",
+        "api-integration",
+        "budget",
+        "packing-list"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "unit-test-generator",
+      "source": "./plugins/testing/unit-test-generator",
+      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
+      "version": "1.21.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "unit-tests",
+        "test-generation",
+        "jest",
+        "pytest",
+        "mocha",
+        "junit"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "visual-regression-tester",
+      "source": "./plugins/testing/visual-regression-tester",
+      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
+      "version": "1.25.0",
+      "category": "testing",
+      "keywords": [
+        "testing",
+        "visual-regression",
+        "ui-testing",
+        "percy",
+        "chromatic",
+        "backstop",
+        "screenshot-testing"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "vulnerability-scanner",
+      "source": "./plugins/security/vulnerability-scanner",
+      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "vulnerability",
+        "scanning",
+        "cve",
+        "sast"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "wallet-portfolio-tracker",
+      "source": "./plugins/crypto/wallet-portfolio-tracker",
+      "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
+      "version": "1.12.0",
+      "category": "crypto",
+      "keywords": [
+        "wallet",
+        "portfolio",
+        "tracking",
+        "blockchain",
+        "defi",
+        "crypto"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "web-to-github-issue",
+      "source": "./plugins/skill-enhancers/web-to-github-issue",
+      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
+      "version": "1.27.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "web-search",
+        "github",
+        "automation",
+        "research",
+        "issue-tracking",
+        "skill-enhancer",
+        "productivity",
+        "workflow"
+      ],
+      "author": {
+        "name": "Claude Code Plugins Team",
+        "email": "[email protected]"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
+    },
+    {
+      "name": "webhook-handler-creator",
+      "source": "./plugins/api-development/webhook-handler-creator",
+      "description": "Create secure webhook endpoints with signature verification and retry logic",
+      "version": "1.25.0",
+      "category": "api-development",
+      "keywords": [
+        "webhook",
+        "events",
+        "signature",
+        "security"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "websocket-server-builder",
+      "source": "./plugins/api-development/websocket-server-builder",
+      "description": "Build WebSocket servers for real-time bidirectional communication",
+      "version": "1.24.0",
+      "category": "api-development",
+      "keywords": [
+        "websocket",
+        "real-time",
+        "socket.io",
+        "ws"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "whale-alert-monitor",
+      "source": "./plugins/crypto/whale-alert-monitor",
+      "description": "Monitor large crypto transactions and whale wallet movements in real-time",
+      "version": "1.26.0",
+      "category": "crypto",
+      "keywords": [
+        "whale",
+        "alert",
+        "monitor",
+        "large",
+        "transactions"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "workflow-orchestrator",
+      "source": "./plugins/mcp/workflow-orchestrator",
+      "description": "DAG-based workflow automation with parallel task execution and dependency management",
+      "version": "1.15.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "workflow",
+        "dag",
+        "automation",
+        "orchestration",
+        "cicd",
+        "parallel-execution"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "xss-vulnerability-scanner",
+      "source": "./plugins/security/xss-vulnerability-scanner",
+      "description": "Scan for XSS vulnerabilities",
+      "version": "1.24.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "compliance",
+        "auditing"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "[email protected]"
+      }
+    },
+    {
+      "name": "zapier-zap-builder",
+      "source": "./plugins/ai-agency/zapier-zap-builder",
+      "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
+      "version": "1.10.0",
+      "category": "ai-agency",
+      "keywords": [
+        "zapier",
+        "zap",
+        "automation",
+        "integration",
+        "workflow",
+        "ai-agency"
+      ],
+      "author": {
+        "name": "Claude Code Plugin Hub"
+      }
+    },
+    {
+      "name": "jeremy-genkit-pro",
+      "source": "./plugins/ai-ml/jeremy-genkit-pro",
+      "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
+      "version": "2.26.0",
+      "category": "ai-ml",
+      "keywords": [
+        "firebase",
+        "genkit",
+        "ai-flows",
+        "rag",
+        "monitoring",
         "gemini",
-        "multimodal",
-        "video-processing",
-        "audio-generation",
-        "image-generation",
-        "marketing",
-        "campaigns",
-        "content-generation",
-        "imagen",
-        "media-production",
-        "google-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "004-jeremy-google-cloud-agent-sdk",
-      "source": "./plugins/productivity/004-jeremy-google-cloud-agent-sdk",
-      "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
-      "version": "2.24.0",
-      "category": "productivity",
-      "keywords": [
-        "agent-development-kit",
-        "adk",
-        "agent-starter-pack",
-        "multi-agent",
-        "containerized-agents",
-        "cloud-run",
-        "gke",
-        "agent-engine",
-        "rag-agents",
-        "react-agents",
-        "google-cloud",
         "vertex-ai"
       ],
       "author": {
@@ -5339,260 +4728,36 @@
       }
     },
     {
-      "name": "agent-context-manager",
-      "source": "./plugins/productivity/agent-context-manager",
-      "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
-      "version": "1.23.0",
-      "category": "productivity",
+      "name": "jeremy-adk-orchestrator",
+      "source": "./plugins/ai-ml/jeremy-adk-orchestrator",
+      "description": "Production ADK orchestrator for A2A protocol and multi-agent coordination on Vertex AI",
+      "version": "2.29.0",
+      "category": "ai-ml",
       "keywords": [
-        "agents",
-        "context",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore"
-      }
-    },
-    {
-      "name": "ai-commit-gen",
-      "source": "./plugins/productivity/ai-commit-gen",
-      "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
-      "version": "1.10.0",
-      "category": "productivity",
-      "keywords": [
-        "git",
-        "commit",
-        "conventional-commits",
-        "ai",
-        "automation",
-        "productivity",
-        "devops"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "box-cloud-filesystem",
-      "source": "./plugins/productivity/box-cloud-filesystem",
-      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "box",
-        "cloud-storage",
-        "filesystem",
-        "file-sync",
-        "box-cli",
-        "upload",
-        "download",
-        "document-management",
-        "collaboration",
-        "ai-agent-storage"
+        "vertex-ai",
+        "adk",
+        "a2a-protocol",
+        "multi-agent",
+        "code-execution",
+        "memory-bank"
       ],
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
-      },
-      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
-      "homepage": "https://tonsofskills.com",
-      "license": "MIT"
+      }
     },
     {
-      "name": "claude-workflow-skills",
-      "source": "./plugins/productivity/claude-workflow-skills",
-      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
-      "version": "1.7.1",
-      "category": "productivity",
+      "name": "jeremy-vertex-validator",
+      "source": "./plugins/ai-ml/jeremy-vertex-validator",
+      "description": "Production readiness validator for Vertex AI deployments and configurations",
+      "version": "2.22.0",
+      "category": "ai-ml",
       "keywords": [
-        "workflow",
-        "promote",
-        "release",
-        "audit",
-        "standards",
-        "improve",
-        "triage",
-        "git",
-        "review",
-        "pull-request"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
-      "repository": "https://github.com/ali5ter/claude-workflow-skills",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
-      "name": "cli-power-skills",
-      "source": "./plugins/productivity/cli-power-skills",
-      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "cli-tools",
-        "agentic-skills",
-        "data-processing",
+        "vertex-ai",
+        "validation",
+        "production-readiness",
         "security",
-        "web-crawling",
-        "python",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Yuriy Kotik",
-        "url": "https://github.com/ykotik"
-      },
-      "repository": "https://github.com/ykotik/cli-power-skills",
-      "license": "MIT"
-    },
-    {
-      "name": "content-multiplier",
-      "source": "./plugins/productivity/content-multiplier",
-      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
-      "version": "0.2.1",
-      "category": "productivity",
-      "keywords": [
-        "marketing",
-        "content",
-        "repurposing",
-        "brand-voice",
-        "localization",
-        "social-media"
-      ],
-      "author": {
-        "name": "localplugins",
-        "email": "localplugins@proton.me"
-      },
-      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
-      "repository": "https://github.com/localplugins/plugins",
-      "license": "MIT"
-    },
-    {
-      "name": "hyperfocus",
-      "source": "./plugins/productivity/hyperfocus",
-      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
-      "version": "0.2.0",
-      "category": "productivity",
-      "author": {
-        "name": "Nestor Magalhaes",
-        "email": "nestor.magalhaes@appex.world"
-      },
-      "keywords": [
-        "accessibility",
-        "adhd",
-        "neurodivergent",
-        "formatting",
-        "readability",
-        "productivity",
-        "cognitive-accessibility"
-      ],
-      "repository": "https://github.com/nextor2k/hyperfocus",
-      "homepage": "https://github.com/nextor2k/hyperfocus",
-      "license": "MIT"
-    },
-    {
-      "name": "intent-labs-pack",
-      "source": "./plugins/productivity/intent-labs-pack",
-      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
-      "version": "0.1.0",
-      "category": "productivity",
-      "keywords": [
-        "audit-tests",
-        "validate-skillmd",
-        "testing",
-        "skill-validation",
-        "intent-eval",
-        "dogfood"
+        "compliance"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -5600,17 +4765,20 @@
       }
     },
     {
-      "name": "j-rig",
-      "source": "./plugins/productivity/j-rig",
-      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
-      "version": "0.1.0",
-      "category": "productivity",
+      "name": "jeremy-google-adk",
+      "source": "./plugins/ai-ml/jeremy-google-adk",
+      "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+      "version": "2.2.0",
+      "category": "ai-ml",
       "keywords": [
-        "skill-refiner",
-        "eval-guided",
-        "skill-md",
-        "meta-tooling",
-        "hooks"
+        "google",
+        "adk",
+        "agent-development-kit",
+        "ai-agents",
+        "react-pattern",
+        "multi-agent",
+        "vertex-ai",
+        "agent-engine"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -5618,151 +4786,20 @@
       }
     },
     {
-      "name": "navigating-github",
-      "source": "./plugins/productivity/navigating-github",
-      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
-      "version": "2.5.0",
-      "category": "productivity",
+      "name": "jeremy-vertex-ai",
+      "source": "./plugins/ai-ml/jeremy-vertex-ai",
+      "description": "Build and deploy generative AI agents on Vertex AI: Gemini model selection, RAG with grounded retrieval, function calling, multimodal extraction, evaluation, and Agent Engine deployment with operational guardrails.",
+      "version": "2.2.0",
+      "category": "ai-ml",
       "keywords": [
-        "github",
-        "git",
-        "learning",
-        "onboarding",
-        "beginner-friendly",
-        "interactive-learning",
-        "version-control",
-        "vibe-coding",
-        "setup",
-        "collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      },
-      "license": "MIT",
-      "repository": "https://github.com/jeremylongshore/navigating-github"
-    },
-    {
-      "name": "neurodivergent-visual-org",
-      "source": "./plugins/productivity/neurodivergent-visual-org",
-      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
-      "version": "3.10.0",
-      "category": "productivity",
-      "keywords": [
-        "neurodivergent",
-        "adhd",
-        "autism",
-        "accessibility",
-        "mermaid-diagrams",
-        "visual-organization",
-        "task-breakdown",
-        "decision-trees"
-      ],
-      "author": {
-        "name": "Jack Reis",
-        "url": "https://github.com/JackReis"
-      },
-      "repository": "https://github.com/JackReis/neurodivergent-visual-org"
-    },
-    {
-      "name": "obsidian-project-documentation",
-      "source": "./plugins/productivity/obsidian-project-documentation",
-      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
-      "version": "3.2.5",
-      "category": "productivity",
-      "keywords": [
-        "obsidian",
-        "documentation",
-        "notes",
-        "projects"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
-      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
-      "license": "MIT"
-    },
-    {
-      "name": "over-50s-health",
-      "source": "./plugins/productivity/over-50s-health",
-      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
-      "version": "3.3.0",
-      "category": "productivity",
-      "keywords": [
-        "health",
-        "fitness",
-        "nutrition",
-        "longevity",
-        "50+"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
-      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
-      "license": "MIT"
-    },
-    {
-      "name": "overnight-dev",
-      "source": "./plugins/productivity/overnight-dev",
-      "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
-      "version": "1.29.0",
-      "category": "productivity",
-      "keywords": [
-        "overnight",
-        "autonomous",
-        "tdd",
-        "testing",
-        "git-hooks",
-        "automation",
-        "continuous-integration",
-        "test-driven-development",
-        "productivity"
-      ],
-      "author": {
-        "name": "Intent Solutions IO",
-        "url": "https://intentsolutions.io",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "pair-programmer",
-      "source": "./plugins/productivity/pair-programmer",
-      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
-      "version": "1.0.0",
-      "category": "productivity",
-      "keywords": [
-        "pair-programming",
-        "coding",
-        "skill-development",
-        "graduated-assistance"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/pair-programmer",
-      "repository": "https://github.com/ali5ter/pair-programmer",
-      "license": "MIT"
-    },
-    {
-      "name": "plane",
-      "source": "./plugins/productivity/plane",
-      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
-      "version": "0.3.0",
-      "category": "productivity",
-      "keywords": [
-        "plane",
-        "project-management",
-        "team-behavior",
-        "observability",
-        "productivity",
-        "agent-skills",
-        "forge-generated"
+        "vertex-ai",
+        "gemini",
+        "google-cloud",
+        "generative-ai",
+        "rag",
+        "agent-engine",
+        "function-calling",
+        "multimodal"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -5770,22 +4807,123 @@
       }
     },
     {
-      "name": "pm-ai-partner",
-      "source": "./plugins/productivity/pm-ai-partner",
-      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
-      "version": "1.8.0",
-      "category": "productivity",
+      "name": "jeremy-genkit-terraform",
+      "source": "./plugins/devops/jeremy-genkit-terraform",
+      "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
+      "version": "2.21.0",
+      "category": "devops",
       "keywords": [
-        "product-management",
-        "pm",
-        "ai-partner",
-        "skills",
-        "commands",
-        "hooks"
+        "terraform",
+        "genkit",
+        "firebase",
+        "cloud-run",
+        "infrastructure"
       ],
       "author": {
-        "name": "Ahmed Khaled",
-        "email": "ahmd.khaled.a.mohamed@gmail.com"
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-adk-terraform",
+      "source": "./plugins/devops/jeremy-adk-terraform",
+      "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
+      "version": "2.22.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "adk",
+        "agent-engine",
+        "vertex-ai",
+        "infrastructure",
+        "vpc-sc"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-vertex-terraform",
+      "source": "./plugins/devops/jeremy-vertex-terraform",
+      "description": "Terraform configurations for Vertex AI platform and Agent Engine",
+      "version": "2.22.0",
+      "category": "devops",
+      "keywords": [
+        "terraform",
+        "vertex-ai",
+        "gemini",
+        "model-garden",
+        "infrastructure"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-vertex-engine",
+      "source": "./plugins/ai-ml/jeremy-vertex-engine",
+      "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
+      "version": "2.31.0",
+      "category": "ai-ml",
+      "keywords": [
+        "vertex-ai",
+        "agent-engine",
+        "runtime-inspector",
+        "agent-monitoring",
+        "compliance",
+        "production-validation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-gcp-starter-examples",
+      "source": "./plugins/ai-ml/jeremy-gcp-starter-examples",
+      "description": "Google Cloud starter kits and example code aggregator with ADK samples",
+      "version": "2.25.0",
+      "category": "ai-ml",
+      "keywords": [
+        "google-cloud",
+        "adk-samples",
+        "genkit-examples",
+        "vertex-ai",
+        "agent-starter-pack",
+        "code-examples",
+        "starter-kits",
+        "templates"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "jeremy-github-actions-gcp",
+      "source": "./plugins/devops/jeremy-github-actions-gcp",
+      "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
+      "version": "2.27.0",
+      "category": "devops",
+      "keywords": [
+        "github-actions",
+        "google-cloud",
+        "workload-identity-federation",
+        "wif",
+        "vertex-ai",
+        "agent-engine",
+        "deployment",
+        "ci-cd",
+        "security",
+        "best-practices",
+        "oidc",
+        "iam"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
@@ -5811,84 +4949,119 @@
       }
     },
     {
-      "name": "publishing-skills",
-      "source": "./plugins/productivity/publishing-skills",
-      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
-      "version": "0.1.0",
-      "category": "productivity",
+      "name": "axiom",
+      "source": "./plugins/skill-enhancers/axiom",
+      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
+      "version": "0.3.0",
+      "category": "skill-enhancers",
       "keywords": [
-        "ghost",
-        "blogging",
-        "seo",
-        "content-creation",
-        "publishing",
-        "claude-code",
-        "ai-writing"
+        "ios",
+        "debugging",
+        "swift",
+        "persistence",
+        "testing",
+        "performance",
+        "xcode",
+        "concurrency",
+        "database",
+        "swiftdata",
+        "grdb",
+        "liquid-glass",
+        "swiftui"
       ],
       "author": {
-        "name": "AutomateLab",
-        "url": "https://github.com/AutomateLab-tech",
-        "email": "hello@automatelab.tech"
-      },
-      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
-      "license": "MIT-0"
+        "name": "Charles Wiltgen",
+        "url": "https://github.com/CharlesWiltgen"
+      }
     },
     {
-      "name": "schedule-after-usage-reset",
-      "source": "./plugins/productivity/schedule-after-usage-reset",
-      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
-      "version": "1.0.0",
-      "category": "productivity",
+      "name": "skill-creator",
+      "source": "./plugins/skill-enhancers/skill-creator",
+      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
+      "version": "5.20.0",
+      "category": "skill-enhancers",
       "keywords": [
-        "schedule",
-        "usage-reset",
-        "rate-limit",
-        "claude-code",
-        "automation"
-      ],
-      "author": {
-        "name": "patricksong1993",
-        "url": "https://github.com/patricksong1993"
-      },
-      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
-      "license": "MIT"
-    },
-    {
-      "name": "skyvern",
-      "source": "./plugins/productivity/skyvern",
-      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
-      "version": "0.1.0",
-      "category": "productivity",
-      "author": {
-        "name": "Skyvern-AI",
-        "url": "https://github.com/Skyvern-AI"
-      },
-      "license": "AGPL-3.0"
-    },
-    {
-      "name": "travel-assistant",
-      "source": "./plugins/productivity/travel-assistant",
-      "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
-      "version": "1.15.0",
-      "category": "productivity",
-      "keywords": [
-        "travel",
-        "weather",
-        "currency",
-        "timezone",
-        "itinerary",
-        "vacation",
-        "trip-planning",
-        "ai-travel",
-        "real-time",
-        "api-integration",
-        "budget",
-        "packing-list"
+        "skill-creation",
+        "validation",
+        "meta-tooling",
+        "grading",
+        "anthropic-spec"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "claude-never-forgets",
+      "source": "./plugins/community/claude-never-forgets",
+      "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
+      "version": "1.21.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "context",
+        "persistent",
+        "preferences",
+        "sessions",
+        "recall"
+      ],
+      "author": {
+        "name": "yldrmahmet",
+        "url": "https://github.com/yldrmahmet"
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "research",
+        "games",
+        "accessibility",
+        "performance",
+        "flask",
+        "react",
+        "godot",
+        "corpus-linguistics",
+        "mcp"
+      ],
+      "author": {
+        "name": "Luke Steuber",
+        "url": "https://github.com/lukeslp"
+      }
+    },
+    {
+      "name": "sprint",
+      "source": "./plugins/community/sprint",
+      "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
+      "version": "1.20.0",
+      "category": "community",
+      "keywords": [
+        "autonomous",
+        "agentic",
+        "yolo",
+        "self-iterating",
+        "multi-agent",
+        "hands-off",
+        "auto-pilot",
+        "orchestration",
+        "sprint",
+        "testing",
+        "qa",
+        "mcp"
+      ],
+      "author": {
+        "name": "Damien Laine",
+        "email": "damien.laine@gmail.com",
+        "url": "https://github.com/damienlaine"
       }
     },
     {
@@ -5919,6 +5092,1313 @@
       "strict": true
     },
     {
+      "name": "jeremy-adk-software-engineer",
+      "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
+      "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
+      "version": "2.19.0",
+      "category": "ai-ml",
+      "keywords": [
+        "adk",
+        "software-engineer",
+        "agent-development",
+        "vertex-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "geepers-agents",
+      "source": "./plugins/community/geepers-agents",
+      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
+      "version": "1.13.0",
+      "category": "community",
+      "keywords": [
+        "mcp",
+        "orchestration",
+        "multi-agent",
+        "development-workflow",
+        "code-quality",
+        "deployment",
+        "geepers",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Luke Steuber"
+      },
+      "homepage": "https://dr.eamer.dev/geepers/",
+      "repository": "https://github.com/lukeslp/geepers"
+    },
+    {
+      "name": "jeremy-firebase",
+      "source": "./plugins/community/jeremy-firebase",
+      "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
+      "version": "2.23.0",
+      "category": "community",
+      "keywords": [
+        "firebase",
+        "vertex-ai",
+        "gemini",
+        "authentication",
+        "storage",
+        "hosting",
+        "cloud-functions",
+        "analytics",
+        "ai-integration",
+        "google-cloud",
+        "embeddings",
+        "model-deployment",
+        "ai-powered",
+        "production-ready"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "wallet-security-auditor",
+      "source": "./plugins/crypto/wallet-security-auditor",
+      "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
+      "version": "1.17.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "wallet",
+        "security",
+        "audit",
+        "web3"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "mattyp-changelog",
+      "source": "./plugins/devops/mattyp-changelog",
+      "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
+      "version": "0.3.0",
+      "category": "devops",
+      "keywords": [
+        "changelog",
+        "release-notes",
+        "weekly-update",
+        "git",
+        "github",
+        "automation"
+      ],
+      "author": {
+        "name": "Mattyp",
+        "email": "mattyp@tonsofskills.com",
+        "url": "https://tonsofskills.com"
+      }
+    },
+    {
+      "name": "supabase-pack",
+      "source": "./plugins/saas-packs/supabase-pack",
+      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.53.0",
+      "category": "saas-packs",
+      "keywords": [
+        "supabase",
+        "postgres",
+        "database",
+        "authentication",
+        "realtime",
+        "storage",
+        "edge-functions",
+        "rls",
+        "row-level-security",
+        "baas",
+        "backend-as-a-service",
+        "firebase-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "vercel-pack",
+      "source": "./plugins/saas-packs/vercel-pack",
+      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vercel",
+        "deployment",
+        "edge-functions",
+        "serverless",
+        "preview",
+        "ci-cd",
+        "hosting",
+        "next-js",
+        "jamstack",
+        "frontend-cloud"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "clay-pack",
+      "source": "./plugins/saas-packs/clay-pack",
+      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clay",
+        "data-enrichment",
+        "waterfall",
+        "gtm",
+        "sales-ops",
+        "lead-enrichment",
+        "ai-agents"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "cursor-pack",
+      "source": "./plugins/saas-packs/cursor-pack",
+      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "cursor",
+        "ai-editor",
+        "code-editor",
+        "composer",
+        "ai-coding",
+        "vscode-fork",
+        "copilot-alternative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "exa-pack",
+      "source": "./plugins/saas-packs/exa-pack",
+      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "exa",
+        "neural-search",
+        "semantic-search",
+        "web-search",
+        "ai-search",
+        "retrieval",
+        "embeddings"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "firecrawl-pack",
+      "source": "./plugins/saas-packs/firecrawl-pack",
+      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "firecrawl",
+        "web-scraping",
+        "crawling",
+        "markdown",
+        "llm-ready",
+        "data-extraction",
+        "scraper"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "klingai-pack",
+      "source": "./plugins/saas-packs/klingai-pack",
+      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
+      "version": "1.18.0",
+      "category": "saas-packs",
+      "keywords": [
+        "klingai",
+        "kling",
+        "video-generation",
+        "text-to-video",
+        "ai-video",
+        "generative-ai",
+        "creative"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "openrouter-pack",
+      "source": "./plugins/saas-packs/openrouter-pack",
+      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
+      "version": "1.20.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openrouter",
+        "llm-routing",
+        "model-selection",
+        "ai-gateway",
+        "multi-model",
+        "cost-optimization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "perplexity-pack",
+      "source": "./plugins/saas-packs/perplexity-pack",
+      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "perplexity",
+        "ai-search",
+        "research",
+        "citations",
+        "real-time",
+        "knowledge",
+        "answers"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "replit-pack",
+      "source": "./plugins/saas-packs/replit-pack",
+      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "replit",
+        "cloud-ide",
+        "deployments",
+        "collaborative",
+        "ai-coding",
+        "browser-ide",
+        "hosting"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "retellai-pack",
+      "source": "./plugins/saas-packs/retellai-pack",
+      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
+      "version": "1.9.0",
+      "category": "saas-packs",
+      "keywords": [
+        "retellai",
+        "retell",
+        "voice-ai",
+        "phone-agents",
+        "conversational-ai",
+        "call-center",
+        "ivr"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "sentry-pack",
+      "source": "./plugins/saas-packs/sentry-pack",
+      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
+      "version": "1.51.0",
+      "category": "saas-packs",
+      "keywords": [
+        "sentry",
+        "error-monitoring",
+        "performance",
+        "observability",
+        "debugging",
+        "crash-reporting",
+        "apm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "windsurf-pack",
+      "source": "./plugins/saas-packs/windsurf-pack",
+      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "windsurf",
+        "ai-editor",
+        "cascade",
+        "codeium",
+        "ai-coding",
+        "code-completion",
+        "refactoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "coderabbit-pack",
+      "source": "./plugins/saas-packs/coderabbit-pack",
+      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "coderabbit",
+        "code-review",
+        "pr-automation",
+        "ai-review",
+        "code-quality",
+        "github-integration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "fireflies-pack",
+      "source": "./plugins/saas-packs/fireflies-pack",
+      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "fireflies",
+        "meeting-transcription",
+        "ai-notes",
+        "conversation-intelligence",
+        "summaries"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "groq-pack",
+      "source": "./plugins/saas-packs/groq-pack",
+      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "groq",
+        "lpu",
+        "fast-inference",
+        "llm",
+        "groq-cloud",
+        "low-latency",
+        "ai-acceleration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "ideogram-pack",
+      "source": "./plugins/saas-packs/ideogram-pack",
+      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
+      "version": "1.10.0",
+      "category": "saas-packs",
+      "keywords": [
+        "ideogram",
+        "image-generation",
+        "text-to-image",
+        "ai-art",
+        "typography",
+        "creative",
+        "design"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "instantly-pack",
+      "source": "./plugins/saas-packs/instantly-pack",
+      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "instantly",
+        "cold-email",
+        "outreach",
+        "email-automation",
+        "lead-generation",
+        "sales"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "posthog-pack",
+      "source": "./plugins/saas-packs/posthog-pack",
+      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "posthog",
+        "product-analytics",
+        "feature-flags",
+        "session-replay",
+        "ab-testing",
+        "experimentation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "vastai-pack",
+      "source": "./plugins/saas-packs/vastai-pack",
+      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "vastai",
+        "vast-ai",
+        "gpu-marketplace",
+        "cloud-gpu",
+        "ml-infrastructure",
+        "compute",
+        "training"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "apollo-pack",
+      "source": "./plugins/saas-packs/apollo-pack",
+      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "apollo",
+        "sales",
+        "prospecting",
+        "sequences",
+        "outbound",
+        "crm",
+        "sales-engagement",
+        "lead-generation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "deepgram-pack",
+      "source": "./plugins/saas-packs/deepgram-pack",
+      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "deepgram",
+        "speech-to-text",
+        "transcription",
+        "voice",
+        "audio",
+        "asr",
+        "real-time",
+        "voice-ai"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "juicebox-pack",
+      "source": "./plugins/saas-packs/juicebox-pack",
+      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
+      "version": "1.16.0",
+      "category": "saas-packs",
+      "keywords": [
+        "juicebox",
+        "people-data",
+        "enrichment",
+        "contacts",
+        "search",
+        "data-api",
+        "lead-enrichment"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "customerio-pack",
+      "source": "./plugins/saas-packs/customerio-pack",
+      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "customerio",
+        "customer-io",
+        "marketing",
+        "email",
+        "automation",
+        "campaigns",
+        "sms",
+        "push-notifications"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "langchain-py-pack",
+      "source": "./plugins/saas-packs/langchain-py-pack",
+      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
+      "version": "2.5.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langchain",
+        "langgraph",
+        "python",
+        "llm",
+        "agents",
+        "rag",
+        "checkpointing",
+        "streaming",
+        "middleware",
+        "langsmith"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "lindy-pack",
+      "source": "./plugins/saas-packs/lindy-pack",
+      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
+      "version": "1.15.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lindy",
+        "ai-assistant",
+        "automation",
+        "workflows",
+        "tasks",
+        "intelligent-automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "granola-pack",
+      "source": "./plugins/saas-packs/granola-pack",
+      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "granola",
+        "meeting-notes",
+        "transcription",
+        "summaries",
+        "meetings",
+        "ai-notes",
+        "meeting-intelligence"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "ga4-pack",
+      "source": "./plugins/saas-packs/ga4-pack",
+      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+      "version": "1.2.0",
+      "category": "saas-packs",
+      "keywords": [
+        "google-analytics",
+        "ga4",
+        "analytics",
+        "data-api",
+        "bigquery",
+        "reporting",
+        "dau-mau",
+        "cohort-retention"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "gamma-pack",
+      "source": "./plugins/saas-packs/gamma-pack",
+      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "gamma",
+        "presentations",
+        "documents",
+        "ai-generation",
+        "templates",
+        "slides",
+        "visual-content"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "clerk-pack",
+      "source": "./plugins/saas-packs/clerk-pack",
+      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "clerk",
+        "authentication",
+        "auth",
+        "users",
+        "identity",
+        "sso",
+        "embeddable-ui",
+        "user-management"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "linear-pack",
+      "source": "./plugins/saas-packs/linear-pack",
+      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "linear",
+        "issues",
+        "project-management",
+        "tracking",
+        "workflows",
+        "agile",
+        "team-collaboration"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "databricks-pack",
+      "source": "./plugins/saas-packs/databricks-pack",
+      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
+      "version": "2.27.0",
+      "category": "saas-packs",
+      "keywords": [
+        "databricks",
+        "delta-lake",
+        "mlflow",
+        "spark",
+        "notebooks",
+        "clusters",
+        "data-engineering",
+        "lakehouse"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "mistral-pack",
+      "source": "./plugins/saas-packs/mistral-pack",
+      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "mistral",
+        "llm",
+        "inference",
+        "embeddings",
+        "fine-tuning",
+        "ai",
+        "machine-learning"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "langfuse-pack",
+      "source": "./plugins/saas-packs/langfuse-pack",
+      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
+      "version": "1.12.0",
+      "category": "saas-packs",
+      "keywords": [
+        "langfuse",
+        "observability",
+        "tracing",
+        "prompts",
+        "evaluation",
+        "llm-ops",
+        "monitoring"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "obsidian-pack",
+      "source": "./plugins/saas-packs/obsidian-pack",
+      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "obsidian",
+        "notes",
+        "vault",
+        "plugins",
+        "markdown",
+        "knowledge-management",
+        "pkm"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "documenso-pack",
+      "source": "./plugins/saas-packs/documenso-pack",
+      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "documenso",
+        "document-signing",
+        "e-signature",
+        "templates",
+        "workflows",
+        "contracts",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "evernote-pack",
+      "source": "./plugins/saas-packs/evernote-pack",
+      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "evernote",
+        "notes",
+        "notebooks",
+        "tags",
+        "search",
+        "productivity",
+        "organization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "guidewire-pack",
+      "source": "./plugins/saas-packs/guidewire-pack",
+      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
+      "version": "1.25.0",
+      "category": "saas-packs",
+      "keywords": [
+        "guidewire",
+        "insurance",
+        "policycenter",
+        "claimcenter",
+        "billingcenter",
+        "insurancesuite",
+        "enterprise"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "lokalise-pack",
+      "source": "./plugins/saas-packs/lokalise-pack",
+      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "lokalise",
+        "translation",
+        "localization",
+        "i18n",
+        "l10n",
+        "tms",
+        "internationalization"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "maintainx-pack",
+      "source": "./plugins/saas-packs/maintainx-pack",
+      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
+      "version": "1.11.0",
+      "category": "saas-packs",
+      "keywords": [
+        "maintainx",
+        "cmms",
+        "work-orders",
+        "maintenance",
+        "assets",
+        "facilities",
+        "operations"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "openevidence-pack",
+      "source": "./plugins/saas-packs/openevidence-pack",
+      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "openevidence",
+        "medical-ai",
+        "clinical",
+        "healthcare",
+        "evidence-based",
+        "decision-support",
+        "medicine"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "speak-pack",
+      "source": "./plugins/saas-packs/speak-pack",
+      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
+      "version": "1.14.0",
+      "category": "saas-packs",
+      "keywords": [
+        "speak",
+        "language-learning",
+        "speech",
+        "ai-tutor",
+        "education",
+        "conversation",
+        "edtech"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "twinmind-pack",
+      "source": "./plugins/saas-packs/twinmind-pack",
+      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
+      "version": "1.13.0",
+      "category": "saas-packs",
+      "keywords": [
+        "twinmind",
+        "meetings",
+        "transcription",
+        "summaries",
+        "ai-assistant",
+        "productivity",
+        "automation"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "gastown",
+      "source": "./plugins/community/gastown",
+      "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "multi-agent",
+        "orchestration",
+        "automation",
+        "polecats",
+        "convoys",
+        "beads",
+        "work-tracking",
+        "ai-factory",
+        "gastown",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      }
+    },
+    {
+      "name": "zai-cli",
+      "source": "./plugins/community/zai-cli",
+      "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
+      "version": "1.0.0",
+      "category": "community",
+      "keywords": [
+        "vision",
+        "image-analysis",
+        "ocr",
+        "web-search",
+        "web-reader",
+        "github",
+        "mcp",
+        "z-ai",
+        "glm-4",
+        "multimodal"
+      ],
+      "author": {
+        "name": "Numman Ali",
+        "email": "numman.ali@gmail.com",
+        "url": "https://github.com/numman-ali"
+      }
+    },
+    {
+      "name": "claude-reflect",
+      "source": "./plugins/community/claude-reflect",
+      "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
+      "version": "1.12.0",
+      "category": "community",
+      "keywords": [
+        "claude-code",
+        "self-learning",
+        "corrections",
+        "CLAUDE.md",
+        "memory",
+        "learnings",
+        "hooks",
+        "automation"
+      ],
+      "author": {
+        "name": "Bayram Annakov",
+        "url": "https://github.com/bayramannakov"
+      },
+      "repository": "https://github.com/bayramannakov/claude-reflect"
+    },
+    {
+      "name": "contributing-clanker",
+      "source": "./plugins/community/contributing-clanker",
+      "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
+      "version": "0.8.0",
+      "category": "community",
+      "keywords": [
+        "oss",
+        "contributions",
+        "github",
+        "ai-slop-prevention",
+        "code-review",
+        "open-source"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "homepage": "https://github.com/jeremylongshore/contributing-clanker",
+      "repository": "https://github.com/jeremylongshore/contributing-clanker",
+      "license": "MIT"
+    },
+    {
+      "name": "neurodivergent-visual-org",
+      "source": "./plugins/productivity/neurodivergent-visual-org",
+      "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
+      "version": "3.10.0",
+      "category": "productivity",
+      "keywords": [
+        "neurodivergent",
+        "adhd",
+        "autism",
+        "accessibility",
+        "mermaid-diagrams",
+        "visual-organization",
+        "task-breakdown",
+        "decision-trees"
+      ],
+      "author": {
+        "name": "Jack Reis",
+        "url": "https://github.com/JackReis"
+      },
+      "repository": "https://github.com/JackReis/neurodivergent-visual-org"
+    },
+    {
+      "name": "gh-dash",
+      "source": "./plugins/devops/gh-dash",
+      "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
+      "version": "1.6.0",
+      "category": "devops",
+      "keywords": [
+        "github",
+        "pull-request",
+        "ci-cd",
+        "dashboard",
+        "devops",
+        "merge",
+        "code-review"
+      ],
+      "author": {
+        "name": "Jake Kozloski",
+        "email": "jakozloski@gmail.com"
+      }
+    },
+    {
+      "name": "youtube-strategy",
+      "source": "./plugins/productivity/youtube-strategy",
+      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
+      "version": "1.10.0",
+      "category": "productivity",
+      "keywords": [
+        "youtube",
+        "content-strategy",
+        "video-production",
+        "ideation",
+        "research",
+        "thumbnails",
+        "titles",
+        "outlining",
+        "content-creation"
+      ],
+      "author": {
+        "name": "Claude Code Plugins"
+      }
+    },
+    {
+      "name": "b12-claude-plugin",
+      "source": "./plugins/community/b12-claude-plugin",
+      "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+      "version": "1.9.0",
+      "category": "community",
+      "keywords": [
+        "website",
+        "b12",
+        "hosting",
+        "web-design",
+        "ai-website",
+        "website-generator",
+        "saas"
+      ],
+      "author": {
+        "name": "B12.io",
+        "url": "https://github.com/b12io"
+      }
+    },
+    {
+      "name": "wondelai-blue-ocean-strategy",
+      "source": "./plugins/business-tools/wondelai-blue-ocean-strategy",
+      "description": "Blue Ocean Strategy framework for creating uncontested market space. Use the Strategy Canvas, Four Actions Framework (ERRC), and value innovation to break the value-cost trade-off.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "strategy",
+        "blue-ocean",
+        "value-innovation",
+        "market-creation",
+        "errc",
+        "strategy-canvas",
+        "competition",
+        "positioning"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-contagious",
+      "source": "./plugins/business-tools/wondelai-contagious",
+      "description": "Word-of-mouth and virality framework using the STEPPS model (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Engineer products and content that people naturally share.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "virality",
+        "word-of-mouth",
+        "stepps",
+        "social-currency",
+        "marketing",
+        "content-strategy",
+        "sharing",
+        "growth"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-cro-methodology",
+      "source": "./plugins/business-tools/wondelai-cro-methodology",
+      "description": "Customer-centric conversion rate optimization methodology. Audit landing pages, identify conversion blockers, write persuasive copy, design A/B tests, and optimize funnels.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "cro",
+        "conversion",
+        "optimization",
+        "landing-pages",
+        "ab-testing",
+        "copywriting",
+        "persuasion",
+        "funnels"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-crossing-the-chasm",
+      "source": "./plugins/business-tools/wondelai-crossing-the-chasm",
+      "description": "Technology adoption and go-to-market strategy for crossing from early adopters to mainstream market. Choose beachhead segments, build whole products, and position against incumbents.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "go-to-market",
+        "technology-adoption",
+        "chasm",
+        "beachhead",
+        "b2b",
+        "saas",
+        "market-strategy",
+        "positioning"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-design-everyday-things",
+      "source": "./plugins/design/wondelai-design-everyday-things",
+      "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "design",
+        "ux",
+        "affordances",
+        "signifiers",
+        "human-centered-design",
+        "usability",
+        "don-norman",
+        "hcd"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
       "name": "wondelai-design-sprint",
       "source": "./plugins/productivity/wondelai-design-sprint",
       "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
@@ -5933,6 +6413,144 @@
         "product-design",
         "rapid-iteration",
         "mvp"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-drive-motivation",
+      "source": "./plugins/business-tools/wondelai-drive-motivation",
+      "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "motivation",
+        "autonomy",
+        "mastery",
+        "purpose",
+        "engagement",
+        "gamification",
+        "intrinsic-motivation",
+        "team-management"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-hooked-ux",
+      "source": "./plugins/design/wondelai-hooked-ux",
+      "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "habits",
+        "engagement",
+        "retention",
+        "hook-model",
+        "triggers",
+        "rewards",
+        "onboarding",
+        "ux"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-hundred-million-offers",
+      "source": "./plugins/business-tools/wondelai-hundred-million-offers",
+      "description": "Grand Slam Offer creation framework. Create irresistible offers using the Value Equation, stack bonuses, design risk-reversing guarantees, and apply ethical scarcity.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "offers",
+        "pricing",
+        "value-equation",
+        "guarantees",
+        "bonuses",
+        "scarcity",
+        "sales",
+        "hormozi"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-influence-psychology",
+      "source": "./plugins/business-tools/wondelai-influence-psychology",
+      "description": "Persuasion science framework based on Cialdini's six principles (Reciprocity, Commitment, Social Proof, Authority, Liking, Scarcity). Apply ethical persuasion to product design and marketing.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "persuasion",
+        "influence",
+        "cialdini",
+        "social-proof",
+        "reciprocity",
+        "scarcity",
+        "psychology",
+        "marketing"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-ios-hig-design",
+      "source": "./plugins/design/wondelai-ios-hig-design",
+      "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ios",
+        "apple",
+        "hig",
+        "swiftui",
+        "uikit",
+        "mobile-design",
+        "accessibility",
+        "interface-guidelines"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-jobs-to-be-done",
+      "source": "./plugins/business-tools/wondelai-jobs-to-be-done",
+      "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "jtbd",
+        "jobs-to-be-done",
+        "product-strategy",
+        "customer-discovery",
+        "innovation",
+        "christensen",
+        "product-market-fit",
+        "interviews"
       ],
       "author": {
         "name": "Wondel.ai",
@@ -5965,25 +6583,307 @@
       "repository": "https://github.com/wondelai/skills"
     },
     {
-      "name": "youtube-strategy",
-      "source": "./plugins/productivity/youtube-strategy",
-      "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
-      "version": "1.10.0",
+      "name": "navigating-github",
+      "source": "./plugins/productivity/navigating-github",
+      "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
+      "version": "2.5.0",
       "category": "productivity",
       "keywords": [
-        "youtube",
-        "content-strategy",
-        "video-production",
-        "ideation",
-        "research",
-        "thumbnails",
-        "titles",
-        "outlining",
-        "content-creation"
+        "github",
+        "git",
+        "learning",
+        "onboarding",
+        "beginner-friendly",
+        "interactive-learning",
+        "version-control",
+        "vibe-coding",
+        "setup",
+        "collaboration"
       ],
       "author": {
-        "name": "Claude Code Plugins"
-      }
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/jeremylongshore/navigating-github"
+    },
+    {
+      "name": "wondelai-made-to-stick",
+      "source": "./plugins/business-tools/wondelai-made-to-stick",
+      "description": "Sticky messaging framework using the SUCCESs model (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Make product messaging memorable and create compelling presentations.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "messaging",
+        "storytelling",
+        "success",
+        "sticky",
+        "communication",
+        "presentations",
+        "copywriting",
+        "branding"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-negotiation",
+      "source": "./plugins/business-tools/wondelai-negotiation",
+      "description": "Tactical negotiation framework based on Chris Voss's techniques. Use mirroring, labeling, calibrated questions, the Ackerman method, and accusation audits for business and salary negotiations.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "negotiation",
+        "chris-voss",
+        "mirroring",
+        "labeling",
+        "ackerman",
+        "salary",
+        "deals",
+        "conflict-resolution"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-obviously-awesome",
+      "source": "./plugins/business-tools/wondelai-obviously-awesome",
+      "description": "Product positioning framework for competitive differentiation. Define competitive alternatives, identify unique attributes, map value themes, and choose the right market category.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "positioning",
+        "differentiation",
+        "competitive-analysis",
+        "market-category",
+        "value-proposition",
+        "april-dunford",
+        "go-to-market",
+        "branding"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-one-page-marketing",
+      "source": "./plugins/business-tools/wondelai-one-page-marketing",
+      "description": "End-to-end marketing plan framework. Define target market, craft USP, choose channels, design lead capture and nurture sequences, optimize conversion, and build referral systems.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "marketing-plan",
+        "usp",
+        "lead-generation",
+        "nurture",
+        "referral",
+        "advertising",
+        "customer-lifetime-value",
+        "marketing-strategy"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-predictable-revenue",
+      "source": "./plugins/business-tools/wondelai-predictable-revenue",
+      "description": "Outbound sales methodology for scalable B2B pipeline. Implement Cold Calling 2.0, structure SDR/AE/CSM roles, design prospecting sequences, and build predictable revenue engines.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "sales",
+        "outbound",
+        "sdr",
+        "pipeline",
+        "b2b",
+        "saas",
+        "prospecting",
+        "cold-calling",
+        "revenue"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-refactoring-ui",
+      "source": "./plugins/design/wondelai-refactoring-ui",
+      "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ui-design",
+        "visual-hierarchy",
+        "typography",
+        "color-palette",
+        "tailwind",
+        "shadows",
+        "spacing",
+        "refactoring-ui"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-scorecard-marketing",
+      "source": "./plugins/business-tools/wondelai-scorecard-marketing",
+      "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "lead-generation",
+        "quiz-funnel",
+        "assessment",
+        "scorecard",
+        "conversion",
+        "segmentation",
+        "lead-magnet",
+        "marketing-automation"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-storybrand-messaging",
+      "source": "./plugins/business-tools/wondelai-storybrand-messaging",
+      "description": "StoryBrand messaging framework that positions customer as hero. Create brand scripts, write website copy that converts, craft one-liners, and build narrative-driven landing pages.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "storybrand",
+        "messaging",
+        "brand-script",
+        "copywriting",
+        "narrative",
+        "website-copy",
+        "one-liner",
+        "donald-miller"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-top-design",
+      "source": "./plugins/design/wondelai-top-design",
+      "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "web-design",
+        "awwwards",
+        "animations",
+        "typography",
+        "scroll-effects",
+        "brand-website",
+        "premium-design",
+        "motion"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-traction-eos",
+      "source": "./plugins/business-tools/wondelai-traction-eos",
+      "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "eos",
+        "traction",
+        "operating-system",
+        "rocks",
+        "l10-meetings",
+        "accountability",
+        "vision",
+        "execution"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-ux-heuristics",
+      "source": "./plugins/design/wondelai-ux-heuristics",
+      "description": "Usability heuristics and UX audit framework based on Nielsen and Krug. Conduct heuristic evaluations, identify usability problems, and prioritize fixes by severity.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "ux",
+        "usability",
+        "heuristics",
+        "nielsen",
+        "krug",
+        "ux-audit",
+        "evaluation",
+        "accessibility"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
+    },
+    {
+      "name": "wondelai-web-typography",
+      "source": "./plugins/design/wondelai-web-typography",
+      "description": "Web typography framework for readable, beautiful type. Select and pair typefaces, set optimal line length and height, implement responsive typography, and optimize web font loading.",
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "typography",
+        "web-fonts",
+        "typeface",
+        "font-pairing",
+        "readability",
+        "responsive-typography",
+        "css",
+        "type-hierarchy"
+      ],
+      "author": {
+        "name": "Wondel.ai",
+        "url": "https://github.com/wondelai"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/wondelai/skills"
     },
     {
       "name": "abridge-pack",
@@ -6104,28 +7004,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "apollo-pack",
-      "source": "./plugins/saas-packs/apollo-pack",
-      "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "apollo",
-        "sales",
-        "prospecting",
-        "sequences",
-        "outbound",
-        "crm",
-        "sales-engagement",
-        "lead-generation"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -6299,49 +7177,6 @@
       }
     },
     {
-      "name": "clay-pack",
-      "source": "./plugins/saas-packs/clay-pack",
-      "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clay",
-        "data-enrichment",
-        "waterfall",
-        "gtm",
-        "sales-ops",
-        "lead-enrichment",
-        "ai-agents"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "clerk-pack",
-      "source": "./plugins/saas-packs/clerk-pack",
-      "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "clerk",
-        "authentication",
-        "auth",
-        "users",
-        "identity",
-        "sso",
-        "embeddable-ui",
-        "user-management"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "clickhouse-pack",
       "source": "./plugins/saas-packs/clickhouse-pack",
       "description": "Claude Code skill pack for ClickHouse (24 skills)",
@@ -6370,26 +7205,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "coderabbit-pack",
-      "source": "./plugins/saas-packs/coderabbit-pack",
-      "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "coderabbit",
-        "code-review",
-        "pr-automation",
-        "ai-review",
-        "code-quality",
-        "github-integration"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -6434,114 +7249,6 @@
       }
     },
     {
-      "name": "cursor-pack",
-      "source": "./plugins/saas-packs/cursor-pack",
-      "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "cursor",
-        "ai-editor",
-        "code-editor",
-        "composer",
-        "ai-coding",
-        "vscode-fork",
-        "copilot-alternative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "customerio-pack",
-      "source": "./plugins/saas-packs/customerio-pack",
-      "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "customerio",
-        "customer-io",
-        "marketing",
-        "email",
-        "automation",
-        "campaigns",
-        "sms",
-        "push-notifications"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "databricks-pack",
-      "source": "./plugins/saas-packs/databricks-pack",
-      "description": "5 live-detection Databricks skills — cost-leak-hunter, cluster-forensics, uc-migration-pilot, streaming-guardian, bundle-medic — backed by the databricks-workspace-mcp server (npm). The v2 rebuild: real workspace detection over static docs.",
-      "version": "2.27.0",
-      "category": "saas-packs",
-      "keywords": [
-        "databricks",
-        "delta-lake",
-        "mlflow",
-        "spark",
-        "notebooks",
-        "clusters",
-        "data-engineering",
-        "lakehouse"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "deepgram-pack",
-      "source": "./plugins/saas-packs/deepgram-pack",
-      "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "deepgram",
-        "speech-to-text",
-        "transcription",
-        "voice",
-        "audio",
-        "asr",
-        "real-time",
-        "voice-ai"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "documenso-pack",
-      "source": "./plugins/saas-packs/documenso-pack",
-      "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "documenso",
-        "document-signing",
-        "e-signature",
-        "templates",
-        "workflows",
-        "contracts",
-        "open-source"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "elevenlabs-pack",
       "source": "./plugins/saas-packs/elevenlabs-pack",
       "description": "Claude Code skill pack for ElevenLabs (18 skills)",
@@ -6552,48 +7259,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "evernote-pack",
-      "source": "./plugins/saas-packs/evernote-pack",
-      "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "evernote",
-        "notes",
-        "notebooks",
-        "tags",
-        "search",
-        "productivity",
-        "organization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "exa-pack",
-      "source": "./plugins/saas-packs/exa-pack",
-      "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "exa",
-        "neural-search",
-        "semantic-search",
-        "web-search",
-        "ai-search",
-        "retrieval",
-        "embeddings"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -6648,46 +7313,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "firecrawl-pack",
-      "source": "./plugins/saas-packs/firecrawl-pack",
-      "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "firecrawl",
-        "web-scraping",
-        "crawling",
-        "markdown",
-        "llm-ready",
-        "data-extraction",
-        "scraper"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "fireflies-pack",
-      "source": "./plugins/saas-packs/fireflies-pack",
-      "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "fireflies",
-        "meeting-transcription",
-        "ai-notes",
-        "conversation-intelligence",
-        "summaries"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -6769,49 +7394,6 @@
       }
     },
     {
-      "name": "ga4-pack",
-      "source": "./plugins/saas-packs/ga4-pack",
-      "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
-      "version": "1.2.0",
-      "category": "saas-packs",
-      "keywords": [
-        "google-analytics",
-        "ga4",
-        "analytics",
-        "data-api",
-        "bigquery",
-        "reporting",
-        "dau-mau",
-        "cohort-retention"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "gamma-pack",
-      "source": "./plugins/saas-packs/gamma-pack",
-      "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "gamma",
-        "presentations",
-        "documents",
-        "ai-generation",
-        "templates",
-        "slides",
-        "visual-content"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "glean-pack",
       "source": "./plugins/saas-packs/glean-pack",
       "description": "Claude Code skill pack for Glean (24 skills)",
@@ -6840,69 +7422,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "granola-pack",
-      "source": "./plugins/saas-packs/granola-pack",
-      "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "granola",
-        "meeting-notes",
-        "transcription",
-        "summaries",
-        "meetings",
-        "ai-notes",
-        "meeting-intelligence"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "groq-pack",
-      "source": "./plugins/saas-packs/groq-pack",
-      "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "groq",
-        "lpu",
-        "fast-inference",
-        "llm",
-        "groq-cloud",
-        "low-latency",
-        "ai-acceleration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "guidewire-pack",
-      "source": "./plugins/saas-packs/guidewire-pack",
-      "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
-      "version": "1.25.0",
-      "category": "saas-packs",
-      "keywords": [
-        "guidewire",
-        "insurance",
-        "policycenter",
-        "claimcenter",
-        "billingcenter",
-        "insurancesuite",
-        "enterprise"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -6965,47 +7484,6 @@
       }
     },
     {
-      "name": "ideogram-pack",
-      "source": "./plugins/saas-packs/ideogram-pack",
-      "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
-      "version": "1.10.0",
-      "category": "saas-packs",
-      "keywords": [
-        "ideogram",
-        "image-generation",
-        "text-to-image",
-        "ai-art",
-        "typography",
-        "creative",
-        "design"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "instantly-pack",
-      "source": "./plugins/saas-packs/instantly-pack",
-      "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "instantly",
-        "cold-email",
-        "outreach",
-        "email-automation",
-        "lead-generation",
-        "sales"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "intercom-pack",
       "source": "./plugins/saas-packs/intercom-pack",
       "description": "Claude Code skill pack for Intercom (24 skills)",
@@ -7016,27 +7494,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "juicebox-pack",
-      "source": "./plugins/saas-packs/juicebox-pack",
-      "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
-      "version": "1.16.0",
-      "category": "saas-packs",
-      "keywords": [
-        "juicebox",
-        "people-data",
-        "enrichment",
-        "contacts",
-        "search",
-        "data-api",
-        "lead-enrichment"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7063,113 +7520,6 @@
       }
     },
     {
-      "name": "klingai-pack",
-      "source": "./plugins/saas-packs/klingai-pack",
-      "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "klingai",
-        "kling",
-        "video-generation",
-        "text-to-video",
-        "ai-video",
-        "generative-ai",
-        "creative"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "langchain-py-pack",
-      "source": "./plugins/saas-packs/langchain-py-pack",
-      "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
-      "version": "2.5.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langchain",
-        "langgraph",
-        "python",
-        "llm",
-        "agents",
-        "rag",
-        "checkpointing",
-        "streaming",
-        "middleware",
-        "langsmith"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "langfuse-pack",
-      "source": "./plugins/saas-packs/langfuse-pack",
-      "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "langfuse",
-        "observability",
-        "tracing",
-        "prompts",
-        "evaluation",
-        "llm-ops",
-        "monitoring"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "lindy-pack",
-      "source": "./plugins/saas-packs/lindy-pack",
-      "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
-      "version": "1.15.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lindy",
-        "ai-assistant",
-        "automation",
-        "workflows",
-        "tasks",
-        "intelligent-automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "linear-pack",
-      "source": "./plugins/saas-packs/linear-pack",
-      "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "linear",
-        "issues",
-        "project-management",
-        "tracking",
-        "workflows",
-        "agile",
-        "team-collaboration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "linktree-pack",
       "source": "./plugins/saas-packs/linktree-pack",
       "description": "Claude Code skill pack for Linktree (18 skills)",
@@ -7188,27 +7538,6 @@
       }
     },
     {
-      "name": "lokalise-pack",
-      "source": "./plugins/saas-packs/lokalise-pack",
-      "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "lokalise",
-        "translation",
-        "localization",
-        "i18n",
-        "l10n",
-        "tms",
-        "internationalization"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "lucidchart-pack",
       "source": "./plugins/saas-packs/lucidchart-pack",
       "description": "Claude Code skill pack for Lucidchart (18 skills)",
@@ -7219,27 +7548,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "maintainx-pack",
-      "source": "./plugins/saas-packs/maintainx-pack",
-      "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "maintainx",
-        "cmms",
-        "work-orders",
-        "maintenance",
-        "assets",
-        "facilities",
-        "operations"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7284,27 +7592,6 @@
       }
     },
     {
-      "name": "mistral-pack",
-      "source": "./plugins/saas-packs/mistral-pack",
-      "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "mistral",
-        "llm",
-        "inference",
-        "embeddings",
-        "fine-tuning",
-        "ai",
-        "machine-learning"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "navan-pack",
       "source": "./plugins/saas-packs/navan-pack",
       "description": "Claude Code skill pack for Navan (24 skills)",
@@ -7341,27 +7628,6 @@
       }
     },
     {
-      "name": "obsidian-pack",
-      "source": "./plugins/saas-packs/obsidian-pack",
-      "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "obsidian",
-        "notes",
-        "vault",
-        "plugins",
-        "markdown",
-        "knowledge-management",
-        "pkm"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "onenote-pack",
       "source": "./plugins/saas-packs/onenote-pack",
       "description": "Claude Code skill pack for OneNote (18 skills)",
@@ -7372,47 +7638,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "openevidence-pack",
-      "source": "./plugins/saas-packs/openevidence-pack",
-      "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openevidence",
-        "medical-ai",
-        "clinical",
-        "healthcare",
-        "evidence-based",
-        "decision-support",
-        "medicine"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "openrouter-pack",
-      "source": "./plugins/saas-packs/openrouter-pack",
-      "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-      "version": "1.20.0",
-      "category": "saas-packs",
-      "keywords": [
-        "openrouter",
-        "llm-routing",
-        "model-selection",
-        "ai-gateway",
-        "multi-model",
-        "cost-optimization"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7458,27 +7683,6 @@
       }
     },
     {
-      "name": "perplexity-pack",
-      "source": "./plugins/saas-packs/perplexity-pack",
-      "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "perplexity",
-        "ai-search",
-        "research",
-        "citations",
-        "real-time",
-        "knowledge",
-        "answers"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "persona-pack",
       "source": "./plugins/saas-packs/persona-pack",
       "description": "Claude Code skill pack for Persona (18 skills)",
@@ -7512,26 +7716,6 @@
         "rag",
         "call-transcripts",
         "multi-location"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "posthog-pack",
-      "source": "./plugins/saas-packs/posthog-pack",
-      "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "posthog",
-        "product-analytics",
-        "feature-flags",
-        "session-replay",
-        "ab-testing",
-        "experimentation"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7612,48 +7796,6 @@
       }
     },
     {
-      "name": "replit-pack",
-      "source": "./plugins/saas-packs/replit-pack",
-      "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
-      "version": "1.12.0",
-      "category": "saas-packs",
-      "keywords": [
-        "replit",
-        "cloud-ide",
-        "deployments",
-        "collaborative",
-        "ai-coding",
-        "browser-ide",
-        "hosting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "retellai-pack",
-      "source": "./plugins/saas-packs/retellai-pack",
-      "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
-      "version": "1.9.0",
-      "category": "saas-packs",
-      "keywords": [
-        "retellai",
-        "retell",
-        "voice-ai",
-        "phone-agents",
-        "conversational-ai",
-        "call-center",
-        "ivr"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "runway-pack",
       "source": "./plugins/saas-packs/runway-pack",
       "description": "Claude Code skill pack for Runway (18 skills)",
@@ -7700,27 +7842,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "sentry-pack",
-      "source": "./plugins/saas-packs/sentry-pack",
-      "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
-      "version": "1.51.0",
-      "category": "saas-packs",
-      "keywords": [
-        "sentry",
-        "error-monitoring",
-        "performance",
-        "observability",
-        "debugging",
-        "crash-reporting",
-        "apm"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7785,27 +7906,6 @@
       }
     },
     {
-      "name": "speak-pack",
-      "source": "./plugins/saas-packs/speak-pack",
-      "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
-      "version": "1.14.0",
-      "category": "saas-packs",
-      "keywords": [
-        "speak",
-        "language-learning",
-        "speech",
-        "ai-tutor",
-        "education",
-        "conversation",
-        "edtech"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "stackblitz-pack",
       "source": "./plugins/saas-packs/stackblitz-pack",
       "description": "Claude Code skill pack for StackBlitz (18 skills)",
@@ -7816,32 +7916,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "supabase-pack",
-      "source": "./plugins/saas-packs/supabase-pack",
-      "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.53.0",
-      "category": "saas-packs",
-      "keywords": [
-        "supabase",
-        "postgres",
-        "database",
-        "authentication",
-        "realtime",
-        "storage",
-        "edge-functions",
-        "rls",
-        "row-level-security",
-        "baas",
-        "backend-as-a-service",
-        "firebase-alternative"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -7887,48 +7961,6 @@
       }
     },
     {
-      "name": "twinmind-pack",
-      "source": "./plugins/saas-packs/twinmind-pack",
-      "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
-      "version": "1.13.0",
-      "category": "saas-packs",
-      "keywords": [
-        "twinmind",
-        "meetings",
-        "transcription",
-        "summaries",
-        "ai-assistant",
-        "productivity",
-        "automation"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "vastai-pack",
-      "source": "./plugins/saas-packs/vastai-pack",
-      "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vastai",
-        "vast-ai",
-        "gpu-marketplace",
-        "cloud-gpu",
-        "ml-infrastructure",
-        "compute",
-        "training"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "veeva-pack",
       "source": "./plugins/saas-packs/veeva-pack",
       "description": "Claude Code skill pack for Veeva (24 skills)",
@@ -7947,30 +7979,6 @@
       }
     },
     {
-      "name": "vercel-pack",
-      "source": "./plugins/saas-packs/vercel-pack",
-      "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
-      "version": "1.18.0",
-      "category": "saas-packs",
-      "keywords": [
-        "vercel",
-        "deployment",
-        "edge-functions",
-        "serverless",
-        "preview",
-        "ci-cd",
-        "hosting",
-        "next-js",
-        "jamstack",
-        "frontend-cloud"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
       "name": "webflow-pack",
       "source": "./plugins/saas-packs/webflow-pack",
       "description": "Claude Code skill pack for Webflow (24 skills)",
@@ -7981,27 +7989,6 @@
         "saas",
         "sdk",
         "integration"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io",
-        "url": "https://github.com/jeremylongshore"
-      }
-    },
-    {
-      "name": "windsurf-pack",
-      "source": "./plugins/saas-packs/windsurf-pack",
-      "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
-      "version": "1.11.0",
-      "category": "saas-packs",
-      "keywords": [
-        "windsurf",
-        "ai-editor",
-        "cascade",
-        "codeium",
-        "ai-coding",
-        "code-completion",
-        "refactoring"
       ],
       "author": {
         "name": "Jeremy Longshore",
@@ -8046,19 +8033,1044 @@
       }
     },
     {
-      "name": "access-control-auditor",
-      "source": "./plugins/security/access-control-auditor",
-      "description": "Audit access control implementations",
-      "version": "1.24.0",
-      "category": "security",
+      "name": "pm-ai-partner",
+      "source": "./plugins/productivity/pm-ai-partner",
+      "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
+      "version": "1.8.0",
+      "category": "productivity",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
+        "product-management",
+        "pm",
+        "ai-partner",
+        "skills",
+        "commands",
+        "hooks"
+      ],
+      "author": {
+        "name": "Ahmed Khaled",
+        "email": "ahmd.khaled.a.mohamed@gmail.com"
+      }
+    },
+    {
+      "name": "validate-plugin",
+      "source": "./plugins/skill-enhancers/validate-plugin",
+      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
+      "version": "1.8.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "validation",
+        "plugin-development",
+        "quality-assurance",
+        "linting"
       ],
       "author": {
         "name": "Jeremy Longshore",
-        "email": "[email protected]"
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "zero-tech-debt",
+      "source": "./plugins/skill-enhancers/zero-tech-debt",
+      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+      "version": "1.1.0",
+      "category": "skill-enhancers",
+      "keywords": [
+        "refactoring",
+        "tech-debt",
+        "architecture",
+        "cleanup",
+        "modernization",
+        "code-quality"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "executive-assistant-skills",
+      "source": "./plugins/business-tools/executive-assistant-skills",
+      "version": "1.8.0",
+      "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
+      "author": {
+        "name": "Martin Gontovnikas",
+        "email": "gonto@hypergrowthpartners.com",
+        "url": "https://github.com/mgonto"
+      },
+      "category": "business-tools",
+      "keywords": [
+        "executive-assistant",
+        "meeting-prep",
+        "email",
+        "productivity",
+        "automation",
+        "todoist"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/mgonto/executive-assistant-skills"
+    },
+    {
+      "name": "box-cloud-filesystem",
+      "source": "./plugins/productivity/box-cloud-filesystem",
+      "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "box",
+        "cloud-storage",
+        "filesystem",
+        "file-sync",
+        "box-cli",
+        "upload",
+        "download",
+        "document-management",
+        "collaboration",
+        "ai-agent-storage"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/box-cloud-filesystem",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT"
+    },
+    {
+      "name": "pr-to-spec",
+      "source": "./plugins/mcp/pr-to-spec",
+      "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+      "version": "0.8.0",
+      "category": "mcp",
+      "repository": "https://github.com/jeremylongshore/pr-to-prompt",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "license": "MIT",
+      "keywords": [
+        "mcp",
+        "pr-analysis",
+        "intent-drift",
+        "code-review",
+        "agent-protocol"
+      ]
+    },
+    {
+      "name": "slack-channel",
+      "source": "./plugins/mcp/slack-channel",
+      "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "slack",
+        "channel",
+        "mcp",
+        "socket-mode",
+        "chatops",
+        "claude-code"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "repository": "https://github.com/jeremylongshore/claude-code-slack-channel",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT"
+    },
+    {
+      "name": "x-bug-triage-plugin",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "keywords": [
+        "bug-triage",
+        "x-twitter",
+        "slack",
+        "devops",
+        "mcp"
+      ],
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "homepage": "https://tonsofskills.com",
+      "license": "MIT"
+    },
+    {
+      "name": "framecraft",
+      "source": "./plugins/community/framecraft",
+      "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
+      "version": "1.3.0",
+      "category": "community",
+      "keywords": [
+        "demo-video",
+        "video-generation",
+        "playwright",
+        "ffmpeg",
+        "edge-tts",
+        "mcp"
+      ],
+      "author": {
+        "name": "vaddisrinivas",
+        "url": "https://github.com/vaddisrinivas"
+      }
+    },
+    {
+      "name": "tweetclaw",
+      "source": "./plugins/devops/tweetclaw",
+      "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
+      "version": "1.5.3",
+      "category": "devops",
+      "keywords": [
+        "twitter",
+        "x",
+        "automation",
+        "social-media",
+        "tweets",
+        "monitoring",
+        "giveaway",
+        "scraping"
+      ],
+      "author": {
+        "name": "Burak Bayir",
+        "email": "burak@xquik.com",
+        "url": "https://xquik.com"
+      },
+      "repository": "https://github.com/Xquik-dev/tweetclaw",
+      "homepage": "https://xquik.com",
+      "license": "MIT"
+    },
+    {
+      "name": "shipwright",
+      "source": "./plugins/ai-agency/shipwright",
+      "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+      "version": "1.3.0",
+      "category": "ai-agency",
+      "author": {
+        "name": "Nate Nelson",
+        "url": "https://github.com/Wynelson94"
+      },
+      "keywords": [
+        "app-builder",
+        "code-generator",
+        "autonomous-agent",
+        "pipeline",
+        "nextjs",
+        "supabase",
+        "sveltekit",
+        "astro",
+        "ai-agency"
+      ],
+      "repository": "https://github.com/Wynelson94/shipwright",
+      "homepage": "https://github.com/Wynelson94/shipwright",
+      "license": "MIT"
+    },
+    {
+      "name": "hyperfocus",
+      "source": "./plugins/productivity/hyperfocus",
+      "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
+      "version": "0.2.0",
+      "category": "productivity",
+      "author": {
+        "name": "Nestor Magalhaes",
+        "email": "nestor.magalhaes@appex.world"
+      },
+      "keywords": [
+        "accessibility",
+        "adhd",
+        "neurodivergent",
+        "formatting",
+        "readability",
+        "productivity",
+        "cognitive-accessibility"
+      ],
+      "repository": "https://github.com/nextor2k/hyperfocus",
+      "homepage": "https://github.com/nextor2k/hyperfocus",
+      "license": "MIT"
+    },
+    {
+      "name": "plane",
+      "source": "./plugins/productivity/plane",
+      "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+      "version": "0.3.0",
+      "category": "productivity",
+      "keywords": [
+        "plane",
+        "project-management",
+        "team-behavior",
+        "observability",
+        "productivity",
+        "agent-skills",
+        "forge-generated"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "local-tts",
+      "source": "./plugins/ai-ml/local-tts",
+      "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+      "version": "1.3.0",
+      "category": "ai-ml",
+      "keywords": [
+        "tts",
+        "text-to-speech",
+        "voice",
+        "voice-cloning",
+        "voice-design",
+        "offline",
+        "voxcpm",
+        "apple-silicon",
+        "audio",
+        "narration"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "Apache-2.0",
+      "repository": "https://github.com/vdk888/local-tts"
+    },
+    {
+      "name": "boycott-filter",
+      "source": "./plugins/community/boycott-filter",
+      "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
+      "version": "1.2.0",
+      "category": "community",
+      "keywords": [
+        "boycott",
+        "consumer",
+        "shopping",
+        "brands",
+        "chrome-extension",
+        "conversational",
+        "privacy",
+        "ethical-consumption"
+      ],
+      "author": {
+        "name": "Bubble Invest",
+        "email": "contact@bubbleinvest.com"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/vdk888/boycott-filter"
+    },
+    {
+      "name": "web-analytics",
+      "source": "./plugins/analytics/web-analytics",
+      "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
+      "version": "1.4.0",
+      "category": "analytics",
+      "keywords": [
+        "analytics",
+        "umami",
+        "ga4",
+        "traffic",
+        "mcp",
+        "self-hosted",
+        "multi-agent",
+        "push-based"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io",
+        "url": "https://github.com/jeremylongshore"
+      }
+    },
+    {
+      "name": "aomi",
+      "source": "./plugins/crypto/aomi",
+      "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
+      "version": "0.10.0",
+      "category": "crypto",
+      "keywords": [
+        "crypto",
+        "defi",
+        "web3",
+        "evm",
+        "ethereum",
+        "wallet",
+        "account-abstraction",
+        "trading",
+        "agent",
+        "mcp"
+      ],
+      "author": {
+        "name": "aomi-labs",
+        "url": "https://aomi.dev",
+        "email": "info@aomi.dev"
+      }
+    },
+    {
+      "name": "cli-power-skills",
+      "source": "./plugins/productivity/cli-power-skills",
+      "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "cli-tools",
+        "agentic-skills",
+        "data-processing",
+        "security",
+        "web-crawling",
+        "python",
+        "ci-cd"
+      ],
+      "author": {
+        "name": "Yuriy Kotik",
+        "url": "https://github.com/ykotik"
+      },
+      "repository": "https://github.com/ykotik/cli-power-skills",
+      "license": "MIT"
+    },
+    {
+      "name": "claude-workflow-skills",
+      "source": "./plugins/productivity/claude-workflow-skills",
+      "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
+      "version": "1.7.1",
+      "category": "productivity",
+      "keywords": [
+        "workflow",
+        "promote",
+        "release",
+        "audit",
+        "standards",
+        "improve",
+        "triage",
+        "git",
+        "review",
+        "pull-request"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-workflow-skills",
+      "repository": "https://github.com/ali5ter/claude-workflow-skills",
+      "license": "MIT"
+    },
+    {
+      "name": "cli-ux-tester",
+      "source": "./plugins/testing/cli-ux-tester",
+      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
+      "version": "3.1.0",
+      "category": "testing",
+      "keywords": [
+        "CLI",
+        "UX",
+        "testing",
+        "developer-experience",
+        "terminal",
+        "usability"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "license": "MIT"
+    },
+    {
+      "name": "skyvern",
+      "source": "./plugins/productivity/skyvern",
+      "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
+      "version": "0.1.0",
+      "category": "productivity",
+      "author": {
+        "name": "Skyvern-AI",
+        "url": "https://github.com/Skyvern-AI"
+      },
+      "license": "AGPL-3.0"
+    },
+    {
+      "name": "tonone",
+      "source": "./plugins/ai-agency/tonone",
+      "description": "23-agent engineering + product team with 125 skills for Claude Code",
+      "version": "1.8.0",
+      "category": "ai-agency",
+      "keywords": [
+        "agents",
+        "engineering-team",
+        "infrastructure",
+        "devops",
+        "backend",
+        "security",
+        "observability",
+        "frontend",
+        "ml",
+        "mobile",
+        "embedded",
+        "analytics",
+        "testing",
+        "platform",
+        "sales",
+        "revenue",
+        "customer-success",
+        "content-marketing",
+        "pr",
+        "community",
+        "finance",
+        "people",
+        "operations",
+        "support"
+      ],
+      "author": {
+        "name": "tonone-ai",
+        "url": "https://tonone.ai"
+      },
+      "repository": "https://github.com/tonone-ai/tonone",
+      "license": "MIT"
+    },
+    {
+      "name": "x-bug-triage",
+      "source": "./plugins/mcp/x-bug-triage",
+      "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+      "version": "0.3.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "triage",
+        "x-api",
+        "bug-tracking",
+        "clustering"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "repository": "https://github.com/jeremylongshore/x-bug-triage-plugin",
+      "license": "MIT"
+    },
+    {
+      "name": "hyperflow",
+      "source": "./plugins/ai-agency/hyperflow",
+      "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
+      "version": "4.26.1",
+      "category": "ai-agency",
+      "keywords": [
+        "claude-code-plugin",
+        "multi-agent",
+        "dynamic-workflows",
+        "workflow-chain",
+        "triageflow",
+        "personas",
+        "flow-profiles",
+        "code-review",
+        "project-memory",
+        "multi-tool"
+      ],
+      "author": {
+        "name": "Mohammed Abdelhady",
+        "url": "https://github.com/Mohammed-Abdelhady"
+      },
+      "homepage": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "repository": "https://github.com/Mohammed-Abdelhady/hyperflow",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-anti-deception",
+      "source": "./plugins/community/ejentum-anti-deception",
+      "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-code",
+      "source": "./plugins/community/ejentum-code",
+      "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-memory",
+      "source": "./plugins/community/ejentum-memory",
+      "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "ejentum-reasoning",
+      "source": "./plugins/community/ejentum-reasoning",
+      "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+      "version": "0.1.0",
+      "category": "community",
+      "author": {
+        "name": "Ejentum",
+        "url": "https://github.com/ejentum",
+        "email": "info@ejentum.com"
+      },
+      "license": "MIT"
+    },
+    {
+      "name": "over-50s-health",
+      "source": "./plugins/productivity/over-50s-health",
+      "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
+      "version": "3.3.0",
+      "category": "productivity",
+      "keywords": [
+        "health",
+        "fitness",
+        "nutrition",
+        "longevity",
+        "50+"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/over-50s-health-advisor",
+      "repository": "https://github.com/ali5ter/over-50s-health-advisor",
+      "license": "MIT"
+    },
+    {
+      "name": "obsidian-project-documentation",
+      "source": "./plugins/productivity/obsidian-project-documentation",
+      "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
+      "version": "3.2.5",
+      "category": "productivity",
+      "keywords": [
+        "obsidian",
+        "documentation",
+        "notes",
+        "projects"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/obsidian-project-assistant",
+      "repository": "https://github.com/ali5ter/obsidian-project-assistant",
+      "license": "MIT"
+    },
+    {
+      "name": "pair-programmer",
+      "source": "./plugins/productivity/pair-programmer",
+      "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "pair-programming",
+        "coding",
+        "skill-development",
+        "graduated-assistance"
+      ],
+      "author": {
+        "name": "Alister Lewis-Bowen",
+        "url": "https://github.com/ali5ter"
+      },
+      "homepage": "https://github.com/ali5ter/pair-programmer",
+      "repository": "https://github.com/ali5ter/pair-programmer",
+      "license": "MIT"
+    },
+    {
+      "name": "governed-second-brain",
+      "source": "./plugins/mcp/governed-second-brain",
+      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
+      "version": "1.1.2",
+      "category": "mcp",
+      "keywords": [
+        "memory",
+        "knowledge",
+        "governance",
+        "qmd",
+        "brain",
+        "citations",
+        "local-first",
+        "second-brain"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "databricks-workspace-mcp",
+      "source": "./plugins/mcp/databricks-workspace-mcp",
+      "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "mcp",
+        "model-context-protocol",
+        "databricks",
+        "lakehouse",
+        "unity-catalog",
+        "clusters",
+        "dlt",
+        "finops"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://tonsofskills.com/learn/databricks/",
+      "repository": "https://github.com/jeremylongshore/claude-code-plugins",
+      "license": "MIT"
+    },
+    {
+      "name": "beads-dolt",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "beads",
+        "bd",
+        "dolt",
+        "dolthub",
+        "task-tracking",
+        "mcp",
+        "version-control",
+        "sql"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "publishing-skills",
+      "source": "./plugins/productivity/publishing-skills",
+      "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "ghost",
+        "blogging",
+        "seo",
+        "content-creation",
+        "publishing",
+        "claude-code",
+        "ai-writing"
+      ],
+      "author": {
+        "name": "AutomateLab",
+        "url": "https://github.com/AutomateLab-tech",
+        "email": "hello@automatelab.tech"
+      },
+      "repository": "https://github.com/AutomateLab-tech/publishing-skills",
+      "license": "MIT-0"
+    },
+    {
+      "name": "dolt-mcp-vcs",
+      "source": "./plugins/mcp/dolt-mcp-vcs",
+      "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
+      "version": "0.1.0",
+      "category": "mcp",
+      "keywords": [
+        "dolt-mcp-vcs",
+        "dolt",
+        "dolthub",
+        "dolt-mcp",
+        "version-control",
+        "vcs",
+        "mcp",
+        "sql",
+        "beads",
+        "bd"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "url": "https://github.com/jeremylongshore",
+        "email": "jeremy@intentsolutions.io"
+      },
+      "homepage": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "repository": "https://github.com/jeremylongshore/dolt-mcp-vcs",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./plugins/community/hermes-tweet",
+      "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
+      "version": "0.1.6",
+      "category": "community",
+      "keywords": [
+        "hermes-agent",
+        "hermes-plugin",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
+      ],
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "homepage": "https://github.com/Xquik-dev/hermes-tweet#readme",
+      "repository": "https://github.com/Xquik-dev/hermes-tweet",
+      "license": "MIT"
+    },
+    {
+      "name": "x-twitter-scraper",
+      "source": "./plugins/api-development/x-twitter-scraper",
+      "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
+      "version": "0.1.0",
+      "category": "api-development",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
+      "license": "MIT"
+    },
+    {
+      "name": "servicegraph",
+      "source": "./plugins/mcp/servicegraph",
+      "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
+      "version": "0.2.0",
+      "category": "mcp",
+      "keywords": [
+        "servicegraph",
+        "service-providers",
+        "agencies",
+        "law-firms",
+        "consulting",
+        "accounting",
+        "marketing",
+        "lead-generation",
+        "professional-services",
+        "us-firms",
+        "product-directories",
+        "saas-directories",
+        "mcp-directories",
+        "ai-directories",
+        "product-launch",
+        "backlinks"
+      ],
+      "author": {
+        "name": "Artur Briugeman",
+        "url": "https://servicegraph.co",
+        "email": "artur@nostr.band"
+      },
+      "homepage": "https://servicegraph.co",
+      "repository": "https://github.com/nostrband/servicegraph",
+      "license": "MIT"
+    },
+    {
+      "name": "schedule-after-usage-reset",
+      "source": "./plugins/productivity/schedule-after-usage-reset",
+      "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "schedule",
+        "usage-reset",
+        "rate-limit",
+        "claude-code",
+        "automation"
+      ],
+      "author": {
+        "name": "patricksong1993",
+        "url": "https://github.com/patricksong1993"
+      },
+      "homepage": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "repository": "https://github.com/patricksong1993/schedule-after-usage-reset",
+      "license": "MIT"
+    },
+    {
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
+      ],
+      "author": {
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
+      },
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
+      "license": "MIT"
+    },
+    {
+      "name": "mnemos",
+      "source": "./plugins/community/mnemos",
+      "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
+      "version": "0.9.0",
+      "category": "community",
+      "keywords": [
+        "memory",
+        "mcp",
+        "claude-code",
+        "persistent-memory",
+        "agent-memory",
+        "knowledge-graph",
+        "context",
+        "skill",
+        "observations",
+        "provenance",
+        "learning-loop",
+        "golang"
+      ],
+      "author": {
+        "name": "André Figueira",
+        "url": "https://polyxmedia.com",
+        "email": "andre@polyxmedia.com"
+      },
+      "homepage": "https://github.com/polyxmedia/mnemos",
+      "repository": "https://github.com/polyxmedia/mnemos",
+      "license": "MIT"
+    },
+    {
+      "name": "portaljs",
+      "source": "./plugins/community/portaljs",
+      "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
+      "version": "0.1.0",
+      "category": "community",
+      "keywords": [
+        "portaljs",
+        "data-portal",
+        "ckan",
+        "nextjs",
+        "data-catalog"
+      ],
+      "author": {
+        "name": "Datopian",
+        "url": "https://www.datopian.com"
+      },
+      "homepage": "https://github.com/datopian/portaljs",
+      "repository": "https://github.com/datopian/portaljs",
+      "license": "MIT"
+    },
+    {
+      "name": "llm-box",
+      "source": "./plugins/community/llm-box",
+      "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
+      "version": "0.3.0",
+      "category": "community",
+      "keywords": [
+        "workflow",
+        "automation",
+        "terminal",
+        "cli",
+        "yaml",
+        "llm",
+        "mcp"
+      ],
+      "author": {
+        "name": "alib8b8",
+        "url": "https://github.com/alib8b8"
+      },
+      "homepage": "https://github.com/alib8b8/llm-box",
+      "repository": "https://github.com/alib8b8/llm-box",
+      "license": "MIT"
+    },
+    {
+      "name": "j-rig",
+      "source": "./plugins/productivity/j-rig",
+      "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "skill-refiner",
+        "eval-guided",
+        "skill-md",
+        "meta-tooling",
+        "hooks"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      }
+    },
+    {
+      "name": "intent-labs-pack",
+      "source": "./plugins/productivity/intent-labs-pack",
+      "description": "Labs skills for Intent Eval Platform dogfood: audit-tests (7-layer test auditor) and validate-skillmd (four-tier SKILL.md grader). Public checkout path for the nightly signed roster.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "keywords": [
+        "audit-tests",
+        "validate-skillmd",
+        "testing",
+        "skill-validation",
+        "intent-eval",
+        "dogfood"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
       }
     },
     {
@@ -8086,1131 +9098,119 @@
       "license": "MIT"
     },
     {
-      "name": "authentication-validator",
-      "source": "./plugins/security/authentication-validator",
-      "description": "Validate authentication implementations",
-      "version": "1.26.0",
-      "category": "security",
+      "name": "claudebase",
+      "source": "./plugins/productivity/claudebase",
+      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+      "version": "0.2.0",
+      "category": "productivity",
       "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "compliance-report-generator",
-      "source": "./plugins/security/compliance-report-generator",
-      "description": "Generate compliance reports",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cors-policy-validator",
-      "source": "./plugins/security/cors-policy-validator",
-      "description": "Validate CORS policies",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "csrf-protection-validator",
-      "source": "./plugins/security/csrf-protection-validator",
-      "description": "Validate CSRF protection",
-      "version": "1.26.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "data-privacy-scanner",
-      "source": "./plugins/security/data-privacy-scanner",
-      "description": "Scan for data privacy issues",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "dependency-checker",
-      "source": "./plugins/security/dependency-checker",
-      "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "dependencies",
-        "npm",
-        "pip",
-        "composer",
-        "vulnerabilities"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "encryption-tool",
-      "source": "./plugins/security/encryption-tool",
-      "description": "Encrypt and decrypt data with various algorithms",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "gdpr-compliance-scanner",
-      "source": "./plugins/security/gdpr-compliance-scanner",
-      "description": "Scan for GDPR compliance issues",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "hipaa-compliance-checker",
-      "source": "./plugins/security/hipaa-compliance-checker",
-      "description": "Check HIPAA compliance",
-      "version": "1.23.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "input-validation-scanner",
-      "source": "./plugins/security/input-validation-scanner",
-      "description": "Scan input validation practices",
-      "version": "1.25.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "owasp-compliance-checker",
-      "source": "./plugins/security/owasp-compliance-checker",
-      "description": "Check OWASP Top 10 compliance",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "pci-dss-validator",
-      "source": "./plugins/security/pci-dss-validator",
-      "description": "Validate PCI DSS compliance",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "penetration-tester",
-      "source": "./plugins/security/penetration-tester",
-      "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
-      "version": "3.30.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "penetration-testing",
-        "pentesting",
-        "owasp",
-        "owasp-top-10",
-        "vulnerability-scanning",
-        "dependency-audit",
-        "license-compliance",
-        "engagement-governance",
-        "chain-of-custody"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "secret-scanner",
-      "source": "./plugins/security/secret-scanner",
-      "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "secrets",
-        "api-keys",
-        "credentials",
-        "passwords"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-audit-reporter",
-      "source": "./plugins/security/security-audit-reporter",
-      "description": "Generate comprehensive security audit reports",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-headers-analyzer",
-      "source": "./plugins/security/security-headers-analyzer",
-      "description": "Analyze HTTP security headers",
-      "version": "1.28.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-incident-responder",
-      "source": "./plugins/security/security-incident-responder",
-      "description": "Assist with security incident response",
-      "version": "1.32.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-misconfiguration-finder",
-      "source": "./plugins/security/security-misconfiguration-finder",
-      "description": "Find security misconfigurations",
-      "version": "1.29.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "session-security-checker",
-      "source": "./plugins/security/session-security-checker",
-      "description": "Check session security implementation",
-      "version": "1.27.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "severity1-marketplace",
-      "source": "./plugins/security/severity1-marketplace",
-      "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
-      "version": "1.6.0",
-      "category": "security",
-      "keywords": [
-        "severity",
-        "classification",
-        "prompt-improvement",
-        "marketplace",
-        "security",
-        "quality",
-        "triage",
-        "agent-skills"
-      ],
-      "author": {
-        "name": "severity1",
-        "email": "severity1@intentsolutions.io"
-      }
-    },
-    {
-      "name": "soc2-audit-helper",
-      "source": "./plugins/security/soc2-audit-helper",
-      "description": "Assist with SOC2 audit preparation",
-      "version": "1.30.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "sql-injection-detector",
-      "source": "./plugins/security/sql-injection-detector",
-      "description": "Detect SQL injection vulnerabilities",
-      "version": "1.31.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "ssl-certificate-manager",
-      "source": "./plugins/security/ssl-certificate-manager",
-      "description": "Manage and monitor SSL/TLS certificates",
-      "version": "1.21.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "vulnerability-scanner",
-      "source": "./plugins/security/vulnerability-scanner",
-      "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "vulnerability",
-        "scanning",
-        "cve",
-        "sast"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "xss-vulnerability-scanner",
-      "source": "./plugins/security/xss-vulnerability-scanner",
-      "description": "Scan for XSS vulnerabilities",
-      "version": "1.24.0",
-      "category": "security",
-      "keywords": [
-        "security",
-        "compliance",
-        "auditing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "axiom",
-      "source": "./plugins/skill-enhancers/axiom",
-      "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
-      "version": "0.3.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "ios",
-        "debugging",
-        "swift",
-        "persistence",
-        "testing",
-        "performance",
-        "xcode",
-        "concurrency",
-        "database",
-        "swiftdata",
-        "grdb",
-        "liquid-glass",
-        "swiftui"
-      ],
-      "author": {
-        "name": "Charles Wiltgen",
-        "url": "https://github.com/CharlesWiltgen"
-      }
-    },
-    {
-      "name": "calendar-to-workflow",
-      "source": "./plugins/skill-enhancers/calendar-to-workflow",
-      "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "calendar",
-        "automation",
-        "meetings",
-        "productivity"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "file-to-code",
-      "source": "./plugins/skill-enhancers/file-to-code",
-      "description": "Converts file references into executable code implementations",
-      "version": "0.16.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "files",
-        "automation",
-        "code-generation"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "research-to-deploy",
-      "source": "./plugins/skill-enhancers/research-to-deploy",
-      "description": "Transforms research findings into deployed solutions automatically",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "research",
-        "automation",
-        "deployment"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "search-to-slack",
-      "source": "./plugins/skill-enhancers/search-to-slack",
-      "description": "Automatically posts search results to Slack channels",
-      "version": "0.14.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "search",
-        "slack",
-        "automation",
-        "integration"
-      ],
-      "author": {
-        "name": "Claude Code Plugins Team"
-      }
-    },
-    {
-      "name": "skill-creator",
-      "source": "./plugins/skill-enhancers/skill-creator",
-      "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.20.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "skill-creation",
-        "validation",
-        "meta-tooling",
-        "grading",
-        "anthropic-spec"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "validate-plugin",
-      "source": "./plugins/skill-enhancers/validate-plugin",
-      "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
-      "version": "1.8.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "validation",
-        "plugin-development",
-        "quality-assurance",
-        "linting"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "web-to-github-issue",
-      "source": "./plugins/skill-enhancers/web-to-github-issue",
-      "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
-      "version": "1.27.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "web-search",
         "github",
-        "automation",
-        "research",
-        "issue-tracking",
-        "skill-enhancer",
-        "productivity",
-        "workflow"
+        "sync",
+        "backup",
+        "config",
+        "profiles",
+        "settings"
       ],
       "author": {
-        "name": "Claude Code Plugins Team",
-        "email": "[email protected]"
+        "name": "Rohit Hazra",
+        "url": "https://github.com/rohithzr"
       },
-      "repository": "https://github.com/jeremylongshore/claude-code-plugins"
-    },
-    {
-      "name": "zero-tech-debt",
-      "source": "./plugins/skill-enhancers/zero-tech-debt",
-      "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
-      "version": "1.1.0",
-      "category": "skill-enhancers",
-      "keywords": [
-        "refactoring",
-        "tech-debt",
-        "architecture",
-        "cleanup",
-        "modernization",
-        "code-quality"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
-    },
-    {
-      "name": "accessibility-test-scanner",
-      "source": "./plugins/testing/accessibility-test-scanner",
-      "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "accessibility",
-        "a11y",
-        "wcag",
-        "aria",
-        "screen-reader",
-        "compliance"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "api-fuzzer",
-      "source": "./plugins/testing/api-fuzzer",
-      "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "fuzzing",
-        "api",
-        "security",
-        "edge-cases",
-        "input-validation"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "api-test-automation",
-      "source": "./plugins/testing/api-test-automation",
-      "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "api",
-        "rest",
-        "graphql",
-        "automation",
-        "endpoints"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "browser-compatibility-tester",
-      "source": "./plugins/testing/browser-compatibility-tester",
-      "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-      "version": "2.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "cross-browser",
-        "browserstack",
-        "selenium",
-        "playwright",
-        "compatibility"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "chaos-engineering-toolkit",
-      "source": "./plugins/testing/chaos-engineering-toolkit",
-      "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "chaos-engineering",
-        "resilience",
-        "failure-injection",
-        "fault-tolerance",
-        "reliability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "cli-ux-tester",
-      "source": "./plugins/testing/cli-ux-tester",
-      "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
-      "version": "3.1.0",
-      "category": "testing",
-      "keywords": [
-        "CLI",
-        "UX",
-        "testing",
-        "developer-experience",
-        "terminal",
-        "usability"
-      ],
-      "author": {
-        "name": "Alister Lewis-Bowen",
-        "url": "https://github.com/ali5ter"
-      },
-      "homepage": "https://github.com/ali5ter/claude-cli-ux-skill",
-      "repository": "https://github.com/ali5ter/claude-cli-ux-skill",
+      "homepage": "https://github.com/rohithzr/claudebase",
+      "repository": "https://github.com/rohithzr/claudebase",
       "license": "MIT"
     },
     {
-      "name": "code-cleanup",
-      "source": "./plugins/testing/code-cleanup",
-      "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
-      "version": "1.7.0",
-      "category": "testing",
+      "name": "skills-janitor",
+      "source": "./plugins/community/skills-janitor",
+      "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
+      "version": "0.1.0",
+      "category": "community",
       "keywords": [
-        "code-quality",
+        "skills",
         "cleanup",
-        "refactoring",
-        "dead-code",
-        "deduplication",
-        "type-safety",
-        "security",
-        "performance",
-        "async",
-        "tech-debt",
-        "code-review"
+        "context-window",
+        "token-budget",
+        "maintenance",
+        "tui"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "jeremy@intentsolutions.io"
-      }
+        "name": "Krzysztof Hendzel",
+        "url": "https://github.com/khendzel",
+        "email": "krzysztoff.hendzel@gmail.com"
+      },
+      "repository": "https://github.com/khendzel/skills-janitor",
+      "license": "MIT"
     },
     {
-      "name": "contract-test-validator",
-      "source": "./plugins/testing/contract-test-validator",
-      "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "contract-testing",
-        "pact",
-        "openapi",
-        "api",
-        "microservices",
-        "consumer-driven"
-      ],
+      "name": "walkie-talkie",
+      "source": "./plugins/community/walkie-talkie",
+      "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
+      "version": "0.1.0",
+      "category": "community",
       "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
+        "name": "Walkie-Talkie Maintainers",
+        "url": "https://github.com/walkie-talkie-skill"
+      },
+      "repository": "https://github.com/walkie-talkie-skill/walkie-talkie",
+      "license": "MIT"
     },
     {
-      "name": "database-test-manager",
-      "source": "./plugins/testing/database-test-manager",
-      "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
-      "version": "1.26.0",
-      "category": "testing",
+      "name": "brand-forge",
+      "source": "./plugins/design/brand-forge",
+      "description": "Generate on-brand logos, social templates, and marketing graphics from a saved brand profile; vector output runs locally, AI imagery is opt-in.",
+      "version": "0.5.1",
+      "category": "design",
       "keywords": [
-        "testing",
-        "database",
-        "sql",
-        "test-data",
-        "fixtures",
-        "migrations",
-        "transactions"
+        "branding",
+        "logo",
+        "brand-identity",
+        "design",
+        "svg",
+        "templates",
+        "image-generation"
       ],
       "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
+      },
+      "homepage": "https://github.com/localplugins/plugins/tree/main/brand-forge",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
     },
     {
-      "name": "e2e-test-framework",
-      "source": "./plugins/testing/e2e-test-framework",
-      "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
-      "version": "1.21.0",
-      "category": "testing",
+      "name": "content-multiplier",
+      "source": "./plugins/productivity/content-multiplier",
+      "description": "Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.",
+      "version": "0.2.1",
+      "category": "productivity",
       "keywords": [
-        "testing",
-        "e2e",
-        "playwright",
-        "cypress",
-        "selenium",
-        "browser-testing"
+        "marketing",
+        "content",
+        "repurposing",
+        "brand-voice",
+        "localization",
+        "social-media"
       ],
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
+        "name": "localplugins",
+        "email": "localplugins@proton.me"
+      },
+      "homepage": "https://github.com/localplugins/plugins/tree/main/content-multiplier",
+      "repository": "https://github.com/localplugins/plugins",
+      "license": "MIT"
     },
     {
-      "name": "integration-test-runner",
-      "source": "./plugins/testing/integration-test-runner",
-      "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "integration-tests",
-        "test-runner",
-        "e2e",
-        "api-testing"
-      ],
+      "name": "quit-sponsor",
+      "source": "./plugins/community/quit-sponsor",
+      "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
+      "version": "0.1.0",
+      "category": "community",
       "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "kobiton-automate",
-      "source": "./plugins/testing/kobiton-automate",
-      "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
-      "version": "1.0.2",
-      "category": "testing",
-      "keywords": [
-        "mobile",
-        "testing",
-        "appium",
-        "automation",
-        "devices",
-        "ios",
-        "android",
-        "real-device",
-        "mcp",
-        "kobiton"
-      ],
-      "author": {
-        "name": "Kobiton Inc.",
-        "url": "https://github.com/kobiton"
-      }
-    },
-    {
-      "name": "load-balancer-tester",
-      "source": "./plugins/testing/load-balancer-tester",
-      "description": "Test load balancing strategies with traffic distribution validation and failover testing",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "load-balancer",
-        "traffic-distribution",
-        "failover",
-        "high-availability"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "mobile-app-tester",
-      "source": "./plugins/testing/mobile-app-tester",
-      "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mobile",
-        "appium",
-        "detox",
-        "xcuitest",
-        "espresso",
-        "ios",
-        "android"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "mutation-test-runner",
-      "source": "./plugins/testing/mutation-test-runner",
-      "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
-      "version": "1.27.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mutation-testing",
-        "test-quality",
-        "stryker",
-        "pitest"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "performance-test-suite",
-      "source": "./plugins/testing/performance-test-suite",
-      "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
-      "version": "1.30.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "performance",
-        "load-testing",
-        "benchmarking",
-        "stress-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "regression-test-tracker",
-      "source": "./plugins/testing/regression-test-tracker",
-      "description": "Track and run regression tests to ensure new changes don't break existing functionality",
-      "version": "1.26.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "regression-testing",
-        "test-tracking",
-        "ci-cd",
-        "quality-assurance"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "security-test-scanner",
-      "source": "./plugins/testing/security-test-scanner",
-      "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
-      "version": "1.29.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "security",
-        "vulnerabilities",
-        "owasp",
-        "penetration-testing"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "smoke-test-runner",
-      "source": "./plugins/testing/smoke-test-runner",
-      "description": "Quick smoke test suites to verify critical functionality after deployments",
-      "version": "1.20.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "smoke-tests",
-        "deployment",
-        "sanity-check",
-        "critical-path"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "snapshot-test-manager",
-      "source": "./plugins/testing/snapshot-test-manager",
-      "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "snapshot",
-        "jest",
-        "vitest",
-        "diff-analysis",
-        "test-management"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-coverage-analyzer",
-      "source": "./plugins/testing/test-coverage-analyzer",
-      "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "coverage",
-        "code-coverage",
-        "metrics",
-        "analysis"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-data-generator",
-      "source": "./plugins/testing/test-data-generator",
-      "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
-      "version": "1.24.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "test-data",
-        "fake-data",
-        "fixtures",
-        "factory"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-doubles-generator",
-      "source": "./plugins/testing/test-doubles-generator",
-      "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
-      "version": "1.22.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "mocks",
-        "stubs",
-        "spies",
-        "fakes",
-        "test-doubles",
-        "jest",
-        "sinon"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-environment-manager",
-      "source": "./plugins/testing/test-environment-manager",
-      "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "environment",
-        "docker",
-        "testcontainers",
-        "isolation",
-        "infrastructure"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-orchestrator",
-      "source": "./plugins/testing/test-orchestrator",
-      "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "orchestration",
-        "workflow",
-        "parallel",
-        "test-selection",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "test-report-generator",
-      "source": "./plugins/testing/test-report-generator",
-      "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
-      "version": "1.23.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "reporting",
-        "coverage",
-        "metrics",
-        "dashboard",
-        "ci-cd"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "unit-test-generator",
-      "source": "./plugins/testing/unit-test-generator",
-      "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
-      "version": "1.21.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "unit-tests",
-        "test-generation",
-        "jest",
-        "pytest",
-        "mocha",
-        "junit"
-      ],
-      "author": {
-        "name": "Jeremy Longshore",
-        "email": "[email protected]"
-      }
-    },
-    {
-      "name": "visual-regression-tester",
-      "source": "./plugins/testing/visual-regression-tester",
-      "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
-      "version": "1.25.0",
-      "category": "testing",
-      "keywords": [
-        "testing",
-        "visual-regression",
-        "ui-testing",
-        "percy",
-        "chromatic",
-        "backstop",
-        "screenshot-testing"
-      ],
-      "author": {
-        "name": "Claude Code Plugin Hub",
-        "email": "[email protected]"
-      }
+        "name": "metr0x",
+        "url": "https://github.com/metrox-eth"
+      },
+      "repository": "https://github.com/metrox-eth/quit-sponsor",
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![Release](https://img.shields.io/badge/release-v4.33.0-green)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/releases/tag/v4.33.0)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
-[![Plugins](https://img.shields.io/badge/plugins-471-blue)](https://tonsofskills.com/explore)
+[![Plugins](https://img.shields.io/badge/plugins-472-blue)](https://tonsofskills.com/explore)
 [![Skills](https://img.shields.io/badge/skills-3179-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
 [![skills.sh](https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills)](https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 
-471 plugins, 3,179 skills, 347 agents, 30 community contributors — validated and ready to install.
+472 plugins, 3,179 skills, 347 agents, 30 community contributors — validated and ready to install.
 
 ## Why this repo
 
@@ -131,7 +131,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | 🎨  | [Design](#design)                                  |       8 |
 | 🔧  | [DevOps & Infrastructure](#devops--infrastructure) |      36 |
 | 📚  | [Examples & Templates](#examples--templates)       |       5 |
-| 🧩  | [MCP Servers](#mcp-servers)                        |      16 |
+| 🧩  | [MCP Servers](#mcp-servers)                        |      17 |
 | 📦  | [Packages](#packages)                              |       5 |
 | ⚡  | [Performance](#performance)                        |      25 |
 | ✅  | [Productivity](#productivity)                      |      34 |
@@ -453,10 +453,11 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 
 ### MCP Servers
 
-🧩 **16 plugins** · category slug: `mcp`
+🧩 **17 plugins** · category slug: `mcp`
 
 | Plugin                        | Description                                                                                                                                 |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a2a-client`                  | Agent2Agent (A2A) client as an MCP server - fetch and audit agent cards, send and stream messages, and control tasks against any…           |
 | `ai-experiment-logger`        | Track and analyze AI experiments with a web dashboard and MCP tools                                                                         |
 | `beads-dolt`                  | ⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead.… |
 | `conversational-api-debugger` | Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation                                  |
@@ -1076,7 +1077,7 @@ The [GitHub wiki](https://github.com/jeremylongshore/claude-code-plugins-plus-sk
 
 ## FAQ
 
-**What is this?** A Claude Code plugin marketplace: 471 plugins, 3,179 skills, 347 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
+**What is this?** A Claude Code plugin marketplace: 472 plugins, 3,179 skills, 347 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
 
 **How do I install a plugin?** Use the CLI (`ccpi install <name>`) or Claude Code's built-in `/plugin marketplace add jeremylongshore/claude-code-plugins` followed by `/plugin install <name>@claude-code-plugins-plus`. The [Quick Start](#quick-start) covers both paths.
 

--- a/plugins/mcp/a2a-client/.claude-plugin/plugin.json
+++ b/plugins/mcp/a2a-client/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "a2a-client",
+  "version": "0.1.0",
+  "description": "Agent2Agent (A2A) client as an MCP server — discover an agent card, send and stream messages, and control tasks against any conformant A2A agent, with remote capability claims reported rather than trusted",
+  "author": {
+    "name": "Jeremy Longshore",
+    "url": "https://intentsolutions.io",
+    "email": "jeremy@intentsolutions.io"
+  },
+  "repository": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
+  "license": "MIT",
+  "keywords": [
+    "a2a",
+    "agent2agent",
+    "agent-card",
+    "multi-agent",
+    "interoperability",
+    "mcp",
+    "agent-comms"
+  ]
+}

--- a/plugins/mcp/a2a-client/.mcp.json
+++ b/plugins/mcp/a2a-client/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "a2a-client": {
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/dist/servers/a2a-client.js"
+      ],
+      "env": {
+        "A2A_ALLOWED_HOSTS": "",
+        "A2A_BEARER_TOKEN": "",
+        "A2A_ALLOW_PRIVATE_HOSTS": ""
+      }
+    }
+  }
+}

--- a/plugins/mcp/a2a-client/LICENSE
+++ b/plugins/mcp/a2a-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Jeremy Longshore & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/mcp/a2a-client/README.md
+++ b/plugins/mcp/a2a-client/README.md
@@ -118,12 +118,15 @@ The in-plugin config uses `${CLAUDE_PLUGIN_ROOT}` so no absolute path is needed 
 plugin. `dist/` is gitignored repo-wide (same as every other MCP plugin here), so the package carries
 a `prepare` script — `pnpm install` in the plugin directory builds the entrypoint automatically.
 
-## Pairs with
+## Skill layer
 
-The [`agent-comms`](../../agent-comms/agent-comms) pack is the skill layer over this server:
-`a2a-protocol` (the wire surface), `a2a-agent-card` (authoring and auditing cards, plus the
-`a2a-card-auditor` agent), `comms-topology`, `topology-safety`, `agent-mailbox`, and
-`mas-failure-triage`. The server is the hands; the pack is the judgment.
+There isn't one yet, deliberately. A companion `agent-comms` skill pack was drafted and closed
+unmerged (PR #1169) after review concluded its centrepiece — a filesystem-backed mailbox — repeats a
+design the most-used project in this space publicly abandoned. The strategy question behind that
+pack is open and demand-gated; see `000-docs/713-AT-DECR` § 5.
+
+This server does not depend on that question. It is the hands; whatever judgment layer eventually
+arrives will sit on top without changing anything here.
 
 ## Develop
 

--- a/plugins/mcp/a2a-client/README.md
+++ b/plugins/mcp/a2a-client/README.md
@@ -1,0 +1,150 @@
+<h1 align="center">a2a-client</h1>
+
+<p align="center">
+  An MCP server that makes a Claude Code session a first-class <strong>Agent2Agent (A2A)</strong>
+  participant — card discovery, messaging, streaming, and task control against any conformant
+  agent.<br>
+  Wraps the official <code>@a2a-js/sdk</code>. Conforms to the published A2A specification and
+  defines no wire format of its own.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/License-MIT-10b981?style=flat-square" alt="License: MIT">
+  <img src="https://img.shields.io/badge/MCP-stdio-8b5cf6?style=flat-square" alt="MCP stdio">
+  <img src="https://img.shields.io/badge/A2A-v1.0-0ea5e9?style=flat-square" alt="A2A v1.0">
+  <img src="https://img.shields.io/badge/cards-untrusted%20input-f59e0b?style=flat-square" alt="cards are untrusted input">
+</p>
+
+---
+
+## Why this server exists
+
+A2A is the surviving open standard for agent-to-agent communication. Its predecessor was archived and
+folded into A2A under the Linux Foundation, so there is exactly one standard to conform to. The
+protocol has SDKs in seven languages and a published conformance inspector — and, before this server,
+no Claude Code layer at all.
+
+That gap is the whole reason this exists. A Claude Code session could talk to tools (MCP) and to
+humans, but not to another organization's agent over the one protocol built for it.
+
+**The design constraint that shapes every tool here:** an agent card is an externally-authored
+manifest, fetched over the network, describing what a remote party would like the local agent to
+believe. Adopting one is a textbook confused-deputy primitive. So every tool **reports** what a card
+claims and none of them convert a claim into local authority — no capability is auto-enabled, no
+interface URL becomes a default, no card-named URL is resolved on the card's say-so, and there is
+deliberately **no trust score**, because a single number invites automating the one decision that has
+to stay with an operator.
+
+That rule is enforced on the wire, not only in the report. A first cut audited hostile cards and then
+let the protocol client call them anyway, and attached the operator's credential to whatever host the
+caller named — so the posture held in the output and failed in the socket. Every request now passes
+`servers/net-guard.ts`; see [Auth and the outbound guard](#auth-and-the-outbound-guard--both-fail-closed).
+
+## Tool surface (7)
+
+| Tool | A2A method | What it does |
+|---|---|---|
+| `fetch_agent_card` | `GET /.well-known/agent-card.json` | Fetch a remote card and return a structure verdict, an enumerated claims table, and findings. Claims are labelled `claimed`; nothing is adopted. |
+| `validate_agent_card` | — (local) | Validate a card (fetched or supplied inline) against the required A2A fields. Returns the verdict, findings, and a count of decisions needing an operator. |
+| `send_message` | `SendMessage` | Send a message. Branches the `oneof` response and reports which arm came back — a `Task`, or an inline `Message` from an agent that answered without creating one. |
+| `stream_message` | `SendStreamingMessage` | Send and collect streamed events with an event cap. Falls back to non-streaming when the agent does not support it. |
+| `get_task` | `GetTask` | Retrieve a task's current status, artifacts, and optional history. |
+| `list_tasks` | `ListTasks` | List tasks, optionally scoped to one conversation `contextId`. |
+| `cancel_task` | `CancelTask` | Request cancellation. The result carries a note that a cancel is a request, not a kill switch — the task may be uncancelable. |
+
+Push-notification config methods (`Create`/`Get`/`List`/`Delete TaskPushNotificationConfig`) and
+`GetExtendedAgentCard` are reachable through the SDK but are not exposed as tools yet: a push
+callback is inbound untrusted traffic that needs a receiving endpoint this server does not own.
+
+## Auth and the outbound guard — both fail closed
+
+Credentials belong to the operator and arrive through the environment. They are never read from an
+agent card, never logged, and never echoed in a tool result — **and they are only ever sent to a host
+the operator nominated.** Every request also passes a destination check, so the "report, never adopt"
+rule holds on the wire and not just in the report.
+
+| Env | Effect |
+|---|---|
+| `A2A_ALLOWED_HOSTS` | Comma-separated hosts a credential may be sent to. **Empty (default) means no credential is ever sent.** |
+| `A2A_BEARER_TOKEN` | Sends `Authorization: Bearer <token>` — to allowlisted hosts only |
+| `A2A_API_KEY` | Sends the value as-is in the auth header — to allowlisted hosts only |
+| `A2A_AUTH_HEADER_NAME` | Overrides the header name (default `Authorization`) |
+| `A2A_ALLOW_PRIVATE_HOSTS` | Set to `1` to permit loopback/private destinations. **Local development only.** |
+
+**Destination check.** Private, loopback, link-local, and carrier-grade-NAT addresses are refused —
+including `169.254.169.254`, the cloud instance-metadata endpoint. Hostnames are resolved and *every*
+returned address is checked, so a public name pointing inward is refused too. This applies to the
+`baseUrl` a caller passes **and** to interface URLs named by a remote agent card, which is the point:
+the audit reports a hostile card, and the guard stops the client acting on it.
+
+**Credential scope.** A token is attached only to a host in `A2A_ALLOWED_HOSTS`. With no allowlist
+configured, no credential leaves the process — nominate where your token may go before it can travel.
+
+There is **no credential discovery and no re-auth negotiation**: a `401`/`403` is surfaced to the
+operator rather than answered with a guessed second credential. An agent's declared `securitySchemes`
+tell you which credential to set; they never cause one to be fetched.
+
+*Residual risk, stated rather than papered over:* the address check runs before the request, so a name
+whose resolution changes between check and connect (DNS rebinding) is not covered. Closing that needs
+a pinned-IP dialer the SDK's `fetch` seam does not expose.
+
+## Install
+
+### Claude Code (via the marketplace)
+
+```
+/plugin marketplace add jeremylongshore/claude-code-plugins
+/plugin install a2a-client
+```
+
+### Any `.mcp.json` consumer (stdio)
+
+```json
+{
+  "mcpServers": {
+    "a2a-client": {
+      "command": "node",
+      "args": ["/abs/path/to/plugins/mcp/a2a-client/dist/servers/a2a-client.js"],
+      "env": {
+        "A2A_ALLOWED_HOSTS": "agents.partner.example.com",
+        "A2A_BEARER_TOKEN": "…"
+      }
+    }
+  }
+}
+```
+
+The in-plugin config uses `${CLAUDE_PLUGIN_ROOT}` so no absolute path is needed when installed as a
+plugin. `dist/` is gitignored repo-wide (same as every other MCP plugin here), so the package carries
+a `prepare` script — `pnpm install` in the plugin directory builds the entrypoint automatically.
+
+## Pairs with
+
+The [`agent-comms`](../../agent-comms/agent-comms) pack is the skill layer over this server:
+`a2a-protocol` (the wire surface), `a2a-agent-card` (authoring and auditing cards, plus the
+`a2a-card-auditor` agent), `comms-topology`, `topology-safety`, `agent-mailbox`, and
+`mas-failure-triage`. The server is the hands; the pack is the judgment.
+
+## Develop
+
+```bash
+pnpm install          # the `prepare` script builds dist/ automatically
+pnpm typecheck        # tsc --noEmit
+pnpm test:ci          # vitest run — 67 tests (card audit + network guard)
+pnpm lint
+pnpm build            # tsc → dist/
+```
+
+**Exercised end-to-end** against a reference A2A agent built on the official `@a2a-js/sdk` server
+module: card fetch and audit, a `SendMessage` round-trip returning a task, a streamed call emitting
+`task → statusUpdate → artifactUpdate → statusUpdate`, `GetTask` reaching a terminal `COMPLETED`
+state with artifacts, a `CancelTask` on a still-live task returning `CANCELED`, and an unknown task
+id surfacing `Task not found` verbatim rather than a fake success — 22 of 22 assertions, run with
+`A2A_ALLOW_PRIVATE_HOSTS=1` because the reference agent is on loopback.
+
+Separately, the guard was exercised with the default (fail-closed) configuration: `127.0.0.1`,
+`localhost`, and `169.254.169.254` were each refused before any request left the process.
+
+## License
+
+MIT

--- a/plugins/mcp/a2a-client/docs/ADR.md
+++ b/plugins/mcp/a2a-client/docs/ADR.md
@@ -1,0 +1,123 @@
+# ADR: a2a-client — wrap the official SDK, and never let a card grant authority
+
+**Author:** Jeremy Longshore
+**Date:** 2026-08-09
+**Status:** Accepted
+
+## Context
+
+The `agent-comms` skills describe A2A correctly but cannot place a call. Something has to speak the
+wire.
+
+Two constraints shape how.
+
+**The protocol is not ours to reimplement.** A2A carries three bindings (JSON-RPC, gRPC, HTTP+JSON),
+an ordered interface-preference list with fallback, an opaque `tenant` that must be echoed when
+present, camelCase-over-proto serialization, a `oneof` send result, and nine specific error codes with
+a canonical mapping across bindings. A hand-rolled client gets the camelCase rule wrong on day one and
+is silently ignored by conformant servers, because unknown fields are dropped rather than rejected.
+
+**The discovery document is hostile by construction.** A2A discovery fetches an agent card — a
+manifest authored by the remote party. The agent-governance-plane's CISO ruling is explicit that
+importing an unsigned external manifest is a governance-bypass / confused-deputy primitive. An agent
+card is precisely that: it names interface URLs (any host, including internal ones), a `tenant` the
+client must echo, security requirements that can be weaker per skill than at the agent level, required
+extensions, and free-text descriptions that reach a model. A client that configures itself from that
+document has spent its own authority on the remote party's instructions.
+
+Doing nothing means the skills stay documentation-only.
+
+## Decision
+
+**We wrap the official `@a2a-js/sdk@1.0.1` client and enforce a one-way trust rule: a card informs a
+human decision and never widens machine authority.**
+
+Four commitments implement it:
+
+1. **Per-call client construction, nothing cached.** Every tool builds a client from the card at the
+   given base URL and discards it. A card cannot install itself as a durable default because no
+   default survives the call.
+2. **Report, never adopt.** `fetch_agent_card` returns claims labelled `claimed` with a disposition of
+   `reported` or `operator-decision-required`, and never writes local configuration. There is
+   deliberately **no trust score** — a single number invites automating the decision the ruling puts
+   with an operator. A test asserts no `trustScore` / `trusted` / `safe` / `verdict` key is ever
+   emitted.
+3. **Three-valued signature status.** `absent`, `unverified`, or `verified against <key>`. Since this
+   server obtains no independent key, it never reports the third. Collapsing `unverified` into either
+   neighbour manufactures confidence that no verification produced.
+4. **Operator-held credentials, scoped to nominated hosts.** Auth comes from `A2A_BEARER_TOKEN` /
+   `A2A_API_KEY` / `A2A_AUTH_HEADER_NAME`, and is attached **only** to a host listed in
+   `A2A_ALLOWED_HOSTS`. With no allowlist, no credential ever leaves the process. There is no
+   credential discovery and no re-auth negotiation — a `401`/`403` surfaces rather than triggering a
+   guessed retry.
+5. **A single outbound choke point** (`servers/net-guard.ts`). Every request — card resolution,
+   protocol calls, anything the SDK does internally — passes a destination check that refuses private,
+   loopback, link-local, and carrier-grade-NAT addresses unless `A2A_ALLOW_PRIVATE_HOSTS=1`. Hostnames
+   are resolved and *every* returned address is checked, so a public name pointing inward is refused.
+
+The audit logic lives in a **pure module with no I/O** (`servers/card-audit.ts`), imported by the
+server and exercised directly by tests. Structure without side effects is what makes "no side effects"
+testable.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| Hand-roll the JSON-RPC client | Three bindings, fallback ordering, tenant echo, camelCase-over-proto, a `oneof` result, and nine error codes. The camelCase rule alone fails silently — servers drop unknown fields rather than rejecting them. Reimplementing a spec the maintainers already implement is cost with no upside. |
+| Auto-configure from the fetched card — adopt capabilities, use the declared URL | The obvious design, and the confused-deputy primitive the CISO ruling names. It converts a remote-authored document into local authority. |
+| Emit a card trust score or overall verdict | Compresses the operator decision into a number, which invites automating it. Enumerated claims plus explicit dispositions keep the human where the ruling puts them. |
+| Verify card signatures and report `valid` | Without a key obtained independently of the card, verification is circular — fetching a key from a location the card names lets the card verify itself. `unverified` is the only honest output. |
+| Cache resolved clients per base URL for speed | Turns one accepted card into a persistent default and makes revocation invisible. The per-call cost is a page fetch; the correctness gain is that trust never accumulates silently. |
+| Expose the push-notification config methods now | A callback is inbound untrusted traffic that needs a receiving endpoint this server does not own. Shipping the registration half without the receiving half invites data loss that looks like success. |
+| Follow `documentationUrl` / `iconUrl` to enrich results | An unattended fetch to a host the remote party chose, from inside the caller's network. Reported as strings instead; the auditing agent additionally denies `WebFetch` so it cannot be done at all. |
+| Enforce the trust rule in the audit output only (the first cut) | Review caught this correctly: the audit *reported* a card pointing at `10.0.0.7`, and the protocol client then called it anyway, while the operator's credential went to whatever host the caller named. The posture held in the report and failed in the socket. A guard at the fetch seam is the only placement that covers card resolution, interface calls, and SDK-internal requests together. |
+| Block private hosts with no escape hatch | Makes local development against a reference agent impossible, which is exactly how this plugin is tested. `A2A_ALLOW_PRIVATE_HOSTS=1` is an explicit, documented, off-by-default opt-in. |
+| Attach credentials to any host, and rely on the caller to pass the right `baseUrl` | The caller may be a model acting on injected content. Requiring the operator to nominate destinations moves the decision to the only party that can make it. |
+
+## Consequences
+
+**Positive:**
+
+- Spec fidelity is inherited from the maintainers, and tracks the spec as the SDK does.
+- The credential-egress and SSRF classes are closed at one auditable place rather than at each call
+  site, and both fail closed: no allowlist means no credential, and private destinations are refused
+  by default.
+- The trust rule is enforced by structure — pure audit module, no caching, no write tools on the
+  auditing agent — rather than by instructions a model may not follow.
+- Errors surface verbatim with their codes, so callers can apply the retry policy the spec implies
+  (never retry a failed-precondition class unchanged) instead of guessing from prose.
+- Exercised end-to-end rather than asserted: 22/22 assertions against a reference agent, 67 unit
+  tests, and a fail-closed guard check refusing `127.0.0.1`, `localhost`, and `169.254.169.254`.
+
+**Negative / accepted tradeoffs:**
+
+- **Slower and more friction than auto-configuration.** Every integration needs an operator decision
+  the first time. That is the intended cost.
+- **Per-call card fetch** adds a round trip to every tool call. Accepted so trust never accumulates.
+- **Bound to the SDK's release cadence and shape.** The SDK exposes proto-numeric `TaskState` values
+  and a `payload.$case` union on stream events; callers see those shapes, and an SDK major will move
+  them.
+- **Four of eleven A2A methods are unexposed**, so push-notification workflows are out of reach today.
+- **`dist/` is gitignored repo-wide**, so a fresh checkout has no entrypoint. Rather than special-case
+  one plugin against the repo convention, the package carries a `prepare` script, so `pnpm install`
+  builds it. A consumer who copies only the launcher without installing still gets `MODULE_NOT_FOUND`.
+- **Fail-closed credentials are a usability cost.** Setting `A2A_BEARER_TOKEN` alone does nothing
+  until `A2A_ALLOWED_HOSTS` names a destination. That will read as a bug to someone who has not read
+  the auth section, and it is the correct default anyway.
+- **DNS rebinding is not covered.** The address check runs before the request; a name whose resolution
+  changes between check and connect defeats it. Closing that needs a pinned-IP dialer the SDK's
+  `fetch` seam does not expose. Stated in the module header and the README rather than left implicit.
+
+## Tool-permission scope
+
+This is an MCP server rather than a skill, so the relevant scope is what the server itself can reach.
+
+| Capability | Why it's needed |
+| --- | --- |
+| Outbound HTTPS via the SDK's `fetch` | The only way to reach a remote A2A agent. Wrapped by `createGuardedFetch` so the destination check and credential scoping apply at one boundary. |
+| DNS resolution (`node:dns/promises`) | Needed to refuse a public hostname that resolves to a private address. Read-only. |
+| Read `A2A_ALLOWED_HOSTS` / `A2A_BEARER_TOKEN` / `A2A_API_KEY` / `A2A_AUTH_HEADER_NAME` / `A2A_ALLOW_PRIVATE_HOSTS` from the environment | Credentials and destination policy must come from the operator, never from a card. No other environment access is used. |
+| stdio | The MCP transport. No HTTP listener, so there is no inbound surface. |
+
+Deliberately absent: **no filesystem access, no shell, no card-named URL resolution.** A tool that
+cannot write cannot adopt a claim by accident.

--- a/plugins/mcp/a2a-client/docs/PRD.md
+++ b/plugins/mcp/a2a-client/docs/PRD.md
@@ -1,0 +1,81 @@
+# PRD: a2a-client
+
+**Author:** Jeremy Longshore
+**Date:** 2026-08-09
+**Status:** Active
+
+## Problem
+
+A Claude Code session can call tools (MCP) and talk to humans, but it cannot talk to another
+organization's agent over the protocol built for exactly that.
+
+Agent2Agent (A2A) is the settled standard for agent-to-agent communication — 25,261 stars, Linux
+Foundation, official SDKs in seven languages, and a published conformance inspector. Its predecessor
+ACP is archived and its README redirects to A2A's migration guide, so there is one standard rather
+than a contested field.
+
+As of 2026-08-09, GitHub searches for "a2a claude code skill", "agent2agent claude code", and "a2a
+agent card claude" returned **zero results** each, and `a2a-mcp` was unpublished on npm. The
+documentation half of the gap is addressable with skills; the calling half needs a real client that
+speaks the wire.
+
+There is a second, sharper problem hiding inside the first. A2A discovery works by fetching an
+**agent card** — a manifest authored by the remote party, describing what they would like the local
+agent to believe: which URLs to send traffic to, which capabilities exist, which security requirements
+apply. A client that configures itself from that document has handed a remote party its own authority.
+That is a confused-deputy primitive, and the obvious implementation walks straight into it.
+
+## Target users
+
+| User | Context | Primary need |
+| --- | --- | --- |
+| Integrator | A partner published an A2A agent; the card is theirs, the blast radius is ours | Complete a real round-trip, and see what the card claims without the client acting on it |
+| Skill author | Building on the `agent-comms` pack; needs the live-call path behind the protocol skills | Typed, spec-faithful tools that surface protocol errors verbatim |
+| Operator debugging an integration | A task stalled, a stream died, or a cancel did nothing | Verbatim status and error codes rather than a paraphrase that loses the code |
+
+## Success criteria
+
+1. A full A2A flow completes against a conformant agent — card fetch, `SendMessage` round-trip,
+   streamed call, `GetTask` to a terminal state, `CancelTask` on a live task — with an unknown task id
+   producing a verbatim error rather than a fake success. **Met: 22/22 assertions against a reference
+   agent built on the official `@a2a-js/sdk` server module.**
+2. No tool converts a card claim into local configuration, and no output contains a trust score.
+   Asserted by test, not by convention. **Met: 67 unit tests over the pure audit and guard modules.**
+   The wire honours the same rule: private, loopback, link-local, and metadata destinations are
+   refused by default whether the caller or a remote card named them.
+3. `.mcp.json` uses `${CLAUDE_PLUGIN_ROOT}`, and the built server completes an MCP handshake and
+   lists all seven tools. **Met.**
+4. Credentials are only ever read from the environment — never from a card, never logged, never echoed
+   in a tool result — and are sent only to a host the operator nominated in `A2A_ALLOWED_HOSTS`. With
+   no allowlist configured, no credential leaves the process. **Met, asserted by test.**
+
+## Functional requirements
+
+- **FR-1:** Resolve an agent card from `/.well-known/agent-card.json` (or an explicit path) and return
+  a structure verdict, an enumerated claims table, and findings — labelled `reported` or
+  `operator-decision-required`.
+- **FR-2:** Flag interface URLs pointing at loopback or private ranges, non-HTTPS interface URLs,
+  card-required extensions, and per-skill `securityRequirements` that drop an agent-level scheme.
+- **FR-3:** Send messages and branch the `SendMessageResult` `oneof`, reporting whether a `Task` or an
+  inline `Message` came back — a spec-legal agent may answer without creating a task.
+- **FR-4:** Stream events with a caller-set cap, reporting truncation explicitly rather than silently.
+- **FR-5:** Get, list, and cancel tasks, with the cancel result stating that a cancel is a request the
+  agent may decline.
+- **FR-6:** Refuse every outbound request to a private, loopback, link-local, or carrier-grade-NAT
+  destination unless explicitly opted in, and attach an operator credential only to an allowlisted
+  host — enforced at a single fetch-level choke point so it covers card resolution, protocol calls,
+  and SDK-internal requests alike.
+
+## Out of scope
+
+- **Defining or extending a protocol.** This wraps the official SDK and conforms to the published
+  spec. No format, version, or registry of its own; no conformance-certification claim.
+- **Push-notification callback receipt.** The four `TaskPushNotificationConfig` methods and
+  `GetExtendedAgentCard` are reachable through the SDK but are not exposed as tools — an inbound
+  callback is untrusted traffic needing a receiving endpoint this server does not own.
+- **Signature verification.** Without a key obtained independently of the card, `unverified` is the
+  only honest answer, and reporting the stronger claim would be a false assurance.
+- **Credential discovery or re-auth negotiation.** A `401`/`403` is surfaced, not answered with a
+  guessed second credential.
+- **Caching cards across calls.** Deliberate: a card must not be able to install itself as a durable
+  default.

--- a/plugins/mcp/a2a-client/eslint.config.mjs
+++ b/plugins/mcp/a2a-client/eslint.config.mjs
@@ -1,0 +1,16 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist/**'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
+];
+

--- a/plugins/mcp/a2a-client/package.json
+++ b/plugins/mcp/a2a-client/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@claude-code-plugins-plus/a2a-client",
+  "version": "0.1.0",
+  "description": "MCP server that makes a Claude Code session an Agent2Agent (A2A) client — card discovery, messaging, streaming, and task control, with remote capability claims reported rather than trusted",
+  "type": "module",
+  "main": "dist/servers/a2a-client.js",
+  "scripts": {
+    "dev": "tsx watch servers/a2a-client.ts",
+    "build": "tsc",
+    "test": "vitest",
+    "test:ci": "vitest run",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "prepare": "tsc"
+  },
+  "keywords": [
+    "claude-code",
+    "mcp",
+    "a2a",
+    "agent2agent",
+    "agent-card",
+    "multi-agent",
+    "interoperability"
+  ],
+  "author": "Intent Solutions IO",
+  "license": "MIT",
+  "dependencies": {
+    "@a2a-js/sdk": "1.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "@types/node": "^25.9.1",
+    "eslint": "^9.39.4",
+    "tsx": "^4.22.3",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.60.0",
+    "vitest": "^4.1.7"
+  }
+}

--- a/plugins/mcp/a2a-client/server.json
+++ b/plugins/mcp/a2a-client/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jeremylongshore/a2a-client",
+  "title": "A2A Client",
+  "description": "Agent2Agent (A2A) client as an MCP server — agent-card discovery, messaging, streaming, and task control",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
+    "source": "github",
+    "subfolder": "plugins/mcp/a2a-client"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@claude-code-plugins-plus/a2a-client",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "_meta": {
+    "io.claudecodeplugins/marketplace": {
+      "category": "mcp",
+      "featured": true,
+      "websiteUrl": "https://tonsofskills.com/plugins/a2a-client"
+    }
+  }
+}

--- a/plugins/mcp/a2a-client/servers/a2a-client.ts
+++ b/plugins/mcp/a2a-client/servers/a2a-client.ts
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+
+/**
+ * a2a-client — an MCP server that lets a Claude Code session speak Agent2Agent (A2A).
+ *
+ * Wraps the official @a2a-js/sdk client. This server conforms to the published A2A
+ * specification; it defines no wire format of its own.
+ *
+ * Trust posture, deliberately: an agent card is an externally-authored manifest fetched
+ * from outside the trust boundary. Every tool here REPORTS what a card claims and never
+ * converts a claim into local authority — no capability is auto-enabled, no interface URL
+ * is adopted as a default, no card-named URL is resolved on the card's say-so.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ClientFactory,
+  ClientFactoryOptions,
+  DefaultAgentCardResolver,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+  type Client,
+} from '@a2a-js/sdk/client';
+import { Role, type AgentCard, type Message, type Part } from '@a2a-js/sdk';
+import { auditCard, claimsOf } from './card-audit.js';
+import { configFromEnv, createGuardedFetch } from './net-guard.js';
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+
+// ── Auth + outbound guard ───────────────────────────────────────────────────────
+// Credentials belong to the operator and arrive through the environment. They are never
+// read from an agent card, never logged, and never echoed in a tool result — AND they are
+// only ever sent to a host the operator nominated in A2A_ALLOWED_HOSTS. With no allowlist
+// configured, no credential leaves this process at all. Every request also passes a
+// destination check that refuses loopback/private/link-local targets, whether they came
+// from the caller or from a remote agent card. See servers/net-guard.ts for the rationale.
+
+const guardConfig = configFromEnv();
+const guardedFetch = createGuardedFetch(guardConfig);
+
+// ── Client construction ─────────────────────────────────────────────────────────
+// A client is built per call from the card at the given base URL. Nothing is cached
+// between calls, so a card cannot install itself as a durable default.
+
+function factory(): ClientFactory {
+  return new ClientFactory(
+    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      transports: [
+        new JsonRpcTransportFactory({ fetchImpl: guardedFetch }),
+        new RestTransportFactory({ fetchImpl: guardedFetch }),
+      ],
+      cardResolver: new DefaultAgentCardResolver({ fetchImpl: guardedFetch }),
+    }),
+  );
+}
+
+async function clientFor(baseUrl: string, cardPath?: string): Promise<Client> {
+  return factory().createFromUrl(baseUrl, cardPath);
+}
+
+async function cardFor(baseUrl: string, cardPath?: string): Promise<AgentCard> {
+  return new DefaultAgentCardResolver({ fetchImpl: guardedFetch }).resolve(baseUrl, cardPath);
+}
+
+function textMessage(text: string, taskId?: string, contextId?: string): Message {
+  const parts: Part[] = [
+    { content: { $case: 'text', value: text }, filename: '', mediaType: '', metadata: undefined },
+  ];
+  return {
+    messageId: randomUUID(),
+    contextId: contextId ?? '',
+    taskId: taskId ?? '',
+    role: Role.ROLE_USER,
+    parts,
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  };
+}
+
+// ── Tool schemas ────────────────────────────────────────────────────────────────
+
+const BaseTarget = { baseUrl: z.string().min(1), cardPath: z.string().optional() };
+
+const FetchAgentCardSchema = z.object(BaseTarget);
+const ValidateAgentCardSchema = z.object({ ...BaseTarget, card: z.unknown().optional() });
+const SendMessageSchema = z.object({
+  ...BaseTarget,
+  text: z.string().min(1),
+  taskId: z.string().optional(),
+  contextId: z.string().optional(),
+});
+const StreamMessageSchema = z.object({
+  ...BaseTarget,
+  text: z.string().min(1),
+  contextId: z.string().optional(),
+  maxEvents: z.number().int().positive().max(500).optional().default(50),
+});
+const GetTaskSchema = z.object({
+  ...BaseTarget,
+  taskId: z.string().min(1),
+  historyLength: z.number().int().nonnegative().optional(),
+});
+const ListTasksSchema = z.object({
+  ...BaseTarget,
+  contextId: z.string().optional(),
+  pageSize: z.number().int().min(1).max(100).optional(),
+});
+const CancelTaskSchema = z.object({ ...BaseTarget, taskId: z.string().min(1) });
+
+// ── Tool implementations ────────────────────────────────────────────────────────
+
+async function fetchAgentCard(a: z.infer<typeof FetchAgentCardSchema>) {
+  const card = await cardFor(a.baseUrl, a.cardPath);
+  const audit = auditCard(card);
+  return {
+    note: 'Claims are reported, not adopted. No capability here is enabled by this result.',
+    structure: audit.structure,
+    missingFields: audit.missingFields,
+    signatureStatus: audit.signatureStatus,
+    claims: claimsOf(card),
+    findings: audit.findings,
+  };
+}
+
+async function validateAgentCard(a: z.infer<typeof ValidateAgentCardSchema>) {
+  const card = (a.card as AgentCard | undefined) ?? (await cardFor(a.baseUrl, a.cardPath));
+  const audit = auditCard(card);
+  return {
+    structure: audit.structure,
+    missingFields: audit.missingFields,
+    signatureStatus: audit.signatureStatus,
+    findings: audit.findings,
+    operatorDecisionsRequired: audit.operatorDecisionsRequired,
+  };
+}
+
+async function sendMessage(a: z.infer<typeof SendMessageSchema>) {
+  const client = await clientFor(a.baseUrl, a.cardPath);
+  const result = await client.sendMessage({
+    tenant: '',
+    message: textMessage(a.text, a.taskId, a.contextId),
+    configuration: undefined,
+    metadata: undefined,
+  });
+  // SendMessageResult is a union: an agent may answer inline without creating a task.
+  const arm = 'status' in result ? 'task' : 'message';
+  return { protocolVersion: client.protocolVersion, arm, result };
+}
+
+async function streamMessage(a: z.infer<typeof StreamMessageSchema>) {
+  const client = await clientFor(a.baseUrl, a.cardPath);
+  const events: unknown[] = [];
+  let truncated = false;
+  for await (const event of client.sendMessageStream({
+    tenant: '',
+    message: textMessage(a.text, undefined, a.contextId),
+    configuration: undefined,
+    metadata: undefined,
+  })) {
+    events.push(event);
+    if (events.length >= a.maxEvents) {
+      truncated = true;
+      break;
+    }
+  }
+  return { protocolVersion: client.protocolVersion, eventCount: events.length, truncated, events };
+}
+
+async function getTask(a: z.infer<typeof GetTaskSchema>) {
+  const client = await clientFor(a.baseUrl, a.cardPath);
+  return client.getTask({ tenant: '', id: a.taskId, historyLength: a.historyLength });
+}
+
+async function listTasks(a: z.infer<typeof ListTasksSchema>) {
+  const client = await clientFor(a.baseUrl, a.cardPath);
+  return client.listTasks({
+    tenant: '',
+    contextId: a.contextId ?? '',
+    status: 0,
+    pageSize: a.pageSize,
+    pageToken: '',
+    historyLength: undefined,
+    statusTimestampAfter: undefined,
+  });
+}
+
+async function cancelTask(a: z.infer<typeof CancelTaskSchema>) {
+  const client = await clientFor(a.baseUrl, a.cardPath);
+  const task = await client.cancelTask({ tenant: '', id: a.taskId, metadata: undefined });
+  return {
+    task,
+    note: 'Cancellation is a request. Treat it as pending until the returned state is CANCELED.',
+  };
+}
+
+// ── Server wiring ───────────────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: 'a2a-client', version: '0.1.0' },
+  { capabilities: { tools: {} } },
+);
+
+const TARGET_PROPS = {
+  baseUrl: { type: 'string', description: 'Base URL of the remote A2A agent' },
+  cardPath: {
+    type: 'string',
+    description: 'Agent-card path. Defaults to /.well-known/agent-card.json',
+  },
+};
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'fetch_agent_card',
+      description:
+        "Fetch a remote agent's card and report its claims plus structural findings. Claims are reported, never adopted — nothing here enables a capability or changes local configuration.",
+      inputSchema: { type: 'object', properties: { ...TARGET_PROPS }, required: ['baseUrl'] },
+    },
+    {
+      name: 'validate_agent_card',
+      description:
+        'Validate an agent card against the required A2A fields and return a structure verdict, findings, and a count of decisions that require an operator.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ...TARGET_PROPS,
+          card: { type: 'object', description: 'An already-fetched card to validate offline' },
+        },
+        required: [],
+        anyOf: [{ required: ['baseUrl'] }, { required: ['card'] }],
+      },
+    },
+    {
+      name: 'send_message',
+      description:
+        'Send a message to a remote A2A agent. The response is a union — a Task, or an inline Message when the agent answers without creating one.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ...TARGET_PROPS,
+          text: { type: 'string', description: 'Message text' },
+          taskId: { type: 'string', description: 'Continue an interrupted task' },
+          contextId: { type: 'string', description: 'Group into an existing conversation' },
+        },
+        required: ['baseUrl', 'text'],
+      },
+    },
+    {
+      name: 'stream_message',
+      description:
+        'Send a message and collect streamed events. Falls back to non-streaming when the agent does not support streaming.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ...TARGET_PROPS,
+          text: { type: 'string', description: 'Message text' },
+          contextId: { type: 'string' },
+          maxEvents: { type: 'number', description: 'Event cap before truncating (default 50)' },
+        },
+        required: ['baseUrl', 'text'],
+      },
+    },
+    {
+      name: 'get_task',
+      description: 'Retrieve the current state of a task, including status and artifacts.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ...TARGET_PROPS,
+          taskId: { type: 'string' },
+          historyLength: { type: 'number' },
+        },
+        required: ['baseUrl', 'taskId'],
+      },
+    },
+    {
+      name: 'list_tasks',
+      description: 'List tasks, optionally filtered to one conversation context.',
+      inputSchema: {
+        type: 'object',
+        properties: { ...TARGET_PROPS, contextId: { type: 'string' }, pageSize: { type: 'number' } },
+        required: ['baseUrl'],
+      },
+    },
+    {
+      name: 'cancel_task',
+      description:
+        'Request cancellation of a task. Success is not guaranteed; the agent may report the task is not cancelable.',
+      inputSchema: {
+        type: 'object',
+        properties: { ...TARGET_PROPS, taskId: { type: 'string' } },
+        required: ['baseUrl', 'taskId'],
+      },
+    },
+  ],
+}));
+
+const HANDLERS: Record<string, (args: unknown) => Promise<unknown>> = {
+  fetch_agent_card: (a) => fetchAgentCard(FetchAgentCardSchema.parse(a)),
+  validate_agent_card: (a) => validateAgentCard(ValidateAgentCardSchema.parse(a)),
+  send_message: (a) => sendMessage(SendMessageSchema.parse(a)),
+  stream_message: (a) => streamMessage(StreamMessageSchema.parse(a)),
+  get_task: (a) => getTask(GetTaskSchema.parse(a)),
+  list_tasks: (a) => listTasks(ListTasksSchema.parse(a)),
+  cancel_task: (a) => cancelTask(CancelTaskSchema.parse(a)),
+};
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const handler = HANDLERS[request.params.name];
+  if (!handler) throw new Error(`Unknown tool: ${request.params.name}`);
+  try {
+    const result = await handler(request.params.arguments);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(
+        `Invalid arguments: ${error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ')}`,
+      );
+    }
+    // Surface protocol errors verbatim — a spec error paraphrased into prose loses its code.
+    throw error;
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('a2a-client MCP server running on stdio');
+}
+
+// Only auto-start under stdio; importing this module for tests must not connect.
+if (process.env.A2A_CLIENT_NO_AUTOSTART !== '1') {
+  main().catch((error) => {
+    console.error('Fatal error in main():', error);
+    process.exit(1);
+  });
+}

--- a/plugins/mcp/a2a-client/servers/card-audit.ts
+++ b/plugins/mcp/a2a-client/servers/card-audit.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure agent-card auditing. No I/O, no network, no side effects — imported by the MCP
+ * server and exercised directly by the tests.
+ *
+ * The governing rule: a card is an externally-authored manifest fetched from outside the
+ * trust boundary. Everything here REPORTS what a card claims. Nothing here converts a
+ * claim into local authority, and there is deliberately no trust score — a single number
+ * would invite automating exactly the decision that has to stay with an operator.
+ */
+
+import type { AgentCard } from '@a2a-js/sdk';
+
+export const REQUIRED_CARD_FIELDS = [
+  'name',
+  'description',
+  'version',
+  'supportedInterfaces',
+  'capabilities',
+  'defaultInputModes',
+  'defaultOutputModes',
+  'skills',
+] as const;
+
+/** Loopback, private, link-local, and carrier-grade ranges an outside card should not name. */
+const PRIVATE_HOST = /^(localhost$|127\.|10\.|192\.168\.|169\.254\.|::1$|172\.(1[6-9]|2\d|3[01])\.)/;
+
+export type Disposition = 'reported' | 'operator-decision-required';
+
+export interface CardFinding {
+  claim: string;
+  value: string;
+  finding: string;
+  disposition: Disposition;
+}
+
+export interface CardAudit {
+  structure: 'valid' | 'malformed';
+  missingFields: string[];
+  findings: CardFinding[];
+  /** Three-valued in the spec. This module never verifies, so it never reports "verified". */
+  signatureStatus: 'absent' | 'unverified';
+  operatorDecisionsRequired: number;
+}
+
+export function auditCard(card: AgentCard): CardAudit {
+  const record = card as unknown as Record<string, unknown>;
+  const missingFields = REQUIRED_CARD_FIELDS.filter((f) => {
+    const v = record[f];
+    return v === undefined || v === null || (Array.isArray(v) && v.length === 0);
+  });
+
+  const findings: CardFinding[] = [
+    ...interfaceFindings(card),
+    ...requiredExtensionFindings(card),
+    ...skillOverrideFindings(card),
+    ...fetchTargetFindings(card),
+  ];
+
+  return {
+    structure: missingFields.length === 0 ? 'valid' : 'malformed',
+    missingFields,
+    findings,
+    signatureStatus: (card.signatures ?? []).length > 0 ? 'unverified' : 'absent',
+    operatorDecisionsRequired: findings.filter(
+      (f) => f.disposition === 'operator-decision-required',
+    ).length,
+  };
+}
+
+function interfaceFindings(card: AgentCard): CardFinding[] {
+  const out: CardFinding[] = [];
+  for (const [i, iface] of (card.supportedInterfaces ?? []).entries()) {
+    const claim = `supportedInterfaces[${i}].url`;
+    let host: string;
+    try {
+      host = new URL(iface.url).hostname;
+    } catch {
+      out.push({
+        claim,
+        value: iface.url,
+        finding: 'URL does not parse as an absolute URL; may be a gRPC host:port or malformed.',
+        disposition: 'operator-decision-required',
+      });
+      continue;
+    }
+    if (PRIVATE_HOST.test(host)) {
+      out.push({
+        claim,
+        value: iface.url,
+        finding: 'Directs traffic to a loopback or private-range host.',
+        disposition: 'operator-decision-required',
+      });
+    } else if (!iface.url.startsWith('https://')) {
+      out.push({
+        claim,
+        value: iface.url,
+        finding: 'Non-HTTPS interface URL.',
+        disposition: 'operator-decision-required',
+      });
+    }
+  }
+  return out;
+}
+
+function requiredExtensionFindings(card: AgentCard): CardFinding[] {
+  return (card.capabilities?.extensions ?? [])
+    .filter((e) => e.required)
+    .map((e) => ({
+      claim: 'capabilities.extensions[].required',
+      value: e.uri,
+      finding: 'Card requires the client to support this extension to interoperate.',
+      disposition: 'operator-decision-required' as const,
+    }));
+}
+
+/**
+ * Per-skill securityRequirements OVERRIDE the agent-level list. A card that reads strict
+ * at the top can still expose one skill behind a weaker requirement, so the audit runs at
+ * the skill level rather than only the agent level.
+ */
+function skillOverrideFindings(card: AgentCard): CardFinding[] {
+  const agentSchemes = new Set(
+    (card.securityRequirements ?? []).flatMap((r) => Object.keys(r.schemes ?? {})),
+  );
+  if (agentSchemes.size === 0) return [];
+
+  const out: CardFinding[] = [];
+  for (const skill of card.skills ?? []) {
+    const declared = skill.securityRequirements ?? [];
+    if (declared.length === 0) continue; // no override — agent-level applies
+    const skillSchemes = new Set(declared.flatMap((r) => Object.keys(r.schemes ?? {})));
+    const dropped = [...agentSchemes].filter((s) => !skillSchemes.has(s));
+    if (dropped.length > 0) {
+      out.push({
+        claim: `skills[${skill.id}].securityRequirements`,
+        value: skillSchemes.size ? [...skillSchemes].join(', ') : '(none)',
+        finding: `Per-skill override drops agent-level scheme(s): ${dropped.join(', ')}.`,
+        disposition: 'operator-decision-required',
+      });
+    }
+  }
+  return out;
+}
+
+/** Card-named fetch targets are reported as strings and never resolved on the card's say-so. */
+function fetchTargetFindings(card: AgentCard): CardFinding[] {
+  const out: CardFinding[] = [];
+  for (const field of ['documentationUrl', 'iconUrl'] as const) {
+    const value = card[field];
+    if (value) {
+      out.push({
+        claim: field,
+        value,
+        finding: 'Card-named fetch target. Reported as a string; not resolved by this server.',
+        disposition: 'reported',
+      });
+    }
+  }
+  return out;
+}
+
+/** Claims are labelled and enumerated, never merged into a single verdict. */
+export function claimsOf(card: AgentCard) {
+  return {
+    identity: { name: card.name, version: card.version, provider: card.provider?.organization },
+    interfaces: (card.supportedInterfaces ?? []).map((i, idx) => ({
+      preference: idx === 0 ? 'preferred' : `fallback-${idx}`,
+      url: i.url,
+      protocolBinding: i.protocolBinding,
+      protocolVersion: i.protocolVersion,
+      tenant: i.tenant || undefined,
+    })),
+    capabilitiesClaimed: {
+      streaming: card.capabilities?.streaming ?? false,
+      pushNotifications: card.capabilities?.pushNotifications ?? false,
+      extendedAgentCard: card.capabilities?.extendedAgentCard ?? false,
+      extensions: (card.capabilities?.extensions ?? []).map((e) => ({
+        uri: e.uri,
+        required: e.required,
+      })),
+    },
+    skillsClaimed: (card.skills ?? []).map((s) => ({ id: s.id, name: s.name, tags: s.tags })),
+    securitySchemesClaimed: Object.keys(card.securitySchemes ?? {}),
+  };
+}

--- a/plugins/mcp/a2a-client/servers/net-guard.ts
+++ b/plugins/mcp/a2a-client/servers/net-guard.ts
@@ -1,0 +1,226 @@
+/**
+ * Outbound network guard — the single choke point every A2A request passes through.
+ *
+ * Two problems this solves, both raised in review of the first cut and both of which
+ * contradicted this plugin's own stated posture:
+ *
+ *  1. **Credential egress.** A configured `A2A_BEARER_TOKEN` was attached to whatever
+ *     `baseUrl` the caller passed. A prompt-injected or mistaken call to an
+ *     attacker-chosen host handed that host the operator's credential.
+ *  2. **SSRF.** A `baseUrl` — or an interface URL named by a remote agent card — could
+ *     point at loopback, link-local, or private-range addresses reachable from the
+ *     Claude Code host. The card audit *reported* those, but the protocol client used
+ *     them anyway, so "report, never adopt" was true of the audit and false of the wire.
+ *
+ * The rules, both fail-closed:
+ *
+ *  - **Destination.** Private, loopback, link-local, and carrier-grade-NAT addresses are
+ *    refused unless `A2A_ALLOW_PRIVATE_HOSTS=1`. Hostnames are resolved and every
+ *    returned address is checked, so a public name that resolves inward is refused too.
+ *  - **Credentials.** A credential is attached ONLY to a host listed in
+ *    `A2A_ALLOWED_HOSTS`. With no allowlist configured, no credential is ever sent —
+ *    the operator must nominate where their token may go.
+ *
+ * Residual risk, stated rather than papered over: the address check happens before the
+ * request, so a name that changes resolution between the check and the connect (DNS
+ * rebinding) is not covered. Closing that needs a pinned-IP dialer, which the SDK's
+ * `fetch` seam does not expose.
+ */
+
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export interface GuardConfig {
+  /** Hosts a credential may be sent to. Empty means no credential is ever sent. */
+  allowedHosts: Set<string>;
+  /** Permit loopback/private/link-local destinations (local development only). */
+  allowPrivateHosts: boolean;
+  /** Header name for the credential, e.g. `Authorization`. */
+  authHeaderName: string;
+  /** The credential value, already formatted (e.g. `Bearer xyz`). Empty means none held. */
+  authHeaderValue: string;
+}
+
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): GuardConfig {
+  const bearer = env.A2A_BEARER_TOKEN ?? '';
+  const apiKey = env.A2A_API_KEY ?? '';
+  return {
+    allowedHosts: new Set(
+      (env.A2A_ALLOWED_HOSTS ?? '')
+        .split(',')
+        .map((h) => h.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+    allowPrivateHosts: env.A2A_ALLOW_PRIVATE_HOSTS === '1',
+    authHeaderName: env.A2A_AUTH_HEADER_NAME ?? 'Authorization',
+    authHeaderValue: bearer ? `Bearer ${bearer}` : apiKey,
+  };
+}
+
+/** IPv4/IPv6 ranges that must not be reachable from a caller-supplied or card-named URL. */
+export function isPrivateAddress(addr: string): boolean {
+  const a = addr.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (isIP(a) === 6) {
+    if (a === '::' || a === '::1') return true;
+    if (a.startsWith('fe80')) return true; // link-local
+    if (/^f[cd]/.test(a)) return true; // unique-local fc00::/7
+    // IPv4-mapped (::ffff:10.0.0.1) — check the embedded v4 address.
+    const mapped = a.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return isPrivateAddress(mapped[1]);
+    return false;
+  }
+
+  const parts = a.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return false;
+  }
+  const [p0, p1] = parts;
+  if (p0 === 0) return true; // "this network"
+  if (p0 === 10) return true; // private
+  if (p0 === 127) return true; // loopback
+  if (p0 === 169 && p1 === 254) return true; // link-local (incl. cloud metadata 169.254.169.254)
+  if (p0 === 172 && p1 >= 16 && p1 <= 31) return true; // private
+  if (p0 === 192 && p1 === 168) return true; // private
+  if (p0 === 100 && p1 >= 64 && p1 <= 127) return true; // carrier-grade NAT
+  if (p0 >= 224) return true; // multicast + reserved
+  return false;
+}
+
+export class BlockedDestinationError extends Error {
+  constructor(host: string, reason: string) {
+    super(
+      `a2a-client refused an outbound request to "${host}": ${reason}. ` +
+        `Set A2A_ALLOW_PRIVATE_HOSTS=1 to permit private destinations (local development only).`,
+    );
+    this.name = 'BlockedDestinationError';
+  }
+}
+
+/** Resolve a hostname and refuse if ANY returned address is private. */
+export async function assertDestinationAllowed(
+  url: URL,
+  cfg: GuardConfig,
+  resolver: (host: string) => Promise<string[]> = defaultResolve,
+): Promise<void> {
+  if (cfg.allowPrivateHosts) return;
+  const host = url.hostname.toLowerCase();
+
+  if (isIP(host)) {
+    if (isPrivateAddress(host)) throw new BlockedDestinationError(host, 'private or loopback address');
+    return;
+  }
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) {
+    throw new BlockedDestinationError(host, 'loopback hostname');
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await resolver(host);
+  } catch (e) {
+    throw new BlockedDestinationError(host, `DNS resolution failed (${(e as Error).message})`);
+  }
+  const bad = addresses.find(isPrivateAddress);
+  if (bad) {
+    throw new BlockedDestinationError(host, `resolves to a private or loopback address (${bad})`);
+  }
+}
+
+async function defaultResolve(host: string): Promise<string[]> {
+  const results = await lookup(host, { all: true });
+  return results.map((r) => r.address);
+}
+
+/** A credential is attached only to a host the operator explicitly nominated. */
+export function shouldSendCredential(url: URL, cfg: GuardConfig): boolean {
+  if (!cfg.authHeaderValue) return false;
+  if (cfg.allowedHosts.size === 0) return false; // fail closed — nominate a host first
+  return cfg.allowedHosts.has(url.hostname.toLowerCase());
+}
+
+/** Redirect hops followed before the request is refused. */
+export const MAX_REDIRECTS = 5;
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+/**
+ * Wrap `fetch` so every outbound request — card resolution, protocol calls, and anything
+ * the SDK does internally — passes the destination check, and carries a credential only
+ * when the destination is nominated.
+ *
+ * Redirects are followed MANUALLY (`redirect: 'manual'`) rather than by the runtime, because
+ * a runtime-followed redirect never re-enters this function. Without that, a permitted public
+ * host answering `302 -> http://169.254.169.254/latest/meta-data/` walks straight around
+ * `assertDestinationAllowed` — `isPrivateAddress` blocks link-local on the pre-flight URL and
+ * never sees the hop. The credential is likewise re-evaluated per hop, so a redirect to a host
+ * the operator did not nominate cannot carry it off-site.
+ *
+ * Residual, deliberately not claimed as closed: a DNS rebind between `assertDestinationAllowed`
+ * resolving a host and the runtime re-resolving it to connect. Closing it requires dialling a
+ * pinned address through a custom dispatcher; until then this is a narrowed window, not a
+ * sealed one.
+ */
+export function createGuardedFetch(
+  cfg: GuardConfig,
+  fetchImpl: typeof fetch = fetch,
+  resolver?: (host: string) => Promise<string[]>,
+): typeof fetch {
+  type FetchInput = Parameters<typeof fetch>[0];
+  return async function guardedFetch(input: FetchInput, init?: RequestInit) {
+    const raw =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : (input as { url: string }).url;
+
+    let url = new URL(raw);
+    let requestInit: RequestInit = { ...init };
+    let target: FetchInput = input;
+
+    for (let hop = 0; ; hop++) {
+      await assertDestinationAllowed(url, cfg, resolver);
+
+      const headers = new Headers(
+        requestInit.headers ??
+          (typeof target === 'object' && target !== null && 'headers' in target
+            ? (target as { headers: ConstructorParameters<typeof Headers>[0] }).headers
+            : undefined),
+      );
+      // Drop first, then re-add only if THIS hop's host is nominated.
+      headers.delete(cfg.authHeaderName);
+      if (shouldSendCredential(url, cfg)) {
+        headers.set(cfg.authHeaderName, cfg.authHeaderValue);
+      }
+
+      const res = await fetchImpl(hop === 0 ? target : url.href, {
+        ...requestInit,
+        headers,
+        redirect: 'manual',
+      });
+
+      const location = res.headers.get('location');
+      if (!isRedirectStatus(res.status) || !location) return res;
+
+      if (hop >= MAX_REDIRECTS) {
+        throw new BlockedDestinationError(url.hostname, `exceeded ${MAX_REDIRECTS} redirects`);
+      }
+
+      const next = new URL(location, url);
+      if (next.protocol !== 'http:' && next.protocol !== 'https:') {
+        throw new BlockedDestinationError(next.protocol, 'non-HTTP redirect scheme');
+      }
+
+      // Match fetch semantics: 303, and 301/302 on POST, degrade to a bodyless GET.
+      const method = (requestInit.method ?? 'GET').toUpperCase();
+      if (res.status === 303 || ((res.status === 301 || res.status === 302) && method === 'POST')) {
+        requestInit = { ...requestInit, method: 'GET', body: undefined };
+      }
+
+      url = next;
+      target = url.href;
+    }
+  } as typeof fetch;
+}

--- a/plugins/mcp/a2a-client/tests/card-audit.test.ts
+++ b/plugins/mcp/a2a-client/tests/card-audit.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentCard } from '@a2a-js/sdk';
+import { auditCard, claimsOf, REQUIRED_CARD_FIELDS } from '../servers/card-audit.js';
+
+/** A minimal card that satisfies every required field, for tests to mutate. */
+function validCard(overrides: Partial<AgentCard> = {}): AgentCard {
+  return {
+    name: 'Incident Summarizer',
+    description: 'Summarizes incident timelines.',
+    version: '1.2.0',
+    supportedInterfaces: [
+      {
+        url: 'https://agents.example.com/a2a/v1',
+        protocolBinding: 'JSONRPC',
+        protocolVersion: '1.0',
+        tenant: '',
+      },
+    ],
+    capabilities: { streaming: false, pushNotifications: false, extensions: [] },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/markdown'],
+    skills: [
+      {
+        id: 'summarize',
+        name: 'Summarize',
+        description: 'Condense a timeline.',
+        tags: ['incident'],
+        examples: [],
+        inputModes: [],
+        outputModes: [],
+        securityRequirements: [],
+      },
+    ],
+    signatures: [],
+    securitySchemes: {},
+    securityRequirements: [],
+    ...overrides,
+  } as unknown as AgentCard;
+}
+
+describe('structure verdict', () => {
+  it('accepts a card carrying every required field', () => {
+    const audit = auditCard(validCard());
+    expect(audit.structure).toBe('valid');
+    expect(audit.missingFields).toEqual([]);
+  });
+
+  it.each(REQUIRED_CARD_FIELDS)('reports %s as missing when absent', (field) => {
+    const card = validCard();
+    delete (card as unknown as Record<string, unknown>)[field];
+    const audit = auditCard(card);
+    expect(audit.structure).toBe('malformed');
+    expect(audit.missingFields).toContain(field);
+  });
+
+  it('treats an empty required array as missing, not as present-but-thin', () => {
+    const audit = auditCard(validCard({ skills: [] } as Partial<AgentCard>));
+    expect(audit.missingFields).toContain('skills');
+  });
+});
+
+describe('interface findings', () => {
+  it('flags a private-range interface URL for an operator decision', () => {
+    const audit = auditCard(
+      validCard({
+        supportedInterfaces: [
+          {
+            url: 'https://10.0.0.7:8443/a2a/v1',
+            protocolBinding: 'JSONRPC',
+            protocolVersion: '1.0',
+            tenant: '',
+          },
+        ],
+      } as Partial<AgentCard>),
+    );
+    const finding = audit.findings.find((f) => f.claim === 'supportedInterfaces[0].url');
+    expect(finding?.disposition).toBe('operator-decision-required');
+    expect(finding?.finding).toMatch(/private-range|loopback/);
+  });
+
+  it.each(['https://localhost/a2a', 'https://127.0.0.1/a2a', 'https://192.168.1.4/a2a', 'https://172.20.0.9/a2a'])(
+    'flags %s',
+    (url) => {
+      const audit = auditCard(
+        validCard({
+          supportedInterfaces: [
+            { url, protocolBinding: 'JSONRPC', protocolVersion: '1.0', tenant: '' },
+          ],
+        } as Partial<AgentCard>),
+      );
+      expect(audit.operatorDecisionsRequired).toBeGreaterThan(0);
+    },
+  );
+
+  it('flags a plaintext interface URL as a downgrade', () => {
+    const audit = auditCard(
+      validCard({
+        supportedInterfaces: [
+          {
+            url: 'http://agents.example.com/a2a/v1',
+            protocolBinding: 'JSONRPC',
+            protocolVersion: '1.0',
+            tenant: '',
+          },
+        ],
+      } as Partial<AgentCard>),
+    );
+    expect(audit.findings.some((f) => f.finding === 'Non-HTTPS interface URL.')).toBe(true);
+  });
+
+  it('does not flag a public HTTPS interface', () => {
+    const audit = auditCard(validCard());
+    expect(audit.operatorDecisionsRequired).toBe(0);
+  });
+
+  it('flags an unparseable URL rather than silently skipping it', () => {
+    const audit = auditCard(
+      validCard({
+        supportedInterfaces: [
+          { url: 'grpc.example.com:443', protocolBinding: 'GRPC', protocolVersion: '1.0', tenant: '' },
+        ],
+      } as Partial<AgentCard>),
+    );
+    expect(audit.operatorDecisionsRequired).toBe(1);
+  });
+});
+
+describe('required extensions', () => {
+  it('surfaces an extension the card marks required', () => {
+    const audit = auditCard(
+      validCard({
+        capabilities: {
+          streaming: false,
+          pushNotifications: false,
+          extensions: [
+            { uri: 'https://ext.example.com/v1', description: 'x', required: true, params: undefined },
+          ],
+        },
+      } as unknown as Partial<AgentCard>),
+    );
+    expect(
+      audit.findings.some((f) => f.claim === 'capabilities.extensions[].required'),
+    ).toBe(true);
+  });
+
+  it('does not surface an optional extension', () => {
+    const audit = auditCard(
+      validCard({
+        capabilities: {
+          streaming: false,
+          pushNotifications: false,
+          extensions: [
+            { uri: 'https://ext.example.com/v1', description: 'x', required: false, params: undefined },
+          ],
+        },
+      } as unknown as Partial<AgentCard>),
+    );
+    expect(audit.operatorDecisionsRequired).toBe(0);
+  });
+});
+
+describe('per-skill security overrides', () => {
+  const agentLevel = [{ schemes: { oauth: { list: ['read'] } } }];
+
+  it('flags a skill whose override drops an agent-level scheme', () => {
+    const card = validCard({ securityRequirements: agentLevel } as unknown as Partial<AgentCard>);
+    card.skills[0].securityRequirements = [
+      { schemes: { apiKey: { list: [] } } },
+    ] as unknown as AgentCard['skills'][number]['securityRequirements'];
+    const audit = auditCard(card);
+    const finding = audit.findings.find((f) => f.claim.startsWith('skills[summarize]'));
+    expect(finding?.disposition).toBe('operator-decision-required');
+    expect(finding?.finding).toContain('oauth');
+  });
+
+  it('does not flag a skill with no override — the agent-level baseline applies', () => {
+    const card = validCard({ securityRequirements: agentLevel } as unknown as Partial<AgentCard>);
+    expect(auditCard(card).operatorDecisionsRequired).toBe(0);
+  });
+
+  it('does not flag a skill whose override preserves the agent-level schemes', () => {
+    const card = validCard({ securityRequirements: agentLevel } as unknown as Partial<AgentCard>);
+    card.skills[0].securityRequirements = [
+      { schemes: { oauth: { list: ['read', 'write'] } } },
+    ] as unknown as AgentCard['skills'][number]['securityRequirements'];
+    expect(auditCard(card).operatorDecisionsRequired).toBe(0);
+  });
+});
+
+describe('signature honesty', () => {
+  it('reports absent when the card carries no signatures', () => {
+    expect(auditCard(validCard()).signatureStatus).toBe('absent');
+  });
+
+  it('reports unverified — never verified — when signatures are present', () => {
+    const audit = auditCard(
+      validCard({
+        signatures: [{ protected: 'eyJ', signature: 'MEU', header: undefined }],
+      } as unknown as Partial<AgentCard>),
+    );
+    expect(audit.signatureStatus).toBe('unverified');
+    expect(audit.signatureStatus).not.toBe('verified');
+  });
+});
+
+describe('card-named fetch targets', () => {
+  it('reports documentationUrl without resolving it', () => {
+    const audit = auditCard(
+      validCard({ documentationUrl: 'https://docs.example.com' } as Partial<AgentCard>),
+    );
+    const finding = audit.findings.find((f) => f.claim === 'documentationUrl');
+    expect(finding?.disposition).toBe('reported');
+    expect(finding?.finding).toContain('not resolved');
+  });
+});
+
+describe('claims reporting', () => {
+  it('labels the first interface preferred and the rest fallbacks', () => {
+    const claims = claimsOf(
+      validCard({
+        supportedInterfaces: [
+          { url: 'https://a.example.com', protocolBinding: 'JSONRPC', protocolVersion: '1.0', tenant: '' },
+          { url: 'https://b.example.com', protocolBinding: 'HTTP+JSON', protocolVersion: '1.0', tenant: '' },
+        ],
+      } as Partial<AgentCard>),
+    );
+    expect(claims.interfaces[0].preference).toBe('preferred');
+    expect(claims.interfaces[1].preference).toBe('fallback-1');
+  });
+
+  it('reports absent capabilities as false rather than assuming support', () => {
+    const claims = claimsOf(validCard({ capabilities: {} } as unknown as Partial<AgentCard>));
+    expect(claims.capabilitiesClaimed.streaming).toBe(false);
+    expect(claims.capabilitiesClaimed.pushNotifications).toBe(false);
+    expect(claims.capabilitiesClaimed.extendedAgentCard).toBe(false);
+  });
+
+  it('emits no trust score or overall verdict field', () => {
+    const claims = claimsOf(validCard()) as Record<string, unknown>;
+    const audit = auditCard(validCard()) as unknown as Record<string, unknown>;
+    for (const key of ['trustScore', 'trusted', 'safe', 'verdict']) {
+      expect(claims).not.toHaveProperty(key);
+      expect(audit).not.toHaveProperty(key);
+    }
+  });
+});

--- a/plugins/mcp/a2a-client/tests/net-guard.test.ts
+++ b/plugins/mcp/a2a-client/tests/net-guard.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BlockedDestinationError,
+  MAX_REDIRECTS,
+  assertDestinationAllowed,
+  configFromEnv,
+  createGuardedFetch,
+  isPrivateAddress,
+  shouldSendCredential,
+  type GuardConfig,
+} from '../servers/net-guard.js';
+
+function cfg(over: Partial<GuardConfig> = {}): GuardConfig {
+  return {
+    allowedHosts: new Set(),
+    allowPrivateHosts: false,
+    authHeaderName: 'Authorization',
+    authHeaderValue: '',
+    ...over,
+  };
+}
+
+/** Resolver stub so tests never touch real DNS. */
+const resolves = (map: Record<string, string[]>) => async (h: string) => {
+  if (!(h in map)) throw new Error(`no stub for ${h}`);
+  return map[h];
+};
+
+describe('isPrivateAddress', () => {
+  it.each([
+    '127.0.0.1',
+    '10.1.2.3',
+    '192.168.1.1',
+    '172.16.0.1',
+    '172.31.255.255',
+    '169.254.169.254', // cloud instance metadata — the classic SSRF target
+    '100.64.0.1', // carrier-grade NAT / tailnet range
+    '0.0.0.0',
+    '::1',
+    'fe80::1',
+    'fd00::1',
+    '::ffff:10.0.0.1', // IPv4-mapped IPv6 must not be a bypass
+  ])('flags %s as private', (addr) => {
+    expect(isPrivateAddress(addr)).toBe(true);
+  });
+
+  it.each(['8.8.8.8', '1.1.1.1', '93.184.216.34', '172.32.0.1', '2606:4700::1111'])(
+    'allows public %s',
+    (addr) => {
+      expect(isPrivateAddress(addr)).toBe(false);
+    },
+  );
+});
+
+describe('assertDestinationAllowed', () => {
+  it('refuses a literal loopback address', async () => {
+    await expect(
+      assertDestinationAllowed(new URL('https://127.0.0.1/a2a'), cfg(), resolves({})),
+    ).rejects.toBeInstanceOf(BlockedDestinationError);
+  });
+
+  it('refuses localhost by name without a DNS round trip', async () => {
+    await expect(
+      assertDestinationAllowed(new URL('https://localhost:8443/a2a'), cfg(), resolves({})),
+    ).rejects.toThrow(/loopback hostname/);
+  });
+
+  it('refuses a public NAME that resolves inward — the rebinding-style bypass', async () => {
+    await expect(
+      assertDestinationAllowed(
+        new URL('https://evil.example.com/a2a'),
+        cfg(),
+        resolves({ 'evil.example.com': ['169.254.169.254'] }),
+      ),
+    ).rejects.toThrow(/resolves to a private or loopback address/);
+  });
+
+  it('refuses when ANY resolved address is private, not just the first', async () => {
+    await expect(
+      assertDestinationAllowed(
+        new URL('https://mixed.example.com/a2a'),
+        cfg(),
+        resolves({ 'mixed.example.com': ['93.184.216.34', '10.0.0.5'] }),
+      ),
+    ).rejects.toBeInstanceOf(BlockedDestinationError);
+  });
+
+  it('refuses when DNS fails rather than falling open', async () => {
+    await expect(
+      assertDestinationAllowed(new URL('https://nx.example.com/a2a'), cfg(), resolves({})),
+    ).rejects.toThrow(/DNS resolution failed/);
+  });
+
+  it('allows a public destination', async () => {
+    await expect(
+      assertDestinationAllowed(
+        new URL('https://agents.example.com/a2a'),
+        cfg(),
+        resolves({ 'agents.example.com': ['93.184.216.34'] }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('permits private destinations only under the explicit opt-in', async () => {
+    await expect(
+      assertDestinationAllowed(
+        new URL('http://127.0.0.1:41777/a2a'),
+        cfg({ allowPrivateHosts: true }),
+        resolves({}),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('shouldSendCredential — fail closed', () => {
+  it('sends nothing when no credential is held', () => {
+    expect(
+      shouldSendCredential(new URL('https://a.example.com'), cfg({ allowedHosts: new Set(['a.example.com']) })),
+    ).toBe(false);
+  });
+
+  it('sends nothing when a credential is held but NO allowlist is configured', () => {
+    expect(
+      shouldSendCredential(new URL('https://a.example.com'), cfg({ authHeaderValue: 'Bearer t' })),
+    ).toBe(false);
+  });
+
+  it('does not send to a host outside the allowlist', () => {
+    expect(
+      shouldSendCredential(
+        new URL('https://attacker.example.com'),
+        cfg({ authHeaderValue: 'Bearer t', allowedHosts: new Set(['partner.example.com']) }),
+      ),
+    ).toBe(false);
+  });
+
+  it('sends to a nominated host', () => {
+    expect(
+      shouldSendCredential(
+        new URL('https://partner.example.com/a2a'),
+        cfg({ authHeaderValue: 'Bearer t', allowedHosts: new Set(['partner.example.com']) }),
+      ),
+    ).toBe(true);
+  });
+
+  it('matches host case-insensitively', () => {
+    expect(
+      shouldSendCredential(
+        new URL('https://Partner.Example.com/a2a'),
+        cfg({ authHeaderValue: 'Bearer t', allowedHosts: new Set(['partner.example.com']) }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('createGuardedFetch', () => {
+  const ok = () => new Response('{}', { status: 200 });
+  type FetchArgs = [Parameters<typeof fetch>[0], RequestInit | undefined];
+
+  it('blocks the request before it reaches fetch', async () => {
+    const inner = vi.fn(ok);
+    const g = createGuardedFetch(cfg(), inner as unknown as typeof fetch, resolves({}));
+    await expect(g('https://10.0.0.9/a2a')).rejects.toBeInstanceOf(BlockedDestinationError);
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it('does NOT attach a credential to a non-nominated host', async () => {
+    const inner = vi.fn(ok);
+    const g = createGuardedFetch(
+      cfg({ authHeaderValue: 'Bearer secret', allowedHosts: new Set(['partner.example.com']) }),
+      inner as unknown as typeof fetch,
+      resolves({ 'attacker.example.com': ['93.184.216.34'] }),
+    );
+    await g('https://attacker.example.com/a2a');
+    expect(inner).toHaveBeenCalledOnce();
+    const [, init] = inner.mock.calls[0] as unknown as FetchArgs;
+    expect(new Headers(init!.headers).get('Authorization')).toBeNull();
+  });
+
+  it('attaches the credential to a nominated host', async () => {
+    const inner = vi.fn(ok);
+    const g = createGuardedFetch(
+      cfg({ authHeaderValue: 'Bearer secret', allowedHosts: new Set(['partner.example.com']) }),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await g('https://partner.example.com/a2a');
+    const [, init] = inner.mock.calls[0] as unknown as FetchArgs;
+    expect(new Headers(init!.headers).get('Authorization')).toBe('Bearer secret');
+  });
+
+  it('honours a custom auth header name', async () => {
+    const inner = vi.fn(ok);
+    const g = createGuardedFetch(
+      cfg({
+        authHeaderName: 'X-Api-Key',
+        authHeaderValue: 'k123',
+        allowedHosts: new Set(['partner.example.com']),
+      }),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await g('https://partner.example.com/a2a');
+    const [, init] = inner.mock.calls[0] as unknown as FetchArgs;
+    expect(new Headers(init!.headers).get('X-Api-Key')).toBe('k123');
+  });
+
+  // --- Redirect handling. Each of these fails if `redirect: 'manual'` and the
+  // per-hop re-check are removed, which is exactly what they exist to pin.
+  const redirectTo = (loc: string, status = 302) =>
+    new Response(null, { status, headers: { location: loc } });
+
+  it("never lets the runtime follow redirects — always requests redirect: 'manual'", async () => {
+    const inner = vi.fn(ok);
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await g('https://partner.example.com/a2a');
+    const [, init] = inner.mock.calls[0] as unknown as FetchArgs;
+    expect(init?.redirect).toBe('manual');
+  });
+
+  it('refuses a redirect into cloud instance metadata (the 169.254.169.254 bypass)', async () => {
+    const inner = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('http://169.254.169.254/latest/meta-data/'))
+      .mockResolvedValue(ok());
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await expect(g('https://partner.example.com/a2a')).rejects.toBeInstanceOf(
+      BlockedDestinationError,
+    );
+    // The hop was refused by the guard, never handed to fetch.
+    expect(inner).toHaveBeenCalledOnce();
+  });
+
+  it('refuses a redirect to a host that resolves privately', async () => {
+    const inner = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('https://rebind.example.com/x'))
+      .mockResolvedValue(ok());
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({
+        'partner.example.com': ['93.184.216.34'],
+        'rebind.example.com': ['10.0.0.9'],
+      }),
+    );
+    await expect(g('https://partner.example.com/a2a')).rejects.toBeInstanceOf(
+      BlockedDestinationError,
+    );
+  });
+
+  it('drops the credential when a nominated host redirects to a non-nominated one', async () => {
+    const inner = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('https://attacker.example.com/steal'))
+      .mockResolvedValue(ok());
+    const g = createGuardedFetch(
+      cfg({ authHeaderValue: 'Bearer secret', allowedHosts: new Set(['partner.example.com']) }),
+      inner as unknown as typeof fetch,
+      resolves({
+        'partner.example.com': ['93.184.216.34'],
+        'attacker.example.com': ['93.184.216.35'],
+      }),
+    );
+    await g('https://partner.example.com/a2a');
+    expect(inner).toHaveBeenCalledTimes(2);
+    const [, first] = inner.mock.calls[0] as unknown as FetchArgs;
+    const [, second] = inner.mock.calls[1] as unknown as FetchArgs;
+    expect(new Headers(first!.headers).get('Authorization')).toBe('Bearer secret');
+    expect(new Headers(second!.headers).get('Authorization')).toBeNull();
+  });
+
+  it('refuses a non-HTTP redirect scheme', async () => {
+    const inner = vi.fn().mockResolvedValueOnce(redirectTo('file:///etc/passwd'));
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await expect(g('https://partner.example.com/a2a')).rejects.toBeInstanceOf(
+      BlockedDestinationError,
+    );
+  });
+
+  it('caps redirect chains instead of looping forever', async () => {
+    const inner = vi.fn(() => redirectTo('https://partner.example.com/next'));
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await expect(g('https://partner.example.com/a2a')).rejects.toThrow(/exceeded \d+ redirects/);
+    expect(inner.mock.calls.length).toBeLessThanOrEqual(MAX_REDIRECTS + 1);
+  });
+
+  it('follows a permitted redirect and returns the final response', async () => {
+    const inner = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('https://partner.example.com/moved'))
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    const res = await g('https://partner.example.com/a2a');
+    expect(res.status).toBe(200);
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades 303 to a bodyless GET', async () => {
+    const inner = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('https://partner.example.com/result', 303))
+      .mockResolvedValue(ok());
+    const g = createGuardedFetch(
+      cfg(),
+      inner as unknown as typeof fetch,
+      resolves({ 'partner.example.com': ['93.184.216.34'] }),
+    );
+    await g('https://partner.example.com/a2a', { method: 'POST', body: '{"a":1}' });
+    const [, second] = inner.mock.calls[1] as unknown as FetchArgs;
+    expect(second?.method).toBe('GET');
+    expect(second?.body).toBeUndefined();
+  });
+});
+
+describe('configFromEnv', () => {
+  it('defaults to fail-closed: no allowlist, no private hosts, no credential', () => {
+    const c = configFromEnv({});
+    expect(c.allowedHosts.size).toBe(0);
+    expect(c.allowPrivateHosts).toBe(false);
+    expect(c.authHeaderValue).toBe('');
+  });
+
+  it('parses a comma-separated allowlist, trimming and lowercasing', () => {
+    const c = configFromEnv({ A2A_ALLOWED_HOSTS: ' Partner.example.com , b.example.com ' });
+    expect([...c.allowedHosts]).toEqual(['partner.example.com', 'b.example.com']);
+  });
+
+  it('formats a bearer token and prefers it over a raw api key', () => {
+    const c = configFromEnv({ A2A_BEARER_TOKEN: 't', A2A_API_KEY: 'k' });
+    expect(c.authHeaderValue).toBe('Bearer t');
+  });
+
+  it('uses a raw api key when no bearer token is set', () => {
+    expect(configFromEnv({ A2A_API_KEY: 'k' }).authHeaderValue).toBe('k');
+  });
+
+  it('only opts into private hosts on an exact "1"', () => {
+    expect(configFromEnv({ A2A_ALLOW_PRIVATE_HOSTS: 'true' }).allowPrivateHosts).toBe(false);
+    expect(configFromEnv({ A2A_ALLOW_PRIVATE_HOSTS: '1' }).allowPrivateHosts).toBe(true);
+  });
+});

--- a/plugins/mcp/a2a-client/tsconfig.json
+++ b/plugins/mcp/a2a-client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "lib": ["ES2022"],
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["servers/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/mcp/a2a-client/vitest.config.ts
+++ b/plugins/mcp/a2a-client/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],  // Only run tests in tests/ directory
+    exclude: ['examples/**/*'],        // Exclude example files from testing
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        'tests/',
+        'examples/',
+        '**/*.config.*',
+        '**/*.d.ts'
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80
+      }
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,40 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  plugins/mcp/a2a-client:
+    dependencies:
+      '@a2a-js/sdk':
+        specifier: 1.0.1
+        version: 1.0.1(express@5.2.1)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.7.0)
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.60.0
+        version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
   plugins/mcp/ai-experiment-logger:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -731,6 +765,21 @@ importers:
   plugins/saas-packs/workhuman-pack: {}
 
 packages:
+
+  '@a2a-js/sdk@1.0.1':
+    resolution: {integrity: sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': ^1.11.0
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3749,6 +3798,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-from-package@0.0.0:
@@ -5548,6 +5598,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -5848,6 +5902,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@a2a-js/sdk@1.0.1(express@5.2.1)':
+    dependencies:
+      jose: 6.2.3
+      uuid: 11.1.1
+    optionalDependencies:
+      express: 5.2.1
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -11057,6 +11118,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.1: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## What

An MCP server that speaks the **A2A (Agent2Agent) protocol as a client** — resolves a remote agent card, calls the protocol, returns results to the host agent. Ships with the outbound network guard every request passes through, 75 tests, `docs/PRD.md` + `docs/ADR.md`, and its catalog entry.

## Why this, separately

Split out of #1169, which is being closed. That PR bundled this server with a six-skill `agent-comms` pack whose centrepiece (`agent-mailbox`) an adversarial review concluded should not ship: ExaDev publicly documented abandoning that exact filesystem-bus design after hitting orphaned files, polling overhead, write races, and stale-agent detection.

The strategy question behind the pack is unresolved and gated on demand evidence (`000-docs/713` § 5). **This server is not.** It stands on its own merits, is independently verified, and does not depend on how the fabric question lands.

*Chose split-and-close over holding the whole PR* because the fabric decision has no deadline; carrying a bundled PR against it accrues branch rot on finished code, and this repo's credibility rests on a three-check gate that a long-lived red PR erodes.

## Layer(s) touched

New plugin under `plugins/mcp/`. Catalog entry in `marketplace.extended.json`; `marketplace.json` + README TOC are **derived** via `pnpm run sync-marketplace`, not hand-edited. No existing plugin surface changed.

## How it works — security posture

Two fail-closed rules in `servers/net-guard.ts`, the single choke point:

- **Destination.** Private, loopback, link-local, and carrier-grade-NAT addresses refused unless `A2A_ALLOW_PRIVATE_HOSTS=1`. Hostnames are resolved and *every* returned address checked, so a public name resolving inward is refused too.
- **Credentials.** A credential is attached **only** to a host listed in `A2A_ALLOWED_HOSTS`. With no allowlist configured, no credential is ever sent.

Redirects are followed **manually** so every hop re-enters `assertDestinationAllowed` and re-evaluates the credential against that hop's host. This carries the SSRF + credential-egress fix from `0548b13b1`: previously the guard validated only the pre-flight URL and let the runtime follow redirects, so a permitted host answering `302 → http://169.254.169.254/latest/meta-data/` walked straight around a check that explicitly blocks link-local — and because the credential header was attached before the fetch, the redirect could egress it.

## Verification & evidence

- **75/75** vitest pass · `tsc --noEmit` clean · `eslint .` clean
- Eight tests pin the redirect behaviour and were **mutation-checked**: flipping `redirect: 'manual'` back to `'follow'` turns the suite red (1 failed / 45 passed). Per the claim rule adopted in `000-docs/713` — a capability claim is valid only when it names a test that fails if the capability is deleted.
- Catalog artifacts regenerated, not hand-edited.

## Risk assessment

Low and contained. Additive plugin. The module documents one residual it explicitly does **not** claim to close: a DNS rebind between the pre-flight resolve and the connect. Closing that needs a pinned-address dispatcher the SDK's `fetch` seam does not expose.

## Operational impact

None. No migrations, no new deploy step, no secrets required to install. Optional env: `A2A_ALLOWED_HOSTS`, `A2A_ALLOW_PRIVATE_HOSTS`, `A2A_BEARER_TOKEN` / `A2A_API_KEY`, `A2A_AUTH_HEADER_NAME`. All default to the fail-closed posture.

## Follow-up & deferred

- The `agent-comms` skills pack is **not** in this PR and has no owner yet.
- Six head-of-board calls remain open — `000-docs/713` § 5.
- DNS-rebind hardening is unscheduled; it needs a custom dispatcher.

## Governance links

- Research: `000-docs/712-RL-RSRC-agent-communication-fabric-competitive-research.md`
- Decision record: `000-docs/713-AT-DECR-isedc-agent-communication-fabric-council-record-2026-08-09.md`
- Bead: `claude-f3ql`

Refs #1169