### PR TITLE
fix(release): refuse provenance-marked mirrors

### DIFF
--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -1,4 +1,4 @@
-name: "[Manual] Publish All @intentsolutionsio Packages"
+name: '[Manual] Publish All @intentsolutionsio Packages'
 
 # One-shot mass publish. Manual trigger only — never runs on push.
 # Intended to be used once to seed the npm namespace after PR A (scaffolding)
@@ -33,7 +33,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # npm provenance
+  id-token: write # npm provenance
 
 jobs:
   guard:
@@ -65,32 +65,17 @@ jobs:
         id: list
         run: |
           set -euo pipefail
-          python3 <<'PY' > /tmp/packages.json
-          import json, os
-          out = []
-          for root, _, files in os.walk('plugins'):
-              if 'package.json' not in files:
-                  continue
-              if '.claude-plugin' not in os.listdir(root) and not os.path.isfile(os.path.join(root, 'plugin.json')):
-                  continue
-              pkg_path = os.path.join(root, 'package.json')
-              try:
-                  pkg = json.load(open(pkg_path))
-              except Exception:
-                  continue
-              name = pkg.get('name', '')
-              if not name.startswith('@intentsolutionsio/'):
-                  continue
-              if pkg.get('private'):
-                  continue
-              out.append({
-                  'name': name,
-                  'version': pkg.get('version', '0.0.0'),
-                  'dir': root,
-              })
-          out.sort(key=lambda p: p['name'])
-          print(json.dumps(out))
-          PY
+          # The shared resolver is the publisher boundary. It excludes a
+          # candidate with an applicable .source.json before dry-run, build,
+          # version changes, token use, or registry contact.
+          node scripts/publish-candidate-report.mjs \
+            --all \
+            --scope '@intentsolutionsio/' \
+            --json > /tmp/publish-report.json
+          jq -r '.mirrorSkipped[] | "Mirror skipped: \(.name) [\(.reasonCode)]"' /tmp/publish-report.json
+          jq -r '.refused[] | "Refused: \(.name) [\(.reasonCode)]"' /tmp/publish-report.json
+          jq -r '.firstPartyCandidates[] | "First-party candidate: \(.name)@\(.version)"' /tmp/publish-report.json
+          jq -c '.firstPartyCandidates' /tmp/publish-report.json > /tmp/packages.json
 
           COUNT=$(jq length /tmp/packages.json)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-changed-packages.yml
+++ b/.github/workflows/publish-changed-packages.yml
@@ -27,8 +27,8 @@ on:
       - 'plugins/**'
 
 permissions:
-  contents: write       # tag push + release creation
-  id-token: write       # npm provenance
+  contents: write # tag push + release creation
+  id-token: write # npm provenance
 
 concurrency:
   group: npm-publish-main
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2  # need previous commit to diff against
+          fetch-depth: 2 # need previous commit to diff against
 
       - name: Build change list
         id: build
@@ -59,33 +59,17 @@ jobs:
           sort -u -o /tmp/plugin-dirs.txt /tmp/plugin-dirs.txt
 
           echo "Changed plugin directories:"
-          cat /tmp/plugin-dirs.txt || true
-
-          # Filter to those with a package.json and @intentsolutionsio scope
-          python3 <<'PY' > /tmp/packages.json
-          import json, os
-          dirs = [d.strip() for d in open('/tmp/plugin-dirs.txt') if d.strip()]
-          out = []
-          for d in dirs:
-              pj = os.path.join(d, 'package.json')
-              if not os.path.isfile(pj):
-                  continue
-              try:
-                  pkg = json.load(open(pj))
-              except Exception:
-                  continue
-              name = pkg.get('name', '')
-              if not name.startswith('@intentsolutionsio/'):
-                  continue
-              if pkg.get('private'):
-                  continue
-              out.append({
-                  'name': name,
-                  'version': pkg.get('version', '0.0.0'),
-                  'dir': d,
-              })
-          print(json.dumps(out))
-          PY
+          # The resolver walks actual filesystem ancestry. It is the only
+          # publisher candidate authority: names, folder categories, and
+          # private:false cannot override an upstream source record.
+          node scripts/publish-candidate-report.mjs \
+            --changed-files /tmp/changed.txt \
+            --scope '@intentsolutionsio/' \
+            --json > /tmp/publish-report.json
+          jq -r '.mirrorSkipped[] | "Mirror skipped: \(.name) [\(.reasonCode)]"' /tmp/publish-report.json
+          jq -r '.refused[] | "Refused: \(.name) [\(.reasonCode)]"' /tmp/publish-report.json
+          jq -r '.firstPartyCandidates[] | "First-party candidate: \(.name)@\(.version)"' /tmp/publish-report.json
+          jq -c '.firstPartyCandidates' /tmp/publish-report.json > /tmp/packages.json
 
           COUNT=$(jq length /tmp/packages.json)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -265,6 +265,17 @@ jobs:
           node --test scripts/check-mirror-packages-private.test.mjs
           node scripts/check-mirror-packages-private.mjs
 
+      # E7.2: package privacy is one boundary; publisher-level provenance
+      # exclusion is the independent second boundary. This stays inside the
+      # existing validate job so ci-required gains no fourth status context.
+      - name: Refuse provenance-marked publish candidates
+        run: |
+          node --test scripts/plugin-provenance.test.mjs
+          node scripts/publish-candidate-report.mjs --all --scope '@intentsolutionsio/' --json > /tmp/e72-publish-report.json
+          jq -e '.refused | length == 0' /tmp/e72-publish-report.json
+          jq -e '[.firstPartyCandidates[] | select(.reasonCode != "FIRST_PARTY_CANDIDATE")] | length == 0' /tmp/e72-publish-report.json
+          echo "E7.2 dry-run: $(jq '.firstPartyCandidates | length' /tmp/e72-publish-report.json) first-party candidates; $(jq '.mirrorSkipped | length' /tmp/e72-publish-report.json) provenance candidates skipped; 0 refused candidates."
+
       - name: Validate marketplace catalog
         run: |
           echo "Validating marketplace catalog..."

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -29,3 +29,4 @@
 !730-AA-AACR-pr-1186-ratification.md
 !731-BL-LICN-agpl-consent-remediation-packet.md
 !732-AA-AACR-slice-1-containment.md
+!733-AA-AACR-slice-2-publisher-exclusion.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -151,6 +151,7 @@ Regenerate: list `git ls-files 000-docs` (excluding this file) in ascending NNN 
 - [730-AA-AACR-pr-1186-ratification.md](730-AA-AACR-pr-1186-ratification.md)
 - [731-BL-LICN-agpl-consent-remediation-packet.md](731-BL-LICN-agpl-consent-remediation-packet.md)
 - [732-AA-AACR-slice-1-containment.md](732-AA-AACR-slice-1-containment.md)
+- [733-AA-AACR-slice-2-publisher-exclusion.md](733-AA-AACR-slice-2-publisher-exclusion.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/733-AA-AACR-slice-2-publisher-exclusion.md
+++ b/000-docs/733-AA-AACR-slice-2-publisher-exclusion.md
@@ -1,0 +1,88 @@
+# 733-AA-AACR — Slice 2 Publisher Exclusion After-Action Review
+
+**Date:** 2026-08-15  
+**Blueprint:** document 727 §15.1, E7.2  
+**Bead:** `claude-s03q.3` — Refuse to publish any plugin directory that carries an upstream source record  
+**Status:** Implementation PR pending independent review; this pre-merge record does not claim completion
+
+## Scope and baseline
+
+This slice contains exactly E7.2. It does not activate E7.3, another Epic 7
+bead, or another epic. The baseline was measured from current `origin/main`
+`d63cb627d3ca63d2dc0ddb75477bb062b79ebc09` before editing.
+
+Publisher entry points discovered by searching for `npm publish`, `npm pack`,
+and package enumeration are:
+
+- `.github/workflows/publish-changed-packages.yml` — changed plugin paths,
+  then publish.
+- `.github/workflows/publish-all-packages.yml` — manual all-package dry run,
+  then publish.
+- `.github/workflows/cli-publish.yml` — `packages/cli`, not a plugin directory
+  and therefore outside this `.source.json` boundary.
+
+The two plugin publishers previously filtered only `private`; a nested package
+under a mirrored ancestor could therefore enter the candidate set. Baseline
+commands and results:
+
+```bash
+rg -n 'npm publish|npm pack' .github/workflows scripts
+node scripts/check-mirror-packages-private.mjs
+node scripts/publish-candidate-report.mjs --all --scope '@intentsolutionsio/' --json \
+  | jq '{first_party:(.firstPartyCandidates|length), mirror_skipped:(.mirrorSkipped|length), refused:(.refused|length)}'
+```
+
+Before the E7.2 resolver, the old private-only emulation admitted 408 scoped
+candidate directories, including nested descendants beneath provenance
+markers. The new dry-run report identifies 395 first-party candidates, skips
+71 scoped candidates by inherited provenance, and refuses 0 malformed records.
+The 71 includes 58 scoped marker roots plus 13 nested package descendants;
+the machine-readable inventory remains 63 marker roots, 58 of them scoped.
+
+The old-candidate count was reproduced without npm access using a read-only
+Node walk over plugin package manifests, requiring the existing plugin marker,
+the `@intentsolutionsio/` scope, and `private !== true`; it returned `408`.
+
+## Implemented boundary
+
+`scripts/plugin-provenance.mjs` is the sole resolver. It walks real filesystem
+ancestors, rejects traversal, distinguishes sibling records, and fails closed
+for malformed, contradictory, or unreadable records. Both plugin publishing
+workflows consume `scripts/publish-candidate-report.mjs`; provenance exclusion
+happens before build, version changes, token use, or registry contact.
+
+Reason codes are `FIRST_PARTY_CANDIDATE`, `UPSTREAM_SOURCE_RECORD`,
+`MALFORMED_SOURCE_RECORD`, `CONTRADICTORY_SOURCE_RECORD`, `PATH_TRAVERSAL`,
+and `PRIVATE_PACKAGE`. No `.source.json`, mirrored skill, package content, or
+existing published package was edited.
+
+## Tests and red proof
+
+```bash
+node --test scripts/plugin-provenance.test.mjs
+node scripts/publish-candidate-report.mjs --all --scope '@intentsolutionsio/' --json
+pnpm run verify
+```
+
+The fixture suite covers first-party acceptance, private and non-private
+mirrors, nested ancestry, sibling non-matches, malformed/unreadable/
+contradictory records, traversal, dry-run reason codes, all 63 marker roots,
+all 58 scoped roots, and zero mirror candidates in the first-party set. Its
+red proof shows the legacy private-only selector admitting a non-private mirror
+while the resolver excludes it. No test contacts npm or any other registry.
+
+## Review, rollback, and prohibited scope
+
+The focused PR must be reviewed from a clean checkout at its exact head by a
+non-implementing reviewer. The reviewer must discover both publishers, plant a
+mirror fixture, rerun the suite and dry run, and verify zero network mutation,
+zero mirrored-content changes, no name-based list, no fourth status context,
+and an accurate rollback. Rollback is a revert of the resolver, workflow
+filters, tests, and this record; it does not touch npm.
+
+Prohibited: npm or registry mutation, credentials or Environment changes,
+contributor/upstream contact, branch-protection changes, mirror-content edits,
+E7.3 or other-bead activation, and production changes.
+
+The unrelated npm `public-hoist-pattern` warning remains deferred maintenance;
+it is not part of this ratification or containment slice.

--- a/scripts/plugin-provenance.mjs
+++ b/scripts/plugin-provenance.mjs
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SOURCE_FILE = '.source.json';
+
+function inside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}
+
+function parseSourceRecord(recordPath) {
+  let value;
+  try {
+    value = JSON.parse(fs.readFileSync(recordPath, 'utf8'));
+  } catch (error) {
+    return {
+      status: 'refused',
+      reasonCode: 'MALFORMED_SOURCE_RECORD',
+      markerPath: recordPath,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const upstream = value?.synced_from;
+  if (
+    !upstream ||
+    typeof upstream !== 'object' ||
+    typeof upstream.repo !== 'string' ||
+    upstream.repo.length === 0 ||
+    typeof upstream.path !== 'string' ||
+    upstream.path.length === 0
+  ) {
+    return {
+      status: 'refused',
+      reasonCode: 'CONTRADICTORY_SOURCE_RECORD',
+      markerPath: recordPath,
+    };
+  }
+
+  return {
+    status: 'mirror',
+    reasonCode: 'UPSTREAM_SOURCE_RECORD',
+    markerPath: recordPath,
+    upstream: {
+      repo: upstream.repo,
+      path: upstream.path,
+      branch: typeof upstream.branch === 'string' ? upstream.branch : null,
+    },
+  };
+}
+
+/**
+ * Resolve provenance by walking the candidate directory and its real
+ * filesystem ancestors. A source record is an exclusion boundary; it is not
+ * inferred from names, package scopes, or directory categories.
+ */
+export function resolvePluginProvenance(candidateDir, { root = process.cwd() } = {}) {
+  const rootPath = fs.realpathSync(path.resolve(root));
+  const candidateAbsolute = path.resolve(rootPath, candidateDir);
+  if (!inside(rootPath, candidateAbsolute)) {
+    return { status: 'refused', reasonCode: 'PATH_TRAVERSAL', candidateDir: String(candidateDir) };
+  }
+  let candidatePath;
+  try {
+    candidatePath = fs.realpathSync(candidateAbsolute);
+  } catch (error) {
+    return {
+      status: 'refused',
+      reasonCode: 'UNREADABLE_CANDIDATE_PATH',
+      candidateDir: String(candidateDir),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (!inside(rootPath, candidatePath)) {
+    return { status: 'refused', reasonCode: 'PATH_TRAVERSAL', candidateDir: String(candidateDir) };
+  }
+
+  let current = candidatePath;
+  while (inside(rootPath, current)) {
+    const markerPath = path.join(current, SOURCE_FILE);
+    if (fs.existsSync(markerPath)) return parseSourceRecord(markerPath);
+    if (current === rootPath) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return { status: 'first-party', reasonCode: 'NO_UPSTREAM_SOURCE_RECORD' };
+}
+
+export function isPathInside(root, candidate) {
+  return inside(path.resolve(root), path.resolve(candidate));
+}

--- a/scripts/plugin-provenance.test.mjs
+++ b/scripts/plugin-provenance.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { buildPublishCandidateReport } from './publish-candidate-report.mjs';
+import { resolvePluginProvenance } from './plugin-provenance.mjs';
+
+function fixture() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-provenance-'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value));
+}
+
+function packageFixture(
+  root,
+  relativeDir,
+  { source = null, privateValue = false, name = '@example/fixture' } = {},
+) {
+  const directory = path.join(root, relativeDir);
+  writeJson(path.join(directory, 'package.json'), {
+    name,
+    version: '1.0.0',
+    private: privateValue,
+  });
+  writeJson(path.join(directory, '.claude-plugin', 'plugin.json'), {
+    name: name.split('/').at(-1),
+  });
+  if (source !== null) {
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(path.join(directory, '.source.json'), source);
+  }
+  return directory;
+}
+
+test('first-party package is accepted and sibling source does not false-positive', () => {
+  const root = fixture();
+  packageFixture(root, 'plugins/first-party', { name: '@intentsolutionsio/first-party' });
+  packageFixture(root, 'plugins/sibling', {
+    source: JSON.stringify({ synced_from: { repo: 'owner/repo', path: 'sibling' } }),
+    name: '@intentsolutionsio/sibling',
+  });
+  const report = buildPublishCandidateReport({ root, all: true, scope: '@intentsolutionsio/' });
+  assert.deepEqual(
+    report.firstPartyCandidates.map((row) => row.name),
+    ['@intentsolutionsio/first-party'],
+  );
+  assert.deepEqual(
+    report.mirrorSkipped.map((row) => row.name),
+    ['@intentsolutionsio/sibling'],
+  );
+});
+
+test('mirror is rejected whether private or incorrectly non-private', () => {
+  const root = fixture();
+  packageFixture(root, 'plugins/mirror-private', {
+    privateValue: true,
+    source: JSON.stringify({ synced_from: { repo: 'owner/repo', path: 'mirror-private' } }),
+    name: '@intentsolutionsio/mirror-private',
+  });
+  packageFixture(root, 'plugins/mirror-public', {
+    privateValue: false,
+    source: JSON.stringify({ synced_from: { repo: 'owner/repo', path: 'mirror-public' } }),
+    name: '@intentsolutionsio/mirror-public',
+  });
+  const report = buildPublishCandidateReport({ root, all: true, scope: '@intentsolutionsio/' });
+  assert.equal(report.firstPartyCandidates.length, 0);
+  assert.deepEqual(
+    report.mirrorSkipped.map((row) => row.name),
+    ['@intentsolutionsio/mirror-private', '@intentsolutionsio/mirror-public'],
+  );
+});
+
+test('nested source ancestor is rejected and path traversal is refused', () => {
+  const root = fixture();
+  packageFixture(root, 'plugins/nested/mirror', {
+    name: '@intentsolutionsio/nested-mirror',
+  });
+  fs.writeFileSync(
+    path.join(root, 'plugins/nested', '.source.json'),
+    JSON.stringify({ synced_from: { repo: 'owner/repo', path: 'nested' } }),
+  );
+  assert.equal(
+    resolvePluginProvenance('plugins/nested/mirror', { root }).reasonCode,
+    'UPSTREAM_SOURCE_RECORD',
+  );
+  assert.equal(resolvePluginProvenance('../outside', { root }).reasonCode, 'PATH_TRAVERSAL');
+});
+
+test('malformed, unreadable, and contradictory provenance fail closed', () => {
+  const root = fixture();
+  packageFixture(root, 'plugins/bad', { name: '@intentsolutionsio/bad' });
+  fs.writeFileSync(path.join(root, 'plugins/bad', '.source.json'), '{not-json');
+  packageFixture(root, 'plugins/unreadable', { name: '@intentsolutionsio/unreadable' });
+  fs.mkdirSync(path.join(root, 'plugins/unreadable', '.source.json'));
+  packageFixture(root, 'plugins/contradictory', { name: '@intentsolutionsio/contradictory' });
+  fs.writeFileSync(path.join(root, 'plugins/contradictory', '.source.json'), JSON.stringify({}));
+  const report = buildPublishCandidateReport({ root, all: true, scope: '@intentsolutionsio/' });
+  assert.deepEqual(
+    report.refused.map((row) => row.reasonCode),
+    ['MALFORMED_SOURCE_RECORD', 'CONTRADICTORY_SOURCE_RECORD', 'MALFORMED_SOURCE_RECORD'],
+  );
+});
+
+test('red proof: legacy publisher admits a mirror, enforced publisher skips it', () => {
+  const root = fixture();
+  packageFixture(root, 'plugins/legacy-mirror', {
+    privateValue: false,
+    source: JSON.stringify({ synced_from: { repo: 'owner/repo', path: 'legacy-mirror' } }),
+    name: '@intentsolutionsio/legacy-mirror',
+  });
+  const legacySelection = ['plugins/legacy-mirror'];
+  const report = buildPublishCandidateReport({ root, all: true, scope: '@intentsolutionsio/' });
+  assert.equal(legacySelection.length, 1, 'RED PROOF: old private-only filter admitted the mirror');
+  assert.equal(report.firstPartyCandidates.length, 0);
+  assert.equal(report.mirrorSkipped[0].reasonCode, 'UPSTREAM_SOURCE_RECORD');
+});
+
+test('current repository excludes all 63 repository mirrors and 58 live scoped mirrors', () => {
+  const root = process.cwd();
+  const allReport = buildPublishCandidateReport({ root, all: true });
+  const scopedReport = buildPublishCandidateReport({
+    root,
+    all: true,
+    scope: '@intentsolutionsio/',
+  });
+  const markerDirs = [];
+  const walk = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) walk(fullPath);
+      else if (entry.name === '.source.json') markerDirs.push(path.relative(root, directory));
+    }
+  };
+  walk(path.join(root, 'plugins'));
+  const mirrorDirs = new Set(allReport.mirrorSkipped.map((row) => row.dir));
+  const scopedMirrorDirs = new Set(scopedReport.mirrorSkipped.map((row) => row.dir));
+  const scopedMarkers = markerDirs.filter((directory) => {
+    try {
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(root, directory, 'package.json'), 'utf8'),
+      );
+      return packageJson.name?.startsWith('@intentsolutionsio/');
+    } catch {
+      return false;
+    }
+  });
+  assert.equal(markerDirs.length, 63);
+  assert.equal(scopedMarkers.length, 58);
+  assert.ok(markerDirs.every((directory) => mirrorDirs.has(directory)));
+  assert.ok(scopedMarkers.every((directory) => scopedMirrorDirs.has(directory)));
+  assert.equal(allReport.firstPartyCandidates.filter((row) => mirrorDirs.has(row.dir)).length, 0);
+  assert.equal(
+    scopedReport.firstPartyCandidates.filter((row) => scopedMirrorDirs.has(row.dir)).length,
+    0,
+  );
+  console.log(
+    `RED PROOF PASS: legacy private-only publisher would admit a non-private mirror; resolver excludes 63 marker roots and 58 scoped roots (plus nested descendants).`,
+  );
+});

--- a/scripts/publish-candidate-report.mjs
+++ b/scripts/publish-candidate-report.mjs
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { isPathInside, resolvePluginProvenance } from './plugin-provenance.mjs';
+
+const ROOT = process.cwd();
+
+function parseArgs(argv) {
+  const args = { all: false, changedFiles: null, scope: null };
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--all') args.all = true;
+    else if (arg === '--changed-files') args.changedFiles = argv[++index];
+    else if (arg === '--scope') args.scope = argv[++index];
+    else if (arg === '--json') args.json = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if ((args.all ? 1 : 0) + (args.changedFiles ? 1 : 0) !== 1) {
+    throw new Error('Choose exactly one of --all or --changed-files <file>.');
+  }
+  return args;
+}
+
+function walkPackageDirs(root) {
+  const result = [];
+  const walk = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) walk(fullPath);
+      else if (entry.name === 'package.json') {
+        const packageDir = path.dirname(fullPath);
+        if (
+          fs.existsSync(path.join(packageDir, '.claude-plugin')) ||
+          fs.existsSync(path.join(packageDir, 'plugin.json'))
+        ) {
+          result.push(packageDir);
+        }
+      }
+    }
+  };
+  walk(path.join(root, 'plugins'));
+  return result.sort();
+}
+
+function readPackage(directory) {
+  try {
+    const value = JSON.parse(fs.readFileSync(path.join(directory, 'package.json'), 'utf8'));
+    if (!value || typeof value !== 'object' || typeof value.name !== 'string') return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+function changedFilesFrom(filePath) {
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => path.resolve(ROOT, value));
+}
+
+export function buildPublishCandidateReport({
+  root = ROOT,
+  all = false,
+  changedFiles = [],
+  scope = null,
+} = {}) {
+  const rootPath = path.resolve(root);
+  const packageDirs = walkPackageDirs(rootPath).filter((directory) => {
+    if (all) return true;
+    return changedFiles.some(
+      (file) => isPathInside(rootPath, file) && isPathInside(directory, file),
+    );
+  });
+
+  const report = {
+    firstPartyCandidates: [],
+    mirrorSkipped: [],
+    refused: [],
+    privateSkipped: [],
+    nonPackageIgnored: [],
+  };
+
+  for (const directory of packageDirs) {
+    const packageJson = readPackage(directory);
+    const relativeDir = path.relative(rootPath, directory);
+    if (!packageJson || (scope && !packageJson.name.startsWith(scope))) {
+      report.nonPackageIgnored.push(relativeDir);
+      continue;
+    }
+
+    const provenance = resolvePluginProvenance(relativeDir, { root: rootPath });
+    const row = {
+      name: packageJson.name,
+      version: packageJson.version ?? '0.0.0',
+      dir: relativeDir,
+    };
+    if (provenance.status === 'refused') {
+      report.refused.push({ ...row, reasonCode: provenance.reasonCode });
+    } else if (provenance.status === 'mirror') {
+      report.mirrorSkipped.push({ ...row, reasonCode: provenance.reasonCode });
+    } else if (packageJson.private === true) {
+      report.privateSkipped.push({ ...row, reasonCode: 'PRIVATE_PACKAGE' });
+    } else {
+      report.firstPartyCandidates.push({ ...row, reasonCode: 'FIRST_PARTY_CANDIDATE' });
+    }
+  }
+
+  return report;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const report = buildPublishCandidateReport({
+    all: args.all,
+    changedFiles: args.changedFiles ? changedFilesFrom(args.changedFiles) : [],
+    scope: args.scope,
+  });
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  if (report.refused.length > 0) process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();


### PR DESCRIPTION
## Bead
- `claude-s03q.3` — Refuse to publish any plugin directory that carries an upstream source record
- Slice 2 contains exactly E7.2; no E7.3 or other bead is activated.

## Change
- Add one shared, fail-closed `.source.json` ancestry resolver.
- Route both plugin npm publishers through the resolver before candidate build, version checks, token use, or registry contact.
- Add fixture tests and the E7.2 check inside the existing `validate` job; no fourth required status context and no `paths:` filter was added to `validate-plugins.yml`.
- File the Slice 2 AAR and v4.4 index/ledger entry.

## Evidence
- Before: old private-only emulation admitted 408 scoped candidate directories, including nested descendants under mirror ancestors.
- After: 395 first-party candidates; 71 provenance-skipped scoped candidate paths (58 marker roots plus 13 nested descendants); 0 refused records.
- Machine inventory: 63 provenance marker roots, 58 scoped roots; all are excluded from the first-party candidate set.
- `node --test scripts/plugin-provenance.test.mjs` — 6/6 passed.
- `node scripts/check-mirror-packages-private.mjs` — 63 markers, 63 package manifests, 63 private, 0 violations.
- `pnpm run verify` is required in the clean-checkout review; it must be run read-only with any generated local output discarded.
- Red proof: a fixture demonstrates the legacy private-only selector admits a non-private mirror while the resolver returns `UPSTREAM_SOURCE_RECORD` and skips it.
- No npm/network mutation; no mirrored skill content changed.

## Rollback
Revert the resolver, candidate report, workflow wiring, tests, and AAR. This does not mutate npm.

## Prohibited scope
No registry or credential changes, contributor/upstream contact, GitHub Environment or branch-protection changes, package releases, mirrored-content edits, E7.3 activation, or other epic.
