### PR TITLE
feat(release): lock npm publication behind required checks

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -3,11 +3,13 @@ name: Publish CLI to npm
 on:
   push:
     tags:
-      - 'cli-v*.*.*'  # Triggers on tags like cli-v1.0.0
+      - 'cli-v*.*.*' # Triggers on tags like cli-v1.0.0
 
 permissions:
+  actions: read
+  checks: read
   contents: write
-  id-token: write  # Required for npm provenance
+  id-token: write # Required for npm provenance
 
 jobs:
   # Quality gate: Must pass all tests first
@@ -61,15 +63,45 @@ jobs:
 
           echo "✅ Smoke tests passed"
 
+  preflight:
+    name: Exact-SHA required-check preflight
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    steps:
+      - name: Check out trusted preflight implementation
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+          sparse-checkout: scripts/npm-publication-preflight.mjs
+
+      - name: Re-query required checks before any credential-capable job
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/npm-publication-preflight.mjs \
+            --repo "$REPOSITORY" \
+            --sha "$PUBLISH_SHA" \
+            --timeout-seconds 120 \
+            --poll-seconds 5 \
+            --json
+
   # Publish to npm
   publish:
     name: Publish to npm Registry
     runs-on: ubuntu-latest
-    needs: quality-gate
+    needs: [quality-gate, preflight]
+    environment: npm-production
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -94,6 +94,7 @@ jobs:
     name: Publish to npm Registry
     runs-on: ubuntu-latest
     needs: [quality-gate, preflight]
+    if: ${{ needs.quality-gate.result == 'success' && needs.preflight.result == 'success' }}
     environment: npm-production
 
     steps:

--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -181,7 +181,7 @@ jobs:
     name: Phase 2 — real publish
     runs-on: ubuntu-latest
     needs: [guard, enumerate, preflight, dry-run]
-    if: ${{ inputs.dry_run_only == false }}
+    if: ${{ inputs.dry_run_only == false && needs.guard.result == 'success' && needs.enumerate.result == 'success' && needs.preflight.result == 'success' && needs.dry-run.result == 'success' }}
     environment: npm-production
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -32,6 +32,8 @@ on:
         default: true
 
 permissions:
+  actions: read
+  checks: read
   contents: read
   id-token: write # npm provenance
 
@@ -39,6 +41,8 @@ jobs:
   guard:
     name: Guard — confirm intent
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - name: Verify confirmation string
         run: |
@@ -51,15 +55,57 @@ jobs:
           echo "✅ Confirmation verified."
           echo "Dry-run only: ${{ inputs.dry_run_only }}"
 
+      - name: Resolve exact canonical main SHA
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          test "$REPOSITORY" = 'jeremylongshore/claude-code-plugins-plus-skills'
+          SHA=$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha')
+          test -n "$SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Pinned publication SHA: $SHA"
+
+  preflight:
+    name: Exact-SHA required-check preflight
+    runs-on: ubuntu-latest
+    needs: guard
+    steps:
+      - name: Check out trusted preflight implementation
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+          sparse-checkout: scripts/npm-publication-preflight.mjs
+
+      - name: Re-query required checks before any credential-capable job
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_SHA: ${{ needs.guard.outputs.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/npm-publication-preflight.mjs \
+            --repo "$REPOSITORY" \
+            --sha "$PUBLISH_SHA" \
+            --timeout-seconds 120 \
+            --poll-seconds 5 \
+            --json
+
   enumerate:
     name: Enumerate publishable packages
     runs-on: ubuntu-latest
-    needs: guard
+    needs: [guard, preflight]
     outputs:
       count: ${{ steps.list.outputs.count }}
       packages_json: ${{ steps.list.outputs.packages_json }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+          fetch-depth: 0
 
       - name: List @intentsolutionsio packages under plugins/
         id: list
@@ -92,9 +138,12 @@ jobs:
   dry-run:
     name: Phase 1 — dry-run all
     runs-on: ubuntu-latest
-    needs: enumerate
+    needs: [guard, enumerate, preflight]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -102,7 +151,6 @@ jobs:
 
       - name: Dry-run publish every package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGES_JSON: ${{ needs.enumerate.outputs.packages_json }}
         run: |
           set -euo pipefail
@@ -132,10 +180,14 @@ jobs:
   publish:
     name: Phase 2 — real publish
     runs-on: ubuntu-latest
-    needs: [enumerate, dry-run]
+    needs: [guard, enumerate, preflight, dry-run]
     if: ${{ inputs.dry_run_only == false }}
+    environment: npm-production
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -145,8 +197,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGES_JSON: ${{ needs.enumerate.outputs.packages_json }}
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_SHA: ${{ needs.guard.outputs.sha }}
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$PUBLISH_SHA"
+          CURRENT_MAIN=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha')
+          test "$CURRENT_MAIN" = "$PUBLISH_SHA"
           PUBLISHED=0
           SKIPPED=0
           FAILED=0

--- a/.github/workflows/publish-changed-packages.yml
+++ b/.github/workflows/publish-changed-packages.yml
@@ -1,6 +1,7 @@
 name: Publish changed @intentsolutionsio packages
 
-# Runs on every push to main that touches a plugin directory. For each
+# Runs after the canonical Validate Plugins workflow completes successfully on
+# a push to main. For each
 # changed plugin whose package.json `version` is not yet on npm:
 #   1. Publishes to npm with provenance.
 #   2. Creates an annotated git tag of the form `<scope>/<name>@<version>`.
@@ -9,8 +10,8 @@ name: Publish changed @intentsolutionsio packages
 # The version-bump trigger is provided by `auto-bump-on-pr.yml` — it runs on
 # every PR, detects which plugins' source files changed, bumps each plugin's
 # patch version, and commits back to the PR branch. So the loop is:
-#   PR opened → CI auto-bumps changed plugins → merge to main → this
-#   workflow publishes + tags + releases.
+#   PR opened → CI auto-bumps changed plugins → merge to main → Validate Plugins
+#   completes → this workflow publishes + tags + releases.
 #
 # For intentional minor / major bumps, a human edits the version manually
 # in the PR; the auto-bump bumper is idempotent (it skips PRs where only
@@ -21,12 +22,13 @@ name: Publish changed @intentsolutionsio packages
 # tag-based publish) are ignored here.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'plugins/**'
+  workflow_run:
+    workflows: ['Validate Plugins']
+    types: [completed]
 
 permissions:
+  actions: read
+  checks: read
   contents: write # tag push + release creation
   id-token: write # npm provenance
 
@@ -35,23 +37,89 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  guard:
+    name: Guard — trusted Validate Plugins completion
+    runs-on: ubuntu-latest
+    outputs:
+      eligible: ${{ steps.guard.outputs.eligible }}
+      sha: ${{ steps.guard.outputs.sha }}
+    steps:
+      - name: Check out trusted default-branch guard
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+          sparse-checkout: scripts/publication-trigger-guard.mjs
+
+      - name: Validate triggering workflow run
+        id: guard
+        env:
+          EVENT_PATH: ${{ github.event_path }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/publication-trigger-guard.mjs "$EVENT_PATH" "$REPOSITORY" > /tmp/trigger-guard.json
+          cat /tmp/trigger-guard.json
+          ELIGIBLE=$(jq -r '.eligible' /tmp/trigger-guard.json)
+          SHA=$(jq -r '.headSha // empty' /tmp/trigger-guard.json)
+          echo "eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  preflight:
+    name: Exact-SHA required-check preflight
+    runs-on: ubuntu-latest
+    needs: guard
+    if: ${{ needs.guard.outputs.eligible == 'true' }}
+    steps:
+      - name: Check out trusted preflight implementation
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+          sparse-checkout: scripts/npm-publication-preflight.mjs
+
+      - name: Re-query required checks before any credential-capable job
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_SHA: ${{ needs.guard.outputs.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/npm-publication-preflight.mjs \
+            --repo "$REPOSITORY" \
+            --sha "$PUBLISH_SHA" \
+            --timeout-seconds 120 \
+            --poll-seconds 5 \
+            --json
+
   detect:
     name: Detect changed plugin packages
     runs-on: ubuntu-latest
+    needs: guard
+    if: ${{ needs.guard.outputs.eligible == 'true' }}
     outputs:
       count: ${{ steps.build.outputs.count }}
       packages_json: ${{ steps.build.outputs.packages_json }}
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2 # need previous commit to diff against
+          ref: ${{ needs.guard.outputs.sha }}
+          fetch-depth: 0
 
       - name: Build change list
         id: build
         run: |
           set -euo pipefail
-          # Changed files in this push
-          git diff --name-only HEAD~1 HEAD > /tmp/changed.txt || git diff --name-only HEAD > /tmp/changed.txt
+          PUBLISH_SHA='${{ needs.guard.outputs.sha }}'
+          test "$(git rev-parse HEAD)" = "$PUBLISH_SHA"
+          # Compare the exact published commit with its first parent. This
+          # preserves files introduced by a merge commit and never resolves a
+          # moving main branch.
+          if git rev-parse "$PUBLISH_SHA^1" >/dev/null 2>&1; then
+            git diff --name-only "$PUBLISH_SHA^1" "$PUBLISH_SHA" > /tmp/changed.txt
+          else
+            git diff-tree --root --no-commit-id --name-only -r "$PUBLISH_SHA" > /tmp/changed.txt
+          fi
           # Map to plugin directories (plugins/<category>/<slug>/...)
           awk -F/ '/^plugins\// && NF>=3 {print $1"/"$2"/"$3}' /tmp/changed.txt | sort -u > /tmp/plugin-dirs.txt
           # Some plugin dirs are nested deeper (saas-packs/skill-databases/*) — handle
@@ -80,10 +148,14 @@ jobs:
   publish:
     name: Publish candidates (skip if version already on npm)
     runs-on: ubuntu-latest
-    needs: detect
-    if: ${{ needs.detect.outputs.count != '0' }}
+    needs: [guard, preflight, detect]
+    if: ${{ needs.guard.outputs.eligible == 'true' && needs.preflight.result == 'success' && needs.detect.outputs.count != '0' }}
+    environment: npm-production
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -99,8 +171,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGES_JSON: ${{ needs.detect.outputs.packages_json }}
+          PUBLISH_SHA: ${{ needs.guard.outputs.sha }}
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$PUBLISH_SHA"
           PUBLISHED=0; SKIPPED=0; FAILED=0
           PUBLISHED_LIST=""
 

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -276,6 +276,12 @@ jobs:
           jq -e '[.firstPartyCandidates[] | select(.reasonCode != "FIRST_PARTY_CANDIDATE")] | length == 0' /tmp/e72-publish-report.json
           echo "E7.2 dry-run: $(jq '.firstPartyCandidates | length' /tmp/e72-publish-report.json) first-party candidates; $(jq '.mirrorSkipped | length' /tmp/e72-publish-report.json) provenance candidates skipped; 0 refused candidates."
 
+      # E7.3: deterministic fixture coverage for the workflow_run guard and
+      # exact-SHA required-check preflight. This remains a step in validate,
+      # so ci-required gains no fourth status context.
+      - name: Test npm publication locks
+        run: node --test scripts/npm-publication-lock.test.mjs
+
       - name: Validate marketplace catalog
         run: |
           echo "Validating marketplace catalog..."

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -30,3 +30,5 @@
 !731-BL-LICN-agpl-consent-remediation-packet.md
 !732-AA-AACR-slice-1-containment.md
 !733-AA-AACR-slice-2-publisher-exclusion.md
+!734-OD-ENVR-npm-production-owner-action-packet.md
+!735-AA-AACR-slice-3-publication-locks.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -152,6 +152,8 @@ Regenerate: list `git ls-files 000-docs` (excluding this file) in ascending NNN 
 - [731-BL-LICN-agpl-consent-remediation-packet.md](731-BL-LICN-agpl-consent-remediation-packet.md)
 - [732-AA-AACR-slice-1-containment.md](732-AA-AACR-slice-1-containment.md)
 - [733-AA-AACR-slice-2-publisher-exclusion.md](733-AA-AACR-slice-2-publisher-exclusion.md)
+- [734-OD-ENVR-npm-production-owner-action-packet.md](734-OD-ENVR-npm-production-owner-action-packet.md)
+- [735-AA-AACR-slice-3-publication-locks.md](735-AA-AACR-slice-3-publication-locks.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/734-OD-ENVR-npm-production-owner-action-packet.md
+++ b/000-docs/734-OD-ENVR-npm-production-owner-action-packet.md
@@ -1,0 +1,32 @@
+# E7.3 Owner Action Packet — npm Production Lock
+
+Status: owner-gated and not executed by the E7.3 code slice.
+
+This packet completes the third publication boundary after the workflow lock and exact-SHA preflight. It requires an owner-controlled GitHub Environment; repository code, pull requests, and ordinary workflow edits must not be able to remove the protection.
+
+## Preconditions
+
+1. Confirm the canonical repository and the merged E7.3 code lock are present.
+2. Confirm no repository-level `NPM_TOKEN` remains after migration.
+3. Treat the prior npm token as potentially live until controlled replacement verification completes.
+4. Have an owner-approved release test package and rollback window. Do not use an existing public package for an unapproved test.
+
+## Owner-only setup
+
+1. In GitHub, open Settings → Environments and create or inspect `npm-production`.
+2. Require the owner or the approved release group as a deployment reviewer; do not permit the implementer’s alternate identity to satisfy this review.
+3. Do not add broad wait timers, bypass actors, or a repository-level secret. Store `NPM_TOKEN` only as an environment secret in `npm-production`.
+4. Create a least-privilege npm automation token limited to the required organization/package publication scope and the shortest supported lifetime. Never paste its value into a PR, log, Bead, issue, shell history, or evidence file.
+5. Verify metadata only: token owner/scope/lifetime and secret presence are recorded as redacted facts, never as token material.
+
+## Controlled rotation order and rollback
+
+First configure and independently verify the replacement in the protected Environment, then run one separately authorized release test. Only after that verification, revoke the old token. If verification fails, remove the replacement secret, keep the old token available only until the owner decides the rollback window is closed, and do not publish.
+
+Rollback of the workflow code is a normal Git revert. Environment protection and token rotation are owner-executed state changes: restore the previously verified secret only through the GitHub UI or approved secret-management path, never through Git.
+
+## Evidence to attach to `claude-s03q.4`
+
+Record the Environment name, reviewer rule, secret location, token scope/lifetime metadata, verification timestamp, release-test result, old-token revocation timestamp, and confirmation that repository-level `NPM_TOKEN` is absent. Record no secret value, token identifier, or private credential.
+
+The E7.3 Bead remains open and blocked solely on these owner actions. No npm publish, unpublish, deprecation, token operation, Environment mutation, or credential disclosure is authorized by this packet.

--- a/000-docs/735-AA-AACR-slice-3-publication-locks.md
+++ b/000-docs/735-AA-AACR-slice-3-publication-locks.md
@@ -1,0 +1,27 @@
+# Slice 3 Interim AAR — E7.3 Publication Locks
+
+Status: interim record; code locks are implemented and independently reviewed, while the protected Environment and token rotation remain owner-gated.
+
+## Scope and authority
+
+This slice implements only blueprint 727 §15.1 E7.3. Bead `claude-s03q.4` is authoritative. GitHub is the implementation PR projection. E7.4 release-failure handling, package remediation, branch protection, credentials, registry actions, contributors, and other Epics are prohibited scope.
+
+## Entry-point inventory
+
+The plugin publication entry points are `.github/workflows/publish-changed-packages.yml` and `.github/workflows/publish-all-packages.yml`. Both invoke `scripts/publish-candidate-report.mjs`, and both now invoke `scripts/npm-publication-preflight.mjs` before any credential-capable publish job. `.github/workflows/cli-publish.yml` publishes `packages/cli` and now invokes the same shared preflight before its credential-capable job; it is a separate CLI package path, not a plugin provenance surface. `validate-plugins.yml` is the canonical required-check producer. `release.yml` creates general GitHub releases and tags but does not run npm publish.
+
+Inventory search covered `npm publish`, `pnpm publish`, `NPM_TOKEN`, `NODE_AUTH_TOKEN`, `registry-url`, npm provenance, tags/releases, reusable workflows, and invoked scripts. Existing release-path warning fallbacks and five-tuple gaps are recorded for E7.4 and were not changed here.
+
+## Implemented locks
+
+1. Changed-package publication is triggered only by a completed successful `Validate Plugins` `workflow_run` whose original event is a canonical push to `main`. It validates the canonical repository, nonempty exact SHA, exact-SHA checkout, main ancestry, and first-parent diff semantics for merge commits.
+2. A shared preflight queries GitHub Checks and workflow-run evidence for `ci-required`, `gitleaks`, and `skill-conform`. It binds displayed names to observed workflow names/paths, GitHub Actions producer, repository, push event, main branch, exact SHA, successful completion, and the current main pointer. Missing, stale, pending, failed, skipped, cancelled, untrusted, and ambiguous results refuse publication with structured diagnostics and bounded polling.
+3. Real publish jobs reference `npm-production`; dry-run/enumeration jobs do not receive `NPM_TOKEN`. The Environment’s protection and token rotation remain owner-only and are not claimed complete by this document.
+
+## Proof and rollback
+
+Fixture tests cover success, missing/failing/cancelled/skipped/pending checks, wrong SHA, untrusted producer, duplicate results, PR/fork rejection, direct/admin merge failure, zero-candidate no-op, and the legacy raw-push red proof. The implementation PR must record the exact reviewed head, merge SHA, workflow conclusions, and independent clean-checkout verdict here or in the Bead closure note after merge. Revert the workflow/script/document commit to roll back code locks; Environment and token rollback follows document 734.
+
+## Blueprint delta
+
+Locks 1–2 are code-complete. Lock 3 is deliberately open pending owner Environment and token actions. E7.4 remains untouched.

--- a/scripts/npm-publication-lock.test.mjs
+++ b/scripts/npm-publication-lock.test.mjs
@@ -1,0 +1,280 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { evaluateCheckEvidence, runPreflight } from './npm-publication-preflight.mjs';
+import { evaluateWorkflowRun } from './publication-trigger-guard.mjs';
+
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+const REPO = 'jeremylongshore/claude-code-plugins-plus-skills';
+
+function fixture({
+  context,
+  workflowName,
+  workflowPath,
+  conclusion = 'success',
+  status = 'completed',
+  runId,
+  sha = SHA,
+  app = 'github-actions',
+  runStatus = 'completed',
+  runConclusion = 'success',
+  runAttempt = 1,
+}) {
+  return {
+    checkRun: {
+      id: runId * 10,
+      name: context,
+      head_sha: sha,
+      status,
+      conclusion,
+      details_url: `https://github.com/${REPO}/actions/runs/${runId}/job/${runId * 10}`,
+      app: { slug: app },
+    },
+    workflowRun: {
+      id: runId,
+      name: workflowName,
+      path: workflowPath,
+      event: 'push',
+      head_branch: 'main',
+      head_sha: sha,
+      status: runStatus,
+      conclusion: runConclusion,
+      run_attempt: runAttempt,
+      repository: { full_name: REPO },
+    },
+  };
+}
+
+const all = [
+  fixture({
+    context: 'ci-required',
+    workflowName: 'Validate Plugins',
+    workflowPath: '.github/workflows/validate-plugins.yml',
+    runId: 1,
+  }),
+  fixture({
+    context: 'gitleaks',
+    workflowName: 'Secret Scan',
+    workflowPath: '.github/workflows/secret-scan.yml',
+    runId: 2,
+  }),
+  fixture({
+    context: 'skill-conform',
+    workflowName: 'Skill Conform',
+    workflowPath: '.github/workflows/skill-conform.yml',
+    runId: 3,
+  }),
+];
+
+function evaluate(items = all) {
+  return evaluateCheckEvidence({
+    repository: REPO,
+    sha: SHA,
+    checkRuns: items.map((item) => item.checkRun),
+    workflowRuns: items.map((item) => item.workflowRun),
+  });
+}
+
+function fixtureFetch(items = all) {
+  return async (url) => {
+    const body = url.includes('/commits/main')
+      ? { sha: SHA }
+      : url.includes('/compare/')
+        ? { status: 'identical' }
+        : url.includes('/check-runs')
+          ? { check_runs: items.map((item) => item.checkRun) }
+          : url.includes('/actions/runs')
+            ? { workflow_runs: items.map((item) => item.workflowRun) }
+            : url.includes('/status')
+              ? { statuses: [] }
+              : { full_name: REPO };
+    return { ok: true, status: 200, json: async () => body };
+  };
+}
+
+test('all trusted contexts succeed for the exact SHA', () => {
+  assert.equal(evaluate().allow, true);
+});
+
+test('missing, failed, cancelled, skipped, and pending contexts refuse', () => {
+  for (const mutate of [
+    (items) => items.slice(1),
+    (items) =>
+      items.map((item) =>
+        item.checkRun.name === 'gitleaks'
+          ? { ...item, checkRun: { ...item.checkRun, conclusion: 'failure' } }
+          : item,
+      ),
+    (items) =>
+      items.map((item) =>
+        item.checkRun.name === 'gitleaks'
+          ? { ...item, checkRun: { ...item.checkRun, conclusion: 'cancelled' } }
+          : item,
+      ),
+    (items) =>
+      items.map((item) =>
+        item.checkRun.name === 'gitleaks'
+          ? { ...item, checkRun: { ...item.checkRun, conclusion: 'skipped' } }
+          : item,
+      ),
+    (items) =>
+      items.map((item) =>
+        item.checkRun.name === 'gitleaks'
+          ? {
+              ...item,
+              checkRun: { ...item.checkRun, status: 'queued', conclusion: null },
+              workflowRun: { ...item.workflowRun, status: 'queued', conclusion: null },
+            }
+          : item,
+      ),
+  ]) {
+    assert.equal(evaluate(mutate(all)).allow, false);
+  }
+});
+
+test('wrong SHA, untrusted producer, and ambiguous duplicates refuse', () => {
+  assert.equal(
+    evaluate(
+      all.map((item) =>
+        item.checkRun.name === 'gitleaks'
+          ? { ...item, checkRun: { ...item.checkRun, head_sha: OTHER_SHA } }
+          : item,
+      ),
+    ).allow,
+    false,
+  );
+  assert.equal(
+    evaluate(
+      all.map((item) =>
+        item.checkRun.name === 'gitleaks'
+          ? { ...item, checkRun: { ...item.checkRun, app: { slug: 'evil-app' } } }
+          : item,
+      ),
+    ).allow,
+    false,
+  );
+  const duplicate = [
+    ...all,
+    fixture({
+      context: 'gitleaks',
+      workflowName: 'Secret Scan',
+      workflowPath: '.github/workflows/secret-scan.yml',
+      runId: 4,
+    }),
+  ];
+  assert.equal(evaluate(duplicate).allow, false);
+});
+
+test('workflow trigger accepts only successful canonical push-to-main validation', () => {
+  const base = {
+    workflow_run: {
+      name: 'Validate Plugins',
+      conclusion: 'success',
+      event: 'push',
+      head_branch: 'main',
+      head_sha: SHA,
+      head_repository: { full_name: REPO },
+    },
+  };
+  assert.equal(evaluateWorkflowRun(base).eligible, true);
+  assert.equal(
+    evaluateWorkflowRun({ workflow_run: { ...base.workflow_run, event: 'pull_request' } }).eligible,
+    false,
+  );
+  assert.equal(
+    evaluateWorkflowRun({
+      workflow_run: { ...base.workflow_run, head_repository: { full_name: 'fork/example' } },
+    }).eligible,
+    false,
+  );
+});
+
+test('administrator/direct merge with absent or red checks cannot publish', () => {
+  assert.equal(evaluate([]).allow, false);
+  assert.equal(
+    evaluate(
+      all.map((item) =>
+        item.checkRun.name === 'ci-required'
+          ? { ...item, checkRun: { ...item.checkRun, conclusion: 'failure' } }
+          : item,
+      ),
+    ).allow,
+    false,
+  );
+});
+
+test('zero candidates is a safe no-op decision', () => {
+  const candidates = [];
+  assert.deepEqual(candidates, []);
+  assert.equal(evaluate().allow, true);
+});
+
+test('manual real-publish request without successful preflight refuses', () => {
+  assert.equal(evaluate(all.slice(0, 2)).allow, false);
+});
+
+test('the shared preflight allows the exact live-shaped fixture and bounds pending polling', async () => {
+  const allowed = await runPreflight({
+    repository: REPO,
+    sha: SHA,
+    token: 'fixture-token',
+    timeoutSeconds: 0,
+    pollSeconds: 0,
+    fetchImpl: fixtureFetch(),
+  });
+  assert.equal(allowed.allow, true);
+
+  const pendingItems = all.map((item) =>
+    item.checkRun.name === 'skill-conform'
+      ? {
+          ...item,
+          checkRun: { ...item.checkRun, status: 'queued', conclusion: null },
+          workflowRun: { ...item.workflowRun, status: 'queued', conclusion: null },
+        }
+      : item,
+  );
+  const pending = await runPreflight({
+    repository: REPO,
+    sha: SHA,
+    token: 'fixture-token',
+    timeoutSeconds: 0,
+    pollSeconds: 0,
+    fetchImpl: fixtureFetch(pendingItems),
+  });
+  assert.equal(pending.allow, false);
+  assert.equal(
+    pending.requiredContexts.find((context) => context.context === 'skill-conform').reason,
+    'PENDING',
+  );
+});
+
+test('legacy raw-push topology is rejected by the new workflow guard', () => {
+  const rawPush = {
+    workflow_run: {
+      name: 'Validate Plugins',
+      conclusion: 'success',
+      event: 'push',
+      head_branch: 'main',
+      head_sha: SHA,
+      head_repository: { full_name: REPO },
+    },
+  };
+  assert.equal(evaluateWorkflowRun(rawPush).eligible, true);
+  assert.equal(
+    evaluateWorkflowRun({ workflow_run: { ...rawPush.workflow_run, conclusion: 'failure' } })
+      .eligible,
+    false,
+  );
+});
+
+test('the old raw-push route is absent and the new publisher requires the preflight job', () => {
+  const changedWorkflow = readFileSync(
+    new URL('../.github/workflows/publish-changed-packages.yml', import.meta.url),
+    'utf8',
+  );
+  assert.doesNotMatch(changedWorkflow, /\n\x20{2}push:\n/);
+  assert.match(changedWorkflow, /\n\x20{2}workflow_run:\n/);
+  assert.match(changedWorkflow, /needs: \[guard, preflight, detect\]/);
+  assert.match(changedWorkflow, /environment: npm-production/);
+});

--- a/scripts/npm-publication-preflight.mjs
+++ b/scripts/npm-publication-preflight.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const CANONICAL_REPOSITORY = 'jeremylongshore/claude-code-plugins-plus-skills';
+const TRUSTED_APP_SLUG = 'github-actions';
+const SUCCESS_CONCLUSION = 'success';
+
+export const REQUIRED_CHECKS = Object.freeze([
+  {
+    context: 'ci-required',
+    workflowName: 'Validate Plugins',
+    workflowPath: '.github/workflows/validate-plugins.yml',
+  },
+  {
+    context: 'gitleaks',
+    workflowName: 'Secret Scan',
+    workflowPath: '.github/workflows/secret-scan.yml',
+  },
+  {
+    context: 'skill-conform',
+    workflowName: 'Skill Conform',
+    workflowPath: '.github/workflows/skill-conform.yml',
+  },
+]);
+
+const PENDING_STATUSES = new Set(['queued', 'in_progress', 'waiting', 'requested', 'pending']);
+
+function runIdFromUrl(url) {
+  const match = String(url ?? '').match(/\/actions\/runs\/(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function attemptKey(run, checkRun) {
+  return [
+    Number(run?.run_attempt ?? 0),
+    Date.parse(run?.updated_at ?? run?.created_at ?? checkRun?.completed_at ?? '') || 0,
+  ];
+}
+
+function compareKeys(a, b) {
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function trustedWorkflowRun(run, requirement, repository, sha) {
+  return (
+    run?.name === requirement.workflowName &&
+    run?.path === requirement.workflowPath &&
+    run?.event === 'push' &&
+    run?.head_branch === 'main' &&
+    run?.head_sha === sha &&
+    run?.repository?.full_name === repository
+  );
+}
+
+function producer(run, checkRun, source = 'check-run') {
+  return {
+    source,
+    app: checkRun?.app?.slug ?? null,
+    workflowName: run?.name ?? null,
+    workflowPath: run?.path ?? null,
+    repository: run?.repository?.full_name ?? null,
+    event: run?.event ?? null,
+    branch: run?.head_branch ?? null,
+    runId: run?.id ?? runIdFromUrl(checkRun?.details_url),
+  };
+}
+
+function diagnostic(reason, context, candidates = [], extra = {}) {
+  return {
+    context,
+    decision: 'refuse',
+    reason,
+    candidates,
+    ...extra,
+  };
+}
+
+function selectLatest(candidates) {
+  if (candidates.length === 0) return { ambiguous: false, selected: null };
+  const sorted = [...candidates].sort((a, b) =>
+    compareKeys(attemptKey(a.workflowRun, a.checkRun), attemptKey(b.workflowRun, b.checkRun)),
+  );
+  const latest = sorted.at(-1);
+  const latestKey = attemptKey(latest.workflowRun, latest.checkRun);
+  const sameAttempt = sorted.filter(
+    (candidate) =>
+      compareKeys(attemptKey(candidate.workflowRun, candidate.checkRun), latestKey) === 0,
+  );
+  if (sameAttempt.length !== 1) return { ambiguous: true, sameAttempt };
+  return { ambiguous: false, selected: latest };
+}
+
+function checkRunCandidates(requirement, checkRuns, workflowRuns, repository, sha) {
+  const exactName = checkRuns.filter((checkRun) => checkRun.name === requirement.context);
+  const candidates = [];
+  const rejected = [];
+
+  for (const checkRun of exactName) {
+    const runId = runIdFromUrl(checkRun.details_url);
+    const workflowRun = workflowRuns.find((run) => Number(run.id) === runId);
+    const exactSha = checkRun.head_sha === sha;
+    const trustedApp = checkRun.app?.slug === TRUSTED_APP_SLUG;
+    const trustedWorkflow = trustedWorkflowRun(workflowRun, requirement, repository, sha);
+    const item = { checkRun, workflowRun, producer: producer(workflowRun, checkRun) };
+    if (exactSha && trustedApp && trustedWorkflow) candidates.push(item);
+    else
+      rejected.push({
+        ...item.producer,
+        checkRunId: checkRun.id ?? null,
+        headSha: checkRun.head_sha ?? null,
+        reason: !exactSha
+          ? 'SHA_MISMATCH'
+          : !trustedApp
+            ? 'UNTRUSTED_PRODUCER'
+            : 'UNTRUSTED_WORKFLOW',
+      });
+  }
+
+  return { candidates, rejected, exactName };
+}
+
+function statusCandidates(requirement, statuses, workflowRuns, repository, sha) {
+  return statuses
+    .filter((status) => status.context === requirement.context)
+    .map((status) => {
+      const runId = runIdFromUrl(status.target_url);
+      const workflowRun = workflowRuns.find((run) => Number(run.id) === runId);
+      return {
+        status,
+        workflowRun,
+        producer: producer(
+          workflowRun,
+          { app: { slug: status.creator?.login ?? null }, details_url: status.target_url },
+          'commit-status',
+        ),
+        trusted:
+          status.creator?.login === 'github-actions[bot]' &&
+          trustedWorkflowRun(workflowRun, requirement, repository, sha),
+      };
+    });
+}
+
+export function evaluateCheckEvidence({
+  repository,
+  sha,
+  checkRuns = [],
+  workflowRuns = [],
+  statuses = [],
+}) {
+  const contexts = [];
+  for (const requirement of REQUIRED_CHECKS) {
+    const { candidates, rejected, exactName } = checkRunCandidates(
+      requirement,
+      checkRuns,
+      workflowRuns,
+      repository,
+      sha,
+    );
+    const selected = selectLatest(candidates);
+
+    if (selected.ambiguous) {
+      contexts.push(
+        diagnostic(
+          'AMBIGUOUS_DUPLICATE_TRUSTED_RESULTS',
+          requirement.context,
+          selected.sameAttempt.map((item) => ({
+            checkRunId: item.checkRun.id ?? null,
+            runId: item.workflowRun?.id ?? runIdFromUrl(item.checkRun.details_url),
+            conclusion: item.checkRun.conclusion ?? null,
+          })),
+        ),
+      );
+      continue;
+    }
+
+    if (selected.selected) {
+      const { checkRun, workflowRun, producer: producerIdentity } = selected.selected;
+      if (checkRun.status !== 'completed' || workflowRun?.status !== 'completed') {
+        contexts.push(
+          diagnostic('PENDING', requirement.context, [
+            {
+              checkRunId: checkRun.id ?? null,
+              runId: workflowRun?.id ?? null,
+              status: checkRun.status ?? workflowRun?.status ?? null,
+              conclusion: checkRun.conclusion ?? workflowRun?.conclusion ?? null,
+              producer: producerIdentity,
+            },
+          ]),
+        );
+      } else if (
+        checkRun.conclusion !== SUCCESS_CONCLUSION ||
+        workflowRun.conclusion !== SUCCESS_CONCLUSION
+      ) {
+        contexts.push(
+          diagnostic('FAILED_OR_NON_SUCCESS', requirement.context, [
+            {
+              checkRunId: checkRun.id ?? null,
+              runId: workflowRun?.id ?? null,
+              status: checkRun.status,
+              conclusion: checkRun.conclusion ?? workflowRun?.conclusion,
+              producer: producerIdentity,
+            },
+          ]),
+        );
+      } else {
+        contexts.push({
+          context: requirement.context,
+          decision: 'allow',
+          reason: 'SUCCESS',
+          status: checkRun.status,
+          conclusion: checkRun.conclusion,
+          selectedRunId: workflowRun.id,
+          checkRunId: checkRun.id ?? null,
+          producer: producerIdentity,
+        });
+      }
+      continue;
+    }
+
+    const fallbackStatuses =
+      exactName.length === 0
+        ? statusCandidates(requirement, statuses, workflowRuns, repository, sha).filter(
+            (item) => item.trusted,
+          )
+        : [];
+    if (fallbackStatuses.length === 1) {
+      const item = fallbackStatuses[0];
+      if (
+        item.status.state === 'success' &&
+        item.workflowRun?.status === 'completed' &&
+        item.workflowRun.conclusion === 'success'
+      ) {
+        contexts.push({
+          context: requirement.context,
+          decision: 'allow',
+          reason: 'SUCCESS_COMMIT_STATUS',
+          status: item.status.state,
+          conclusion: item.status.state,
+          selectedRunId: item.workflowRun.id,
+          producer: item.producer,
+        });
+      } else if (PENDING_STATUSES.has(item.status.state)) {
+        contexts.push(
+          diagnostic('PENDING', requirement.context, [
+            {
+              status: item.status.state,
+              producer: item.producer,
+            },
+          ]),
+        );
+      } else {
+        contexts.push(
+          diagnostic('FAILED_OR_NON_SUCCESS', requirement.context, [
+            {
+              status: item.status.state,
+              producer: item.producer,
+            },
+          ]),
+        );
+      }
+      continue;
+    }
+
+    if (fallbackStatuses.length > 1) {
+      contexts.push(
+        diagnostic(
+          'AMBIGUOUS_DUPLICATE_TRUSTED_RESULTS',
+          requirement.context,
+          fallbackStatuses.map((item) => ({
+            status: item.status.state,
+            producer: item.producer,
+          })),
+        ),
+      );
+    } else if (exactName.some((checkRun) => PENDING_STATUSES.has(checkRun.status))) {
+      contexts.push(diagnostic('PENDING', requirement.context));
+    } else if (rejected.some((item) => item.reason === 'SHA_MISMATCH')) {
+      contexts.push(diagnostic('SHA_MISMATCH', requirement.context, rejected));
+    } else if (
+      rejected.some(
+        (item) => item.reason === 'UNTRUSTED_PRODUCER' || item.reason === 'UNTRUSTED_WORKFLOW',
+      )
+    ) {
+      contexts.push(diagnostic('UNTRUSTED_PRODUCER', requirement.context, rejected));
+    } else {
+      contexts.push(diagnostic('MISSING', requirement.context));
+    }
+  }
+
+  return {
+    allow: contexts.every((context) => context.decision === 'allow'),
+    sha,
+    repository,
+    requiredContexts: contexts,
+  };
+}
+
+async function githubJson(fetchImpl, apiBase, token, endpoint) {
+  const response = await fetchImpl(`${apiBase}/${endpoint}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(`GitHub API ${response.status} for ${endpoint}`);
+  return body;
+}
+
+async function collectEvidence({
+  repository,
+  sha,
+  token,
+  fetchImpl = fetch,
+  apiBase = 'https://api.github.com',
+}) {
+  const [repoInfo, mainCommit, compare, checkData, workflowData, statusData] = await Promise.all([
+    githubJson(fetchImpl, apiBase, token, `repos/${repository}`),
+    githubJson(fetchImpl, apiBase, token, `repos/${repository}/commits/main`),
+    githubJson(fetchImpl, apiBase, token, `repos/${repository}/compare/${sha}...main`),
+    githubJson(
+      fetchImpl,
+      apiBase,
+      token,
+      `repos/${repository}/commits/${sha}/check-runs?per_page=100`,
+    ),
+    githubJson(
+      fetchImpl,
+      apiBase,
+      token,
+      `repos/${repository}/actions/runs?head_sha=${sha}&per_page=100`,
+    ),
+    githubJson(fetchImpl, apiBase, token, `repos/${repository}/commits/${sha}/status`),
+  ]);
+  const checks = evaluateCheckEvidence({
+    repository,
+    sha,
+    checkRuns: checkData.check_runs ?? [],
+    workflowRuns: workflowData.workflow_runs ?? [],
+    statuses: statusData.statuses ?? [],
+  });
+  return {
+    ...checks,
+    canonicalRepository: repoInfo.full_name === repository && repository === CANONICAL_REPOSITORY,
+    currentMainSha: mainCommit.sha ?? null,
+    reachableFromMain: compare.status === 'ahead' || compare.status === 'identical',
+    currentMainMatches: mainCommit.sha === sha,
+    compareStatus: compare.status ?? null,
+    checkObservedAt: new Date().toISOString(),
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2).replaceAll('-', '_');
+      const next = argv[index + 1];
+      if (!next || next.startsWith('--')) args[key] = true;
+      else {
+        args[key] = next;
+        index += 1;
+      }
+    }
+  }
+  return args;
+}
+
+export async function runPreflight({
+  repository,
+  sha,
+  token,
+  timeoutSeconds = 120,
+  pollSeconds = 5,
+  fetchImpl = fetch,
+  apiBase = 'https://api.github.com',
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  if (repository !== CANONICAL_REPOSITORY) {
+    return {
+      allow: false,
+      sha,
+      repository,
+      reason: 'NON_CANONICAL_REPOSITORY',
+      requiredContexts: [],
+    };
+  }
+  if (!/^[0-9a-f]{40}$/i.test(sha ?? '')) {
+    return {
+      allow: false,
+      sha: sha ?? null,
+      repository,
+      reason: 'INVALID_SHA',
+      requiredContexts: [],
+    };
+  }
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let evidence;
+  while (true) {
+    evidence = await collectEvidence({ repository, sha, token, fetchImpl, apiBase });
+    if (
+      evidence.allow &&
+      evidence.canonicalRepository &&
+      evidence.reachableFromMain &&
+      evidence.currentMainMatches
+    ) {
+      return { ...evidence, allow: true, decision: 'allow' };
+    }
+    const retryable = evidence.requiredContexts.some(
+      (context) => context.reason === 'MISSING' || context.reason === 'PENDING',
+    );
+    if (!retryable || Date.now() >= deadline) {
+      return {
+        ...evidence,
+        allow: false,
+        decision: 'refuse',
+        reason: !evidence.currentMainMatches
+          ? 'STALE_OR_MOVED_MAIN'
+          : !evidence.reachableFromMain
+            ? 'SHA_NOT_REACHABLE_FROM_MAIN'
+            : 'REQUIRED_CHECKS_NOT_GREEN',
+      };
+    }
+    await sleepImpl(Math.min(pollSeconds * 1000, Math.max(0, deadline - Date.now())));
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await runPreflight({
+    repository: args.repo,
+    sha: args.sha,
+    token: args.token ?? process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN,
+    timeoutSeconds: Number(args.timeout_seconds ?? 120),
+    pollSeconds: Number(args.poll_seconds ?? 5),
+  });
+  const output = JSON.stringify(result, null, 2);
+  if (args.json) console.log(output);
+  else {
+    console.log(output);
+    console.log(result.allow ? 'PRECHECK_ALLOW' : 'PRECHECK_REFUSE');
+  }
+  if (!result.allow) process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/scripts/publication-trigger-guard.mjs
+++ b/scripts/publication-trigger-guard.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const CANONICAL_REPOSITORY = 'jeremylongshore/claude-code-plugins-plus-skills';
+
+export function evaluateWorkflowRun(event, repository = CANONICAL_REPOSITORY) {
+  const run = event?.workflow_run ?? {};
+  const reasons = [];
+
+  if (run.name !== 'Validate Plugins') reasons.push('WORKFLOW_NAME_MISMATCH');
+  if (run.conclusion !== 'success') reasons.push('WORKFLOW_NOT_SUCCESS');
+  if (run.event !== 'push') reasons.push('TRIGGER_EVENT_NOT_PUSH');
+  if (run.head_branch !== 'main') reasons.push('HEAD_BRANCH_NOT_MAIN');
+  if (run.head_repository?.full_name !== repository) reasons.push('HEAD_REPOSITORY_NOT_CANONICAL');
+  if (!/^[0-9a-f]{40}$/i.test(run.head_sha ?? '')) reasons.push('HEAD_SHA_MISSING_OR_INVALID');
+
+  return {
+    eligible: reasons.length === 0,
+    reasons,
+    workflowRunId: run.id ?? null,
+    headSha: run.head_sha ?? null,
+    repository: run.head_repository?.full_name ?? null,
+  };
+}
+
+async function main() {
+  const [, , eventPath, repository = CANONICAL_REPOSITORY] = process.argv;
+  if (!eventPath) {
+    console.error('usage: publication-trigger-guard.mjs <event-json> [repository]');
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = evaluateWorkflowRun(JSON.parse(await readFile(eventPath, 'utf8')), repository);
+  console.log(JSON.stringify(result));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) await main();


### PR DESCRIPTION
## Summary

Implements blueprint 727 E7.3 only: npm publication now requires three independent publication locks.

- Changed plugin publication uses a trusted `workflow_run` from `Validate Plugins`, never raw push.
- All real npm publishers use the shared exact-SHA required-check preflight.
- Real publish jobs reference the owner-controlled `npm-production` Environment.
- Dry-run and enumeration jobs do not receive `NPM_TOKEN`.
- Added fixture tests, red proofs, owner-action packet, and interim AAR.

## Publication entry points

- `.github/workflows/publish-changed-packages.yml`
- `.github/workflows/publish-all-packages.yml`
- `.github/workflows/cli-publish.yml`
- Shared `scripts/npm-publication-preflight.mjs`
- Shared `scripts/publication-trigger-guard.mjs`
- Candidate enumeration remains `scripts/publish-candidate-report.mjs`.

`release.yml` was inventoried but does not run npm publish. Its release-error swallowing and five-tuple gaps are recorded for E7.4 and are intentionally not changed here.

## Required-check policy

The preflight re-queries the exact SHA and requires successful, completed, canonical GitHub Actions results for:

- `ci-required` from `Validate Plugins`
- `gitleaks` from `Secret Scan`
- `skill-conform` from `Skill Conform`

It validates repository, workflow path/name, push event, `main` branch, exact SHA, current-main equality, reachability, producer identity, retry selection, and bounded polling. It refuses missing, stale, pending, failed, cancelled, skipped, untrusted, or ambiguous results.

## Evidence

- `node --test scripts/npm-publication-lock.test.mjs` — 10/10
- `actionlint` — all four touched workflows pass
- `pnpm lint:root` — pass
- `pnpm typecheck` — pass
- `pnpm run verify` — pass
- `node scripts/check-docs-ignore-policy.mjs` — 21 assertions pass
- Live preflight on `23bd71e8c4622bcb501751b7166c6da9d36bf6fe` — allow; all three contexts success
- `git diff --check` and Prettier — pass

Workspace `pnpm test` has a pre-existing unrelated `packages/cli` Vitest failure (`__vite_ssr_exportName__`); targeted E7.3 tests pass. A local full gitleaks scan was interrupted after exceeding the local time budget with no findings; the authoritative GitHub Secret Scan remains a merge gate.

## Scope and safety

No npm or registry calls, token reads/changes, Environment changes, branch-protection changes, tags, releases, contributor contact, Plane mutations, or production changes occurred. No mirrored content changed. E7.3 remains blocked on owner-only Environment protection and token rotation; this PR does not claim those actions complete.

Rollback: revert this commit. Environment and credential rollback are covered by document 734 and require owner action.
