### PR TITLE
fix(plugins-packages): quarantine externally mirrored packages

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -257,6 +257,14 @@ jobs:
             fi
           done
 
+      # Every package-bearing external mirror is non-publishable. Provenance
+      # comes only from .source.json; this prevents a mirror from entering a
+      # future publish candidate list through a naming or path convention.
+      - name: Enforce private external mirror packages
+        run: |
+          node --test scripts/check-mirror-packages-private.test.mjs
+          node scripts/check-mirror-packages-private.mjs
+
       - name: Validate marketplace catalog
         run: |
           echo "Validating marketplace catalog..."

--- a/plugins/ai-agency/hyperflow/package.json
+++ b/plugins/ai-agency/hyperflow/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hyperflow",
+  "private": true,
   "version": "5.9.0",
   "description": "Point it at a GitHub issue, get back a reviewed pull request. Multi-agent orchestration for Claude Code, Codex, OpenCode, Grok, Antigravity & Cursor — every step reviewed, memory that stays in your repo.",
   "type": "module",

--- a/plugins/ai-agency/tonone/package.json
+++ b/plugins/ai-agency/tonone/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/tonone",
+  "private": true,
   "version": "0.9.21",
   "description": "Engineering + Product team — 23 agents as Claude Code specialists. Infrastructure, DevOps, backend, security, ML/AI, mobile, UX, analytics, growth, strategy, and more.",
   "keywords": [

--- a/plugins/api-development/x-twitter-scraper/package.json
+++ b/plugins/api-development/x-twitter-scraper/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/x-twitter-scraper",
+  "private": true,
   "version": "0.1.0",
   "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
   "keywords": [

--- a/plugins/business-tools/wondelai-blue-ocean-strategy/package.json
+++ b/plugins/business-tools/wondelai-blue-ocean-strategy/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-blue-ocean-strategy",
+  "private": true,
   "version": "1.0.2",
   "description": "Blue Ocean Strategy framework for creating uncontested market space",
   "keywords": [

--- a/plugins/business-tools/wondelai-contagious/package.json
+++ b/plugins/business-tools/wondelai-contagious/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-contagious",
+  "private": true,
   "version": "1.0.2",
   "description": "Word-of-mouth and virality framework using the STEPPS model",
   "keywords": [

--- a/plugins/business-tools/wondelai-cro-methodology/package.json
+++ b/plugins/business-tools/wondelai-cro-methodology/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-cro-methodology",
+  "private": true,
   "version": "1.0.2",
   "description": "Customer-centric conversion rate optimization methodology",
   "keywords": [

--- a/plugins/business-tools/wondelai-crossing-the-chasm/package.json
+++ b/plugins/business-tools/wondelai-crossing-the-chasm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-crossing-the-chasm",
+  "private": true,
   "version": "1.0.4",
   "description": "Technology adoption and go-to-market strategy for mainstream markets",
   "keywords": [

--- a/plugins/business-tools/wondelai-drive-motivation/package.json
+++ b/plugins/business-tools/wondelai-drive-motivation/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-drive-motivation",
+  "private": true,
   "version": "1.0.2",
   "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose)",
   "keywords": [

--- a/plugins/business-tools/wondelai-hundred-million-offers/package.json
+++ b/plugins/business-tools/wondelai-hundred-million-offers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-hundred-million-offers",
+  "private": true,
   "version": "1.0.3",
   "description": "Grand Slam Offer creation framework for irresistible pricing",
   "keywords": [

--- a/plugins/business-tools/wondelai-influence-psychology/package.json
+++ b/plugins/business-tools/wondelai-influence-psychology/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-influence-psychology",
+  "private": true,
   "version": "1.0.2",
   "description": "Persuasion science framework based on Cialdini's six principles",
   "keywords": [

--- a/plugins/business-tools/wondelai-jobs-to-be-done/package.json
+++ b/plugins/business-tools/wondelai-jobs-to-be-done/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-jobs-to-be-done",
+  "private": true,
   "version": "1.0.2",
   "description": "Strategic product innovation framework using JTBD theory",
   "keywords": [

--- a/plugins/business-tools/wondelai-made-to-stick/package.json
+++ b/plugins/business-tools/wondelai-made-to-stick/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-made-to-stick",
+  "private": true,
   "version": "1.0.2",
   "description": "Sticky messaging framework using the SUCCESs model",
   "keywords": [

--- a/plugins/business-tools/wondelai-negotiation/package.json
+++ b/plugins/business-tools/wondelai-negotiation/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-negotiation",
+  "private": true,
   "version": "1.0.2",
   "description": "Tactical negotiation framework based on Chris Voss's techniques",
   "keywords": [

--- a/plugins/business-tools/wondelai-obviously-awesome/package.json
+++ b/plugins/business-tools/wondelai-obviously-awesome/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-obviously-awesome",
+  "private": true,
   "version": "1.0.3",
   "description": "Product positioning framework for competitive differentiation",
   "keywords": [

--- a/plugins/business-tools/wondelai-one-page-marketing/package.json
+++ b/plugins/business-tools/wondelai-one-page-marketing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-one-page-marketing",
+  "private": true,
   "version": "1.0.2",
   "description": "End-to-end marketing plan framework in a single page",
   "keywords": [

--- a/plugins/business-tools/wondelai-predictable-revenue/package.json
+++ b/plugins/business-tools/wondelai-predictable-revenue/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-predictable-revenue",
+  "private": true,
   "version": "1.0.2",
   "description": "Outbound sales methodology for scalable B2B pipeline",
   "keywords": [

--- a/plugins/business-tools/wondelai-scorecard-marketing/package.json
+++ b/plugins/business-tools/wondelai-scorecard-marketing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-scorecard-marketing",
+  "private": true,
   "version": "1.0.2",
   "description": "Lead generation framework using quiz and assessment funnels",
   "keywords": [

--- a/plugins/business-tools/wondelai-storybrand-messaging/package.json
+++ b/plugins/business-tools/wondelai-storybrand-messaging/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-storybrand-messaging",
+  "private": true,
   "version": "1.0.2",
   "description": "StoryBrand messaging framework that positions customer as hero",
   "keywords": [

--- a/plugins/business-tools/wondelai-traction-eos/package.json
+++ b/plugins/business-tools/wondelai-traction-eos/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-traction-eos",
+  "private": true,
   "version": "1.0.2",
   "description": "Entrepreneurial Operating System for business execution",
   "keywords": [

--- a/plugins/community/ejentum-anti-deception/package.json
+++ b/plugins/community/ejentum-anti-deception/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/ejentum-anti-deception",
+  "private": true,
   "version": "0.1.5",
   "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, int",
   "keywords": [

--- a/plugins/community/ejentum-code/package.json
+++ b/plugins/community/ejentum-code/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/ejentum-code",
+  "private": true,
   "version": "0.1.5",
   "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern ",
   "keywords": [

--- a/plugins/community/ejentum-memory/package.json
+++ b/plugins/community/ejentum-memory/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/ejentum-memory",
+  "private": true,
   "version": "0.1.5",
   "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detectio",
   "keywords": [

--- a/plugins/community/ejentum-reasoning/package.json
+++ b/plugins/community/ejentum-reasoning/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/ejentum-reasoning",
+  "private": true,
   "version": "0.1.5",
   "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable proced",
   "keywords": [

--- a/plugins/community/gastown/package.json
+++ b/plugins/community/gastown/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/gastown",
+  "private": true,
   "version": "1.0.2",
   "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
   "keywords": [

--- a/plugins/community/hermes-tweet/package.json
+++ b/plugins/community/hermes-tweet/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/hermes-tweet",
+  "private": true,
   "version": "0.1.6",
   "description": "Native Hermes Agent X/Twitter plugin for Xquik automation with read-first workflows and approval-gated actions.",
   "keywords": [

--- a/plugins/community/llm-box/package.json
+++ b/plugins/community/llm-box/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/llm-box",
+  "private": true,
   "version": "0.3.0",
   "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English descriptions. Features 20+ built-in nodes, 15+ LLM providers (Ollama, DeepSeek, OpenAI-compatible), an",
   "keywords": [

--- a/plugins/community/mnemos/package.json
+++ b/plugins/community/mnemos/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/mnemos",
+  "private": true,
   "version": "0.9.0",
   "description": "Persistent memory and learning-loop skills for AI coding agents. MCP-native with 20 tools, single Go binary, ships with measured efficacy harness.",
   "keywords": [

--- a/plugins/community/portaljs/package.json
+++ b/plugins/community/portaljs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/portaljs",
+  "private": true,
   "version": "0.1.0",
   "description": "Agentic skills for building PortalJS data portals — recommend an architecture, scaffold a portal, add datasets, charts, and maps, connect a CKAN backend, deploy, and audit data quality.",
   "keywords": [

--- a/plugins/community/quit-sponsor/package.json
+++ b/plugins/community/quit-sponsor/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/quit-sponsor",
+  "private": true,
   "version": "0.1.0",
   "description": "Turns an AI agent with persistent memory into a quit-smoking sponsor — evidence-based cessation protocols (44 cited sources) plus a sponsor decision tree",
   "keywords": [

--- a/plugins/community/skills-janitor/package.json
+++ b/plugins/community/skills-janitor/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/skills-janitor",
+  "private": true,
   "version": "0.1.0",
   "description": "Audit, clean and swipe-triage your Claude Code skills — honest always-loaded vs on-demand token costs, usage tracking, duplicate detection, and safe deletion (auto-fix, prune, interactive swipe TUI)",
   "keywords": [

--- a/plugins/community/walkie-talkie/package.json
+++ b/plugins/community/walkie-talkie/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/walkie-talkie",
+  "private": true,
   "version": "0.1.0",
   "description": "Cross-platform agent-to-agent comms via an append-only in-repo mailbox, with a GRILL protocol for interrogating handoffs",
   "keywords": [

--- a/plugins/community/zai-cli/package.json
+++ b/plugins/community/zai-cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/zai-cli",
+  "private": true,
   "version": "1.0.2",
   "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
   "keywords": [

--- a/plugins/crypto/aomi/package.json
+++ b/plugins/crypto/aomi/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/aomi",
+  "private": true,
   "version": "1.0.10",
   "description": "Aomi for AI agents — drive the Aomi CLI from natural-language prompts (chat, simulate, sign on-chain transactions with account-abstraction-first execution) and scaffold new Aomi apps from API specs. B",
   "keywords": [

--- a/plugins/design/brand-forge/package.json
+++ b/plugins/design/brand-forge/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/brand-forge",
+  "private": true,
   "version": "0.5.1",
   "description": "Generate on-brand logos, social templates, and marketing graphics for any brand — vector assets need no accounts or keys; AI imagery is opt-in.",
   "keywords": [

--- a/plugins/design/wondelai-design-everyday-things/package.json
+++ b/plugins/design/wondelai-design-everyday-things/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-design-everyday-things",
+  "private": true,
   "version": "1.0.2",
   "description": "Fundamental design principles for intuitive interfaces",
   "keywords": [

--- a/plugins/design/wondelai-hooked-ux/package.json
+++ b/plugins/design/wondelai-hooked-ux/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-hooked-ux",
+  "private": true,
   "version": "1.0.3",
   "description": "Hook Model framework for building habit-forming products",
   "keywords": [

--- a/plugins/design/wondelai-ios-hig-design/package.json
+++ b/plugins/design/wondelai-ios-hig-design/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-ios-hig-design",
+  "private": true,
   "version": "1.0.4",
   "description": "Native iOS app design following Apple Human Interface Guidelines",
   "keywords": [

--- a/plugins/design/wondelai-refactoring-ui/package.json
+++ b/plugins/design/wondelai-refactoring-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-refactoring-ui",
+  "private": true,
   "version": "1.0.4",
   "description": "Practical UI design system for professional interfaces",
   "keywords": [

--- a/plugins/design/wondelai-top-design/package.json
+++ b/plugins/design/wondelai-top-design/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-top-design",
+  "private": true,
   "version": "1.0.2",
   "description": "Award-winning web design framework for premium experiences",
   "keywords": [

--- a/plugins/design/wondelai-ux-heuristics/package.json
+++ b/plugins/design/wondelai-ux-heuristics/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-ux-heuristics",
+  "private": true,
   "version": "1.0.3",
   "description": "Usability heuristics and principles for UX audits",
   "keywords": [

--- a/plugins/design/wondelai-web-typography/package.json
+++ b/plugins/design/wondelai-web-typography/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-web-typography",
+  "private": true,
   "version": "1.0.2",
   "description": "Web typography framework for readable, beautiful type",
   "keywords": [

--- a/plugins/devops/sugar/package.json
+++ b/plugins/devops/sugar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/sugar",
+  "private": true,
   "version": "2.0.6",
   "description": "Sugar 🍰 - AI-powered autonomous development system for complex, multi-step development tasks",
   "keywords": [

--- a/plugins/mcp/dolt-mcp-vcs/package.json
+++ b/plugins/mcp/dolt-mcp-vcs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/dolt-mcp-vcs",
+  "private": true,
   "version": "0.1.0",
   "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server. A version-control-surface skill + expert agents over a Dolt backend — diagnosing DoltHub visibility, taming serve",
   "keywords": [

--- a/plugins/mcp/governed-second-brain/package.json
+++ b/plugins/mcp/governed-second-brain/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/governed-second-brain",
+  "private": true,
   "version": "0.1.7",
   "description": "A local-first governed second brain for Claude Code — turn your own files into cited (qmd://) memory, with every write run through deterministic governance and recorded in a tamper-evident, SHA-256 ha",
   "keywords": [

--- a/plugins/mcp/pr-to-spec/package.json
+++ b/plugins/mcp/pr-to-spec/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pr-to-spec",
+  "private": true,
   "version": "0.8.0",
   "description": "Convert code changes into structured, agent-consumable spec artifacts",
   "type": "module",

--- a/plugins/mcp/servicegraph/package.json
+++ b/plugins/mcp/servicegraph/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/servicegraph",
+  "private": true,
   "version": "0.2.1",
   "description": "Drive the ServiceGraph API — metrics-enriched business datasets for founders (agencies, directories, newsletters, and more). Ships a branded `servicegraph` skill that works against any dataset, plus 1",
   "keywords": [

--- a/plugins/mcp/slack-channel/package.json
+++ b/plugins/mcp/slack-channel/package.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-channel-slack",
+  "private": true,
   "version": "0.12.0",
   "description": "Slack channel for Claude Code — two-way chat via Socket Mode",
   "type": "module",

--- a/plugins/productivity/box-cloud-filesystem/package.json
+++ b/plugins/productivity/box-cloud-filesystem/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/box-cloud-filesystem",
+  "private": true,
   "version": "1.0.3",
   "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
   "keywords": [

--- a/plugins/productivity/claude-workflow-skills/package.json
+++ b/plugins/productivity/claude-workflow-skills/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/claude-workflow-skills",
+  "private": true,
   "version": "1.5.8",
   "description": "Common workflow skills for Claude Code sessions: promote changes through the full release cycle, audit Claude Code plugins/skills/agents, audit project standards compliance, analyse projects for impro",
   "keywords": [

--- a/plugins/productivity/claudebase/package.json
+++ b/plugins/productivity/claudebase/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/claudebase",
+  "private": true,
   "version": "0.2.11",
   "description": "Back up and restore your entire Claude Code environment to a private GitHub repo",
   "keywords": [

--- a/plugins/productivity/cli-power-skills/package.json
+++ b/plugins/productivity/cli-power-skills/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cli-power-skills",
+  "private": true,
   "version": "1.0.0",
   "description": "Agentic CLI tool skills for Claude — data processing, security scanning, API testing, web crawling, research, Python tooling, and CI automation",
   "claude": {

--- a/plugins/productivity/content-multiplier/package.json
+++ b/plugins/productivity/content-multiplier/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/content-multiplier",
+  "private": true,
   "version": "0.2.1",
   "description": "Turn one idea, post, or transcript into a week of on-brand content across every channel and language — no accounts, no API keys, no setup.",
   "keywords": [

--- a/plugins/productivity/obsidian-project-documentation/package.json
+++ b/plugins/productivity/obsidian-project-documentation/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/obsidian-project-documentation",
+  "private": true,
   "version": "3.2.11",
   "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
   "keywords": [

--- a/plugins/productivity/over-50s-health/package.json
+++ b/plugins/productivity/over-50s-health/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/over-50s-health",
+  "private": true,
   "version": "3.2.10",
   "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
   "keywords": [

--- a/plugins/productivity/pair-programmer/package.json
+++ b/plugins/productivity/pair-programmer/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/pair-programmer",
+  "private": true,
   "version": "1.0.11",
   "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
   "keywords": [

--- a/plugins/productivity/publishing-skills/package.json
+++ b/plugins/productivity/publishing-skills/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/publishing-skills",
+  "private": true,
   "version": "0.1.0",
   "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline: topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
   "keywords": [

--- a/plugins/productivity/schedule-after-usage-reset/package.json
+++ b/plugins/productivity/schedule-after-usage-reset/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/schedule-after-usage-reset",
+  "private": true,
   "version": "1.0.1",
   "description": "Automatically find the Claude usage reset time and schedule a deferred task to run right after the limit lifts.",
   "keywords": [

--- a/plugins/productivity/skyvern/package.json
+++ b/plugins/productivity/skyvern/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/skyvern",
+  "private": true,
   "version": "0.1.5",
   "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
   "keywords": [

--- a/plugins/productivity/wondelai-design-sprint/package.json
+++ b/plugins/productivity/wondelai-design-sprint/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-design-sprint",
+  "private": true,
   "version": "1.0.2",
   "description": "Google Ventures Design Sprint methodology for rapid prototyping",
   "keywords": [

--- a/plugins/productivity/wondelai-lean-startup/package.json
+++ b/plugins/productivity/wondelai-lean-startup/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/wondelai-lean-startup",
+  "private": true,
   "version": "1.0.3",
   "description": "Lean Startup methodology for validated learning and MVPs",
   "keywords": [

--- a/plugins/testing/cli-ux-tester/package.json
+++ b/plugins/testing/cli-ux-tester/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/cli-ux-tester",
+  "private": true,
   "version": "3.1.4",
   "description": "Expert UX evaluator for command-line interfaces, CLIs, terminal tools, shell scripts, and developer APIs",
   "keywords": [

--- a/plugins/testing/kobiton-automate/package.json
+++ b/plugins/testing/kobiton-automate/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intentsolutionsio/kobiton-automate",
+  "private": true,
   "version": "1.0.6",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "keywords": [

--- a/scripts/check-mirror-packages-private.mjs
+++ b/scripts/check-mirror-packages-private.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/** Enforce the publication boundary for externally mirrored plugins. */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function sourceMarkers(directory) {
+  const found = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.isSymbolicLink()) continue;
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) found.push(...sourceMarkers(path));
+    else if (entry.name === '.source.json') found.push(path);
+  }
+  return found;
+}
+
+export function scanMirrorPackages(root) {
+  const pluginsRoot = join(root, 'plugins');
+  const markers = existsSync(pluginsRoot) ? sourceMarkers(pluginsRoot) : [];
+  const packages = [];
+  const violations = [];
+
+  for (const marker of markers) {
+    const directory = dirname(marker);
+    const packagePath = join(directory, 'package.json');
+    if (!existsSync(packagePath)) continue;
+    const packageData = JSON.parse(readFileSync(packagePath, 'utf8'));
+    const item = {
+      marker: relative(root, marker),
+      packagePath: relative(root, packagePath),
+      name: packageData.name ?? '(unnamed)',
+      private: packageData.private === true,
+    };
+    packages.push(item);
+    if (!item.private) violations.push(item);
+  }
+
+  return { markerCount: markers.length, packageCount: packages.length, packages, violations };
+}
+
+export function formatReport(result) {
+  const lines = [
+    `Machine-provenance mirror markers: ${result.markerCount}`,
+    `Mirror packages with package.json: ${result.packageCount}`,
+    `Private mirror packages: ${result.packageCount - result.violations.length}`,
+  ];
+  if (result.violations.length) {
+    lines.push('Publishability violations:');
+    for (const violation of result.violations)
+      lines.push(`  ${violation.packagePath} (${violation.name})`);
+  } else {
+    lines.push('Publishability violations: 0');
+  }
+  return lines.join('\n');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const root = process.argv[2] ? resolve(process.argv[2]) : repositoryRoot;
+  const result = scanMirrorPackages(root);
+  console.log(formatReport(result));
+  if (result.violations.length) process.exitCode = 1;
+}

--- a/scripts/check-mirror-packages-private.test.mjs
+++ b/scripts/check-mirror-packages-private.test.mjs
@@ -1,0 +1,41 @@
+import { deepEqual, equal } from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+import { scanMirrorPackages } from './check-mirror-packages-private.mjs';
+
+function fixture(privateValue) {
+  const root = mkdtempSync(join(tmpdir(), 'mirror-private-'));
+  const plugin = join(root, 'plugins', 'fixture', 'example');
+  mkdirSync(plugin, { recursive: true });
+  writeFileSync(join(plugin, '.source.json'), '{"source":"upstream/example"}\n');
+  writeFileSync(
+    join(plugin, 'package.json'),
+    JSON.stringify({ name: '@example/mirror', private: privateValue }),
+  );
+  return root;
+}
+
+test('machine-provenance package passes only when private is true', () => {
+  const root = fixture(true);
+  try {
+    const result = scanMirrorPackages(root);
+    equal(result.markerCount, 1);
+    equal(result.packageCount, 1);
+    deepEqual(result.violations, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('machine-provenance package is reported when publishable', () => {
+  const root = fixture(false);
+  try {
+    const result = scanMirrorPackages(root);
+    equal(result.violations.length, 1);
+    equal(result.violations[0].name, '@example/mirror');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Implements the owner-authorized Epic 7 containment slice from bead `claude-s03q.1`.

- Uses machine-readable `.source.json` provenance to identify external mirrors.
- Sets `private: true` on every provenance-marked package manifest (63 package-bearing mirrors; 62 changed, 1 already private).
- Adds a tree-wide invariant and CI gate preventing a mirror package from becoming publishable.
- Does not edit mirrored skill content, existing published packages, npm, or external registries.

## Evidence

- `node --test scripts/check-mirror-packages-private.test.mjs`
- `node scripts/check-mirror-packages-private.mjs`
- Deliberate temporary non-private fixture exited 1.
- `pnpm run verify` passed.
- Independent clean-checkout review will rerun the invariant, negative fixture, and diff inspection before the review gate.

Stop at the independent review gate; do not merge this PR without owner authorization.
