### PR TITLE
Add: free-vision-skill (local vision source)

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1745,6 +1745,38 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # free-vision-skill (niyongsheng)
+  # https://github.com/niyongsheng/free-vision-skill
+  # ============================================================
+
+  - name: free-vision-skill
+    description: Fully-local OCR and image understanding for vision-less models via macOS Vision (text, tables, image description, QR decode)
+    repo: niyongsheng/free-vision-skill
+    source_path: .
+    target_path: plugins/community/free-vision-skill
+    author:
+      name: Nico (niyongsheng)
+      github: niyongsheng
+    license: MIT
+    category: utilities
+    verified: false
+    keywords:
+      - ocr
+      - vision
+      - macos
+      - offline
+      - local
+    include:
+      - '/SKILL.md'
+      - '/scripts/**'
+      - '/examples/**'
+      - '/README.md'
+      - '/LICENSE'
+    exclude:
+      - '/.git/**'
+      - '**/*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Adds [free-vision-skill](https://github.com/niyongsheng/free-vision-skill) as an external plugin source.

**What**: Fully-local image understanding skill for vision-less models (e.g. DeepSeek V4 Flash), powered by macOS Vision Framework:
- OCR (Chinese & English) in reading order
- Table detection (`--layout`) with coordinates
- Content description (`--describe`): classification, people/faces/animals, QR/barcode decode, aesthetics
- Zero network, zero API keys — images never leave the machine

**Repo**: https://github.com/niyongsheng/free-vision-skill (MIT, macOS 11+, tested with Claude Code)