### PR TITLE
feat(sources): add agent-memory-discipline external skill source

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1745,6 +1745,40 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # Mnemoverse (agent-memory-discipline)
+  # https://github.com/mnemoverse/agent-memory-discipline
+  # Submission: #1180
+  # ============================================================
+
+  - name: agent-memory-discipline
+    description: Standing rules for when an agent recalls from long-term memory before acting and when it saves durable decisions, corrections and failures afterwards. Backend-neutral.
+    repo: mnemoverse/agent-memory-discipline
+    source_path: .
+    target_path: plugins/community/agent-memory-discipline
+    author:
+      name: Mnemoverse
+      github: mnemoverse
+    license: CC0-1.0
+    category: community
+    verified: false
+    keywords:
+      - agent-memory
+      - long-term-memory
+      - context-engineering
+      - mcp
+      - agent-skills
+    include:
+      - '/.claude-plugin/plugin.json'
+      - '/.claude-plugin/marketplace.json'
+      - '/skills/agent-memory-discipline/SKILL.md'
+      - '/README.md'
+      - '/LICENSE'
+    exclude:
+      - '/.git/**'
+      - '**/node_modules/**'
+      - '**/*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
## Type of Change

- [x] New external plugin source
- [x] Configuration change
- [ ] Vendored plugin submission
- [ ] Marketplace website update

## Description

**Summary:** Register `mnemoverse/agent-memory-discipline` as a Path B external
source. Upstream stays the source of truth. The weekly sync mirrors five
root-anchored files into `plugins/community/agent-memory-discipline`. This PR
changes one file, `sources.yaml`, and nothing else.

**Motivation:** Connecting a memory tool does not make an agent use it. The tool
registers, the session runs, and nothing gets recalled or saved. This skill is the
policy layer between the two: when to recall before acting, when to save a
decision, a correction or a failure afterwards, how to write an entry that is
still useful weeks later, and why a superseded entry should be closed with its
validity window instead of overwritten. It is backend-neutral, so it works with a
plain folder of Markdown files, a local MCP server, or a hosted service.

**Overlap:** `plugins/community/` already has `mnemos`, `claude-never-forgets` and
`ejentum-memory`. Those are memory backends with their own storage. This is a
policy skill with no backend and no dependency, so it composes with them rather
than competing.

**Related Issues:** Closes #1180

## Submission Standard (plugin & source submissions)

- [x] This PR links its submission issue.
- [x] Uses the documented Path B external-source route.
- [ ] The required docs for my declared tier are included. Not applicable: per
      CONTRIBUTING, external mirrors are exempt from `check-submission-docs`
      because their docs live upstream.
- [x] Validator run locally, output below.
- [x] Source vetted per the external-source vetting playbook, evidence below.
- [x] `verified: false`, `curated:` not set. Both flags are honest.

## External-source vet evidence

- Upstream: `mnemoverse/agent-memory-discipline`, public, MIT-compatible CC0-1.0
  `LICENSE` at root.
- Tier: markdown-only. No scripts, executables, hooks, commands, agents, MCP
  configuration, environment files or dependencies are admitted by the include
  globs.
- Globs: every include is root-anchored, so nested or unrelated upstream files
  cannot enter the mirror. Five files exactly.
- Credentials: none. The skill declares no network tool and calls no external API,
  so no `scan-allowlist.txt` waiver is needed.
- Typosquat check: no `agent-memory-discipline` collision in the current catalog.
- License: CC0-1.0, a public domain dedication, so downstream use is unrestricted.

## Plugin Details

- **Plugin Name:** agent-memory-discipline
- **Category:** community
- **Version:** 1.0.0
- **Keywords:** agent-memory, long-term-memory, context-engineering, mcp,
  agent-skills
- **Target:** `plugins/community/agent-memory-discipline`

**Components Included:**

- [ ] Commands
- [ ] Agents
- [ ] Hooks
- [ ] Scripts
- [ ] MCP servers

One skill. Nothing else.

**Dependencies:** none.

## Testing Evidence

```
python3 scripts/validate-skills-schema.py --marketplace --verbose <plugin-dir>
CLAUDE CODE PLUGIN VALIDATOR v7.0 / schema 3.16.1 (marketplace tier)
Average skill score: 76.0/100
```

Zero frontmatter errors. All eight marketplace-required frontmatter fields are
present. Unicode hygiene is clean, the body is plain ASCII.

**Where it does not meet the bar, stated plainly.** The seven validator errors are
all the same thing: the skill does not carry `## Overview`, `## Prerequisites`,
`## Instructions`, `## Output`, `## Error Handling`, `## Examples` and
`## Resources`. It is a policy skill rather than a procedure skill. The body is a
set of standing rules with a worked example and a checklist. It has no
prerequisites, no output format and no error surface, and padding it into that
shape would make it worse. So the entry ships `verified: false` and I am not
claiming A grade. If you want it at your bar, your CONTRIBUTING already describes
the path: open an issue on the upstream repo and I will take the PR.

## Security

- Related alerts: none.
- Impact assessment: None. Markdown only, no executable content, no network
  surface, no credential handling.

## Affiliation

I work on Mnemoverse, which is one hosted memory implementation. The skill names
it once, in a closing line, alongside a plain Markdown folder and a local MCP
server as equally valid backends. The rules themselves reference no vendor, and
the CC0-1.0 license means anyone can fork it and remove that line.
