### PR TITLE
fix(docs-governance): stop the workspace ignore rule from hiding the published Learning Lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,17 @@ test-marketplace/
 test-results/
 tmp/
 website/
-workspace/
+# workspace/ stays a scratch sandbox by default — but NOT as `workspace/`, which
+# excludes the directory itself so git never descends and no `!` rule inside can
+# ever fire. `workspace/*` excludes the CONTENTS, leaving the dir walkable.
+workspace/*
+# ...EXCEPT the Learning Lab, which is published teaching material: root README
+# L917/925/926 and the four /learning/* site pages link these files on GitHub, so
+# untracking them 404s public links. They were already wiped once by an unrelated
+# sync commit and needed a CRITICAL RECOVERY (da09e99d7, 2025-12-21). Two-part
+# rule because git cannot re-include files inside an excluded directory.
+!workspace/lab/
+!workspace/lab/**
 yarn-error.log
 yarn.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -179,7 +179,7 @@ website/
 # ever fire. `workspace/*` excludes the CONTENTS, leaving the dir walkable.
 workspace/*
 # ...EXCEPT the Learning Lab, which is published teaching material: root README
-# L917/925/926 and the four /learning/* site pages link these files on GitHub, so
+# L917/925/926 and the eight /learning/* site pages link these files on GitHub, so
 # untracking them 404s public links. They were already wiped once by an unrelated
 # sync commit and needed a CRITICAL RECOVERY (da09e99d7, 2025-12-21). Two-part
 # rule because git cannot re-include files inside an excluded directory.

--- a/scripts/check-docs-ignore-policy.mjs
+++ b/scripts/check-docs-ignore-policy.mjs
@@ -66,6 +66,21 @@ const FIXTURES = [
   ['000-docs/scratch.tmp', true, 'runtime/temp files stay local'],
   ['plugins/other-pack/000-docs/private-notes.md', true, 'nested per-pack private docs stay local'],
   ['scripts/.kernel-shadow/report.json', true, 'generated CI artifacts stay local'],
+  // Learning Lab: published teaching material linked from README L917/925/926 and
+  // the four /learning/* site pages. Wiped once already (CRITICAL RECOVERY
+  // da09e99d7, 2025-12-21) — these assertions keep the ignore rule from re-hiding it.
+  [
+    'workspace/lab/GUIDE-00-START-HERE.md',
+    false,
+    'published Learning Lab guide must stay trackable',
+  ],
+  [
+    'workspace/lab/GUIDE-99-BRAND-NEW.md',
+    false,
+    'a NEW Learning Lab guide must be trackable, not silently ignored',
+  ],
+  ['workspace/scratch-notes.md', true, 'workspace outside lab/ stays a scratch sandbox'],
+  ['workspace/experiments/throwaway.py', true, 'workspace sandbox subdirs stay ignored'],
 ];
 
 let failures = 0;

--- a/scripts/check-docs-ignore-policy.mjs
+++ b/scripts/check-docs-ignore-policy.mjs
@@ -67,7 +67,7 @@ const FIXTURES = [
   ['plugins/other-pack/000-docs/private-notes.md', true, 'nested per-pack private docs stay local'],
   ['scripts/.kernel-shadow/report.json', true, 'generated CI artifacts stay local'],
   // Learning Lab: published teaching material linked from README L917/925/926 and
-  // the four /learning/* site pages. Wiped once already (CRITICAL RECOVERY
+  // the eight /learning/* site pages. Wiped once already (CRITICAL RECOVERY
   // da09e99d7, 2025-12-21) — these assertions keep the ignore rule from re-hiding it.
   [
     'workspace/lab/GUIDE-00-START-HERE.md',


### PR DESCRIPTION
## What

One commit, 2 files. Replaces the directory-level `workspace/` ignore with `workspace/*` + `!workspace/lab/` + `!workspace/lab/**`, and pins the behavior with 4 new assertions in `check-docs-ignore-policy.mjs` (17 → 21).

## Why + decision rationale

`workspace/lab/` is **published teaching material, not scratch** — ~3,222 lines of Learning Lab guides. Root `README.md` L917/925/926 link them ("Start Here", "Architecture Deep Dive", "Architecture Map", "System Summary"), and all four `marketplace/src/pages/learning/*.astro` pages render a *View Full Guide on GitHub →* button pointing straight at `workspace/lab/*.md`. If those files leave tracking, every one of those public links 404s.

They have already been lost once: `da09e99d7` (2025-12-21) — *"CRITICAL RECOVERY: Restored files accidentally deleted in bd sync commit (7afd7b84)"* — restored all five guides. The ignore rule is what leaves them one mistake from a repeat: the 18 tracked files survive only because git exempts already-tracked files from ignore rules, while any **new** lab file is silently dropped. Same failure class as the 200-document invisibility fixed in #1175, smaller blast radius.

Chose **narrowing over deleting** the rule so the documented sandbox intent survives — `workspace/scratch-notes.md` and `workspace/experiments/**` stay ignored.

**`workspace/*` rather than `workspace/` is load-bearing, not cosmetic.** A directory-level exclusion stops git descending, so no `!` rule inside can ever fire — the exact trap this `.gitignore` already documents for its 000-docs rules, and which the first attempt at this fix walked straight into (caught by the new assertions before commit).

## Layer(s) touched

Ignore semantics for `workspace/` only, plus assertions in the existing `doc-governance` gate. No code, catalog, schema, or site changes. No file contents touched.

## Verification & evidence

- 8 hand-run `git check-ignore --no-index` assertions: 5 lab paths TRACKABLE (including brand-new files like `GUIDE-99` and `exercises/exercise-9-new.md`), 3 sandbox paths IGNORED.
- Gate: `docs-ignore-policy: 21 assertions OK`; citation gate unchanged (`20 baselined, 0 new`).
- `git ls-files workspace/` still returns the same 18 files; un-ignoring surfaced **zero** unexpected files (`git status` clean apart from the two intended edits).
- **Negative test:** reinstating the broken `workspace/` form makes the gate print both Learning Lab assertions as failures — the regression is genuinely caught, not just asserted.
- Secret-pattern scan of the diff: 0.

## Risk assessment

Ignore-only; tracked files are immune to ignore rules either way, so no content can be lost by this change. Worst case is a sandbox path becoming visible in `git status`, which is loud and harmless.

## Operational impact

New files under `workspace/lab/` now behave normally (plain `git add`). Anything else under `workspace/` remains a scratch sandbox.

## Rollback

`git revert 89ace401e`.

## Refs

Bead `claude-5awj.7` · register doc 719 row 10 · prior incident `da09e99d7`.