### PR TITLE
ci: add protected npm credential verification

### DIFF
--- a/.github/workflows/verify-npm-production-credential.yml
+++ b/.github/workflows/verify-npm-production-credential.yml
@@ -1,0 +1,31 @@
+name: Verify npm production credential
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify npm authentication without publishing
+    runs-on: ubuntu-latest
+    environment: npm-production
+    steps:
+      - name: Verify npm authentication without publishing
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set +x
+          set -euo pipefail
+          test -n "${NODE_AUTH_TOKEN:-}" || {
+            echo "NPM_TOKEN is unavailable"
+            exit 1
+          }
+
+          npm_config_file="$(mktemp)"
+          cleanup() { rm -f "$npm_config_file"; }
+          trap cleanup EXIT
+          printf '%s\n' "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > "$npm_config_file"
+          npm --userconfig "$npm_config_file" whoami \
+            --registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

Add a permanent manual workflow that verifies the protected `npm-production` Environment credential with `npm whoami` only.

## Scope

- Bead: `claude-s03q.4`
- Trigger: `workflow_dispatch` only
- Job environment: `npm-production`
- Permissions: `{}`
- No checkout, build, publish, pack, tag, version, release, or registry mutation
- Temporary npm configuration is removed by a shell trap
- The token is never printed or persisted in the repository

## Validation

- `actionlint .github/workflows/verify-npm-production-credential.yml`
- `pnpm exec prettier --check .github/workflows/verify-npm-production-credential.yml`
- `git diff --check`
- Static scan confirms no publish-capable command is present

## Verification procedure after merge

1. Dispatch the workflow manually.
2. Have the configured `blueandyellow44` Environment reviewer approve it.
3. Confirm `npm whoami` succeeds without publishing.
4. Remove only the duplicate repository-level `NPM_TOKEN`.
5. Dispatch the workflow a second time and confirm success with only the Environment secret present.

No token rotation, revocation, replacement, package publication, or registry mutation is part of this PR.
