### PR TITLE
feat(sources): add youtube-skills (TranscriptAPI) via Path B auto-sync

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1745,6 +1745,37 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # TranscriptAPI YouTube Skills (Zero Point Studio)
+  # https://github.com/ZeroPointRepo/youtube-skills
+  # ============================================================
+
+  - name: youtube-skills
+    description: YouTube transcripts, video and channel search, channel browsing, and playlist extraction for AI agents — 12 installable skills backed by the TranscriptAPI REST API, no Google API quotas or OAuth.
+    repo: ZeroPointRepo/youtube-skills
+    source_path: .
+    target_path: plugins/community/youtube-skills
+    author:
+      name: Zero Point Studio
+      github: ZeroPointRepo
+    license: MIT
+    category: community
+    verified: false
+    keywords:
+      - youtube
+      - transcripts
+      - video-search
+      - channels
+      - playlists
+    include:
+      - 'skills/**'
+      - 'README.md'
+      - 'LICENSE'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+      - '*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Adds a single **Path B** entry to `sources.yaml` for [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills), so the upstream repo stays the source of truth and the weekly sync mirrors `skills/**`, `README.md` and `LICENSE` into `plugins/community/youtube-skills`. One file changed, +31 lines.

### What the plugin does

12 Agent Skills for pulling YouTube content: transcripts (with a language priority list), video and channel search, channel browsing, in-channel search, playlist extraction, and free RSS-based new-upload tracking. They call the TranscriptAPI REST API, so an agent gets YouTube data without Google API quotas or OAuth. Auth is a single `TRANSCRIPT_API_KEY` bearer token declared in each skill's `required_environment_variables`; a free account gets 100 credits with no card.

Every skill is prose plus documented HTTP calls: no scripts, no hooks, no MCP server, no bundled binaries. The only network destination is `transcriptapi.com`.

### Why it might earn a spot

`youtube-full` is the one-skill entry point (the other 11 are narrower slices, e.g. `transcript`, `youtube-search`, `youtube-channels`, `youtube-playlist`). The repo is MIT, 498 stars, and the skills are also published on ClawHub, where `youtube-full` has ~13.4k installs.

### Entry details

- `category: community`, `verified: false` (left for maintainer vetting per the 699 playbook)
- `source_path: .` with `include: ['skills/**', 'README.md', 'LICENSE']` so the mirror stays lean, the `clawhub/` runtime variants are not synced
- Schema matches the existing entries: `name` unique, `author.name` / `author.github`, standard exclude globs; `sources.yaml` parses clean and the 65 source names remain unique
- No `.claude-plugin/plugin.json` upstream yet, since the repo targets the plain Agent Skills layout. Happy to add one upstream if the catalog generator needs it, just say the word.
- No hand-edits to `README.md` or the marketplace catalogs, those are generated.

Disclosure: TranscriptAPI is an independent service from Zero Point Studio and is not affiliated with, endorsed by, or sponsored by YouTube or Google.
