### PR TITLE
feat(docs-governance): enforce canonical authority pointers

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1429,6 +1429,13 @@ jobs:
       - name: Check doc citations resolve to tracked files
         run: node scripts/check-doc-citations.mjs
 
+      # A document cannot grant itself authority by editing its own header.
+      # STANDARDS.md § Canonical documents is the sole public authority index.
+      - name: Check document authority claims have canonical pointers
+        run: |
+          node --test scripts/check-doc-authority.test.mjs
+          node scripts/check-doc-authority.mjs
+
       # Recurrence prevention for the tracked-generated-artifact class: a
       # projection that is also committed has two claimants to one fact and
       # diverges silently (public/data duplicated ~28.5MB of src/data with

--- a/000-docs/264-DR-GUID-skill-config-pattern.md
+++ b/000-docs/264-DR-GUID-skill-config-pattern.md
@@ -1,6 +1,6 @@
 # Skill Config Pattern (schema 3.6.0)
 
-> **Status:** AUTHORITATIVE — defines the self-declared config surface introduced in schema 3.6.0.
+> **Status:** REFERENCE — the governing schema owners are linked below.
 > **Schema log:** `000-docs/SCHEMA_CHANGELOG.md` § [3.6.0]
 > **Master spec:** `000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (2026-08-15 — document authority gate)
+
+- **Documents can no longer self-grant canonical authority.** The existing
+  `doc-governance` job now rejects an effective `AUTHORITATIVE` or `CANONICAL`
+  declaration unless `STANDARDS.md` § Canonical documents links the claimant. The gate's first
+  live run also demoted the subordinate schema 3.6.0 configuration guide from self-declared
+  authority to a reference that points at its existing schema owners.
+
 ### Changed (2026-08-15 — documentation authority consolidation)
 
 - **Superseded standards are explicitly frozen.** Documents 6767-a/c/d/e/h now identify

--- a/scripts/check-doc-authority.mjs
+++ b/scripts/check-doc-authority.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+/**
+ * Enforce STANDARDS.md as the only grant of document authority.
+ *
+ * Usage: node scripts/check-doc-authority.mjs [repository-root]
+ */
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync } from 'node:fs';
+import { dirname, posix, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const STATUS_FIELD =
+  /^\s*(?:>\s*)*(?:(?:[-+*]|\d+[.)])\s+)?(?:\*\*Status\*\*\s*:|\*\*Status:\*\*|Status\s*:)\s*(.+?)\s*$/i;
+const FROZEN_BANNER = /^\s*>\s*\*\*SUPERSEDED–FROZEN\b/;
+function visibleMarkdownLines(lines) {
+  let fence = null;
+  let htmlComment = false;
+  return lines.map((rawLine) => {
+    if (fence) {
+      const close = rawLine.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/)?.[1] ?? null;
+      if (close && close[0] === fence.character && close.length >= fence.length) fence = null;
+      return null;
+    }
+
+    let line = rawLine;
+    let visible = '';
+    while (line.length) {
+      if (htmlComment) {
+        const end = line.indexOf('-->');
+        if (end === -1) return visible;
+        htmlComment = false;
+        line = line.slice(end + 3);
+        continue;
+      }
+      const start = line.indexOf('<!--');
+      if (start === -1) {
+        visible += line;
+        break;
+      }
+      visible += line.slice(0, start);
+      htmlComment = true;
+      line = line.slice(start + 4);
+    }
+
+    const opening = visible.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (opening && !(opening[1][0] === '`' && opening[2].includes('`'))) {
+      fence = { character: opening[1][0], length: opening[1].length };
+      return null;
+    }
+    return visible;
+  });
+}
+
+function canonicalTarget(linkCell) {
+  const link = linkCell.match(/^\s*\[[^\]]+\]\(([^)]+)\)\s*$/);
+  if (!link) throw new Error('each Canonical documents Document cell must be one active link');
+  const href = link[1].trim();
+  if (
+    !href ||
+    href.includes('#') ||
+    href.includes('?') ||
+    href.includes('%') ||
+    /^[a-z][a-z+.-]*:/i.test(href) ||
+    href.startsWith('/')
+  )
+    throw new Error(`invalid canonical Document link: ${JSON.stringify(href)}`);
+  const normalized = posix.normalize(href.replace(/^\.\//, ''));
+  if (normalized === '..' || normalized.startsWith('../'))
+    throw new Error(`canonical Document link escapes the repository: ${JSON.stringify(href)}`);
+  return normalized;
+}
+
+export function canonicalDocumentLinks(standardsText, trackedPaths = null) {
+  const lines = standardsText.split(/\r?\n/);
+  const visible = visibleMarkdownLines(lines);
+  const headings = visible
+    .map((line, index) => (/^##\s+Canonical documents\s*$/i.test(line) ? index : -1))
+    .filter((index) => index !== -1);
+  if (headings.length !== 1)
+    throw new Error(
+      `STANDARDS.md must contain exactly one "## Canonical documents" section (found ${headings.length})`,
+    );
+
+  const heading = headings[0];
+  let end = lines.length;
+  for (let index = heading + 1; index < lines.length; index += 1) {
+    if (visible[index] && /^##\s+/.test(visible[index])) {
+      end = index;
+      break;
+    }
+  }
+
+  const sectionLines = visible.slice(heading + 1, end);
+  const tableStarts = sectionLines
+    .map((line, index) => {
+      if (line === null) return -1;
+      const cells = line
+        .split('|')
+        .slice(1, -1)
+        .map((cell) => cell.trim().toLowerCase());
+      return cells.length === 2 && cells[0] === 'topic' && cells[1] === 'document' ? index : -1;
+    })
+    .filter((index) => index !== -1);
+  if (tableStarts.length !== 1)
+    throw new Error(
+      `Canonical documents section must contain exactly one Topic | Document table (found ${tableStarts.length})`,
+    );
+
+  const tableRows = [];
+  for (const line of sectionLines.slice(tableStarts[0])) {
+    if (line === null || !/^\s*\|/.test(line)) break;
+    tableRows.push(line);
+  }
+  if (tableRows.length < 3)
+    throw new Error('Canonical documents table is missing or has no data rows');
+
+  const headerCells = tableRows[0]
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim().toLowerCase());
+  if (headerCells.length !== 2 || headerCells[0] !== 'topic' || headerCells[1] !== 'document')
+    throw new Error('Canonical documents table must have exactly the columns Topic | Document');
+  const delimiterCells = tableRows[1]
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  if (delimiterCells.length !== 2 || delimiterCells.some((cell) => !/^:?-{3,}:?$/.test(cell)))
+    throw new Error('Canonical documents table is missing its delimiter row');
+
+  const links = new Set();
+  for (const row of tableRows.slice(2)) {
+    const cells = row
+      .split('|')
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+    if (cells.length !== 2) throw new Error(`malformed Canonical documents row: ${row.trim()}`);
+    const target = canonicalTarget(cells[1]);
+    if (trackedPaths && !trackedPaths.has(target))
+      throw new Error(`canonical Document target is not tracked: ${target}`);
+    links.add(target);
+  }
+  if (links.size === 0) throw new Error('Canonical documents table has no document links');
+  return links;
+}
+
+function claimToken(value) {
+  const normalized = value.replace(/[*_`]/g, '');
+  const direct = normalized.match(/^\s*(AUTHORITATIVE|CANONICAL)\b/i);
+  if (direct) return direct[1].toUpperCase();
+  const activation = normalized.match(/\bbecomes\s+(AUTHORITATIVE|CANONICAL)\b/i);
+  return activation?.[1].toUpperCase() ?? null;
+}
+
+function preambleLines(contents) {
+  const lines = contents.split(/\r?\n/);
+  const visible = visibleMarkdownLines(lines);
+  const firstContentIndex = visible.findIndex((line) => line?.trim());
+  if (firstContentIndex === -1) return { frozen: false, lines: [] };
+  if (FROZEN_BANNER.test(visible[firstContentIndex])) return { frozen: true, lines: [] };
+
+  const preamble = [];
+  let sawH1 = false;
+  for (let index = 0; index < visible.length; index += 1) {
+    const line = visible[index];
+    if (line === null) continue;
+    if (/^#\s+/.test(line)) sawH1 = true;
+    if (sawH1 && (/^##\s+/.test(line) || /^\s*(?:---+|___+|\*\*\*+)\s*$/.test(line))) break;
+    preamble.push({ line: index + 1, text: line });
+  }
+  return { frozen: false, lines: preamble };
+}
+
+export function inspectAuthorityMetadata(contents) {
+  const preamble = preambleLines(contents);
+  if (preamble.frozen) return { claim: null, errors: [] };
+
+  const statuses = [];
+  for (const item of preamble.lines) {
+    const match = item.text.match(STATUS_FIELD);
+    if (match) statuses.push({ line: item.line, value: match[1].trim() });
+  }
+  if (statuses.length > 1) {
+    return {
+      claim: null,
+      errors: [
+        {
+          reason: 'DOC_AUTHORITY_AMBIGUOUS_STATUS',
+          line: statuses[1].line,
+          value: statuses.map((status) => status.value).join(' | '),
+        },
+      ],
+    };
+  }
+  if (statuses.length === 0) return { claim: null, errors: [] };
+
+  const token = claimToken(statuses[0].value);
+  return {
+    claim: token
+      ? { kind: `STATUS_${token}`, line: statuses[0].line, value: statuses[0].value }
+      : null,
+    errors: [],
+  };
+}
+
+export function effectiveAuthorityClaim(contents) {
+  return inspectAuthorityMetadata(contents).claim;
+}
+
+export function checkAuthorityGraph({ standardsText, documents, trackedPaths = null }) {
+  const canonicalLinks = canonicalDocumentLinks(standardsText, trackedPaths);
+  const claimants = [];
+  const findings = [];
+
+  for (const document of documents) {
+    const inspection = inspectAuthorityMetadata(document.contents);
+    for (const error of inspection.errors) findings.push({ path: document.path, ...error });
+    if (!inspection.claim) continue;
+    const item = { path: document.path, ...inspection.claim };
+    claimants.push(item);
+    if (!canonicalLinks.has(document.path))
+      findings.push({ reason: 'DOC_AUTHORITY_UNLINKED', ...item });
+  }
+
+  return { canonicalLinks, claimants, findings };
+}
+
+export function scanRepository(root = repositoryRoot) {
+  const tracked = execFileSync('git', ['-C', root, 'ls-files', '-z'], {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  })
+    .split('\0')
+    .filter(Boolean);
+  if (tracked.length === 0) throw new Error('Git reported no tracked repository files');
+  const trackedPaths = new Set(tracked);
+  const markdownDocs = tracked.filter(
+    (path) => path.startsWith('000-docs/') && path.endsWith('.md'),
+  );
+  if (markdownDocs.length === 0)
+    throw new Error('Git reported no tracked Markdown documents in 000-docs');
+
+  const documents = markdownDocs.map((path) => {
+    const absolute = resolve(root, path);
+    if (!lstatSync(absolute).isFile())
+      throw new Error(`tracked document is not a regular file: ${path}`);
+    return { path, contents: readFileSync(absolute, 'utf8') };
+  });
+  return checkAuthorityGraph({
+    standardsText: readFileSync(resolve(root, 'STANDARDS.md'), 'utf8'),
+    documents,
+    trackedPaths,
+  });
+}
+
+export function formatAuthorityReport(result) {
+  if (result.findings.length === 0)
+    return `document-authority: OK (${result.claimants.length} effective claimant documents; ${result.canonicalLinks.size} canonical-table links)`;
+
+  const lines = result.findings.map((finding) => {
+    if (finding.reason === 'DOC_AUTHORITY_UNLINKED')
+      return `${finding.reason} ${finding.path}:${finding.line} declares ${finding.kind} (${JSON.stringify(finding.value)}) but STANDARDS.md § Canonical documents does not link it`;
+    return `${finding.reason} ${finding.path}:${finding.line} has conflicting preamble status fields (${JSON.stringify(finding.value)})`;
+  });
+  lines.push(
+    `document-authority: ${result.findings.length} violation(s) among ${result.claimants.length} effective claimant documents`,
+  );
+  return lines.join('\n');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const result = scanRepository(process.argv[2] ? resolve(process.argv[2]) : repositoryRoot);
+    const report = formatAuthorityReport(result);
+    if (result.findings.length) {
+      console.error(report);
+      process.exitCode = 1;
+    } else console.log(report);
+  } catch (error) {
+    console.error(`DOC_AUTHORITY_CONFIG_ERROR ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-doc-authority.test.mjs
+++ b/scripts/check-doc-authority.test.mjs
@@ -193,6 +193,7 @@ test('Topic-column and later prose links cannot grant authority', () => {
 test('live repository has only linked effective claimants', () => {
   const result = scanRepository(repositoryRoot);
   deepEqual(result.findings, []);
+  equal(result.canonicalLinks.size, 10);
   deepEqual(result.claimants.map((item) => item.path).sort(), [
     '000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md',
     '000-docs/727-AT-ARCH-master-modernization-blueprint.md',

--- a/scripts/check-doc-authority.test.mjs
+++ b/scripts/check-doc-authority.test.mjs
@@ -1,0 +1,204 @@
+import { deepEqual, equal, match, throws } from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import {
+  canonicalDocumentLinks,
+  checkAuthorityGraph,
+  effectiveAuthorityClaim,
+  formatAuthorityReport,
+  scanRepository,
+} from './check-doc-authority.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const fixtureRoot = join(repositoryRoot, 'tests', 'fixtures', 'doc-authority');
+const fixture = (path) => readFileSync(join(fixtureRoot, path), 'utf8');
+const document = (path) => ({ path: `000-docs/${path}`, contents: fixture(`documents/${path}`) });
+
+test('linked direct and activated-conditional statuses pass while doc-class grants no authority', () => {
+  const result = checkAuthorityGraph({
+    standardsText: fixture('STANDARDS.md'),
+    documents: [document('linked.md'), document('conditional.md'), document('canonical-class.md')],
+  });
+  deepEqual(
+    result.claimants.map((item) => [item.path, item.kind]),
+    [
+      ['000-docs/linked.md', 'STATUS_AUTHORITATIVE'],
+      ['000-docs/conditional.md', 'STATUS_AUTHORITATIVE'],
+    ],
+  );
+  deepEqual(result.findings, []);
+});
+
+test('unlinked authority claim is a stable red proof', () => {
+  const result = checkAuthorityGraph({
+    standardsText: fixture('STANDARDS.md'),
+    documents: [document('unlinked.md'), document('masked.md')],
+  });
+  equal(result.findings.length, 2);
+  equal(result.findings[0].reason, 'DOC_AUTHORITY_UNLINKED');
+  equal(result.findings[1].reason, 'DOC_AUTHORITY_AMBIGUOUS_STATUS');
+  match(formatAuthorityReport(result), /unlinked\.md:3 declares STATUS_CANONICAL/);
+});
+
+test('command-line gate exits non-zero for a planted unlinked claimant', () => {
+  const root = mkdtempSync(join(tmpdir(), 'doc-authority-red-'));
+  try {
+    mkdirSync(join(root, '000-docs'), { recursive: true });
+    writeFileSync(join(root, 'STANDARDS.md'), fixture('STANDARDS.md'));
+    writeFileSync(join(root, '000-docs', 'linked.md'), fixture('documents/linked.md'));
+    writeFileSync(join(root, '000-docs', 'conditional.md'), fixture('documents/conditional.md'));
+    writeFileSync(join(root, '000-docs', 'unlinked.md'), fixture('documents/unlinked.md'));
+    execFileSync('git', ['init', '--quiet'], { cwd: root });
+    execFileSync(
+      'git',
+      [
+        'add',
+        'STANDARDS.md',
+        '000-docs/linked.md',
+        '000-docs/conditional.md',
+        '000-docs/unlinked.md',
+      ],
+      { cwd: root },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [join(repositoryRoot, 'scripts/check-doc-authority.mjs'), root],
+      {
+        encoding: 'utf8',
+      },
+    );
+    equal(result.status, 1);
+    match(result.stderr, /DOC_AUTHORITY_UNLINKED 000-docs\/unlinked\.md:3/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('ordinary prose, fenced examples, doc-class, frozen history, and references grant no authority', () => {
+  for (const path of [
+    'ordinary.md',
+    'fenced.md',
+    'canonical-class.md',
+    'frozen.md',
+    'reference.md',
+  ])
+    equal(effectiveAuthorityClaim(fixture(`documents/${path}`)), null, path);
+  equal(effectiveAuthorityClaim(fixture('documents/near-frozen.md')).kind, 'STATUS_CANONICAL');
+});
+
+test('equivalent preamble status metadata forms cannot evade detection', () => {
+  for (const status of [
+    '**Status:** **AUTHORITATIVE**',
+    '> **Status:** `CANONICAL`',
+    '> > **Status:** AUTHORITATIVE',
+    '- **Status:** CANONICAL',
+  ]) {
+    match(effectiveAuthorityClaim(`# Fixture\n\n${status}\n`).kind, /^STATUS_/);
+  }
+  equal(effectiveAuthorityClaim('# Fixture\n\n## History\n\n**Status:** CANONICAL\n'), null);
+  equal(effectiveAuthorityClaim('# Fixture\n\n---\n\n**Status:** CANONICAL\n'), null);
+  equal(effectiveAuthorityClaim('# Fixture\n\n<!-- **Status:** AUTHORITATIVE -->\n'), null);
+});
+
+test('canonical table parser fails closed when its section or links disappear', () => {
+  throws(() => canonicalDocumentLinks('# Standards\n'), /exactly one/);
+  throws(
+    () => canonicalDocumentLinks('## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n'),
+    /no data rows/,
+  );
+  throws(
+    () => canonicalDocumentLinks(`${fixture('STANDARDS.md')}\n## Canonical documents\n`),
+    /found 2/,
+  );
+  throws(
+    () =>
+      canonicalDocumentLinks(
+        '## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Bad | [external](https://example.com/x.md) |\n',
+      ),
+    /invalid canonical Document link/,
+  );
+  throws(
+    () => canonicalDocumentLinks(fixture('STANDARDS.md'), new Set(['000-docs/linked.md'])),
+    /not tracked: 000-docs\/conditional.md/,
+  );
+  throws(
+    () =>
+      canonicalDocumentLinks(
+        '## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Bad | [escape](../outside.md) |\n',
+      ),
+    /escapes the repository/,
+  );
+  throws(
+    () =>
+      canonicalDocumentLinks(
+        '## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Missing document cell |\n',
+      ),
+    /malformed Canonical documents row/,
+  );
+  throws(
+    () =>
+      canonicalDocumentLinks(
+        '## Canonical documents\n\n| Topic | Document |\n| --- | invalid |\n| Bad | [linked](000-docs/linked.md) |\n',
+      ),
+    /delimiter row/,
+  );
+  throws(
+    () =>
+      canonicalDocumentLinks(
+        '## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Bad | ~~[linked](000-docs/linked.md)~~ |\n',
+      ),
+    /one active link/,
+  );
+  const noncontiguous = canonicalDocumentLinks(
+    '## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Good | [linked](000-docs/linked.md) |\n\nProse ends the table.\n\n| Bad | [later](000-docs/later.md) |\n',
+  );
+  deepEqual([...noncontiguous], ['000-docs/linked.md']);
+  const fencedFake = canonicalDocumentLinks(
+    '```markdown\n## Canonical documents\n| Topic | Document |\n| --- | --- |\n| Fake | [fake](000-docs/fake.md) |\n```\n\n## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Good | [linked](000-docs/linked.md) |\n',
+  );
+  deepEqual([...fencedFake], ['000-docs/linked.md']);
+  const commentedFake = canonicalDocumentLinks(
+    '<!--\n## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Hidden | [hidden](000-docs/hidden.md) |\n-->\n\n## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Good | [linked](000-docs/linked.md) |\n',
+  );
+  deepEqual([...commentedFake], ['000-docs/linked.md']);
+  throws(
+    () =>
+      canonicalDocumentLinks(
+        '```markdown\n## Canonical documents\n| Topic | Document |\n| --- | --- |\n| Hidden | [hidden](000-docs/hidden.md) |\n```not-a-closing-fence\n| Still hidden | [hidden](000-docs/hidden.md) |\n```\n',
+      ),
+    /found 0/,
+  );
+  const fourSpacePseudoFence = canonicalDocumentLinks(
+    '    ```markdown\n## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Good | [linked](000-docs/linked.md) |\n',
+  );
+  deepEqual([...fourSpacePseudoFence], ['000-docs/linked.md']);
+  const tildeFake = canonicalDocumentLinks(
+    '~~~markdown\n## Canonical documents\n| Topic | Document |\n| --- | --- |\n| Hidden | [hidden](000-docs/hidden.md) |\n~~~\n\n## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| Good | [linked](000-docs/linked.md) |\n',
+  );
+  deepEqual([...tildeFake], ['000-docs/linked.md']);
+});
+
+test('Topic-column and later prose links cannot grant authority', () => {
+  const standardsText =
+    '## Canonical documents\n\n| Topic | Document |\n| --- | --- |\n| [unlinked](000-docs/unlinked.md) | [linked](000-docs/linked.md) |\n\n[unlinked](000-docs/unlinked.md)\n';
+  const result = checkAuthorityGraph({ standardsText, documents: [document('unlinked.md')] });
+  equal(result.findings[0].reason, 'DOC_AUTHORITY_UNLINKED');
+});
+
+test('live repository has only linked effective claimants', () => {
+  const result = scanRepository(repositoryRoot);
+  deepEqual(result.findings, []);
+  deepEqual(result.claimants.map((item) => item.path).sort(), [
+    '000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md',
+    '000-docs/727-AT-ARCH-master-modernization-blueprint.md',
+  ]);
+  equal(
+    result.claimants.find((item) => item.path.startsWith('000-docs/727-')).kind,
+    'STATUS_AUTHORITATIVE',
+  );
+});

--- a/tests/fixtures/doc-authority/STANDARDS.md
+++ b/tests/fixtures/doc-authority/STANDARDS.md
@@ -1,0 +1,12 @@
+# Standards fixture
+
+## Canonical documents
+
+| Topic              | Document                               |
+| ------------------ | -------------------------------------- |
+| Linked status      | [linked](000-docs/linked.md)           |
+| Conditional status | [conditional](000-docs/conditional.md) |
+
+## Later links do not grant authority
+
+[unlinked](000-docs/unlinked.md)

--- a/tests/fixtures/doc-authority/documents/canonical-class.md
+++ b/tests/fixtures/doc-authority/documents/canonical-class.md
@@ -1,0 +1,3 @@
+<!-- doc-class: canonical -->
+
+# Canonical class fixture

--- a/tests/fixtures/doc-authority/documents/conditional.md
+++ b/tests/fixtures/doc-authority/documents/conditional.md
@@ -1,0 +1,3 @@
+# Conditional authority
+
+**Status:** PROPOSED — becomes AUTHORITATIVE after its canonical pointer lands.

--- a/tests/fixtures/doc-authority/documents/fenced.md
+++ b/tests/fixtures/doc-authority/documents/fenced.md
@@ -1,0 +1,7 @@
+# Fenced example
+
+```markdown
+**Status:** CANONICAL
+```
+
+The example above does not grant this document authority.

--- a/tests/fixtures/doc-authority/documents/frozen.md
+++ b/tests/fixtures/doc-authority/documents/frozen.md
@@ -1,0 +1,5 @@
+> **SUPERSEDED–FROZEN.** Retained as historical evidence; not authoritative.
+
+# Frozen standard
+
+**Status**: CANONICAL (historical declaration)

--- a/tests/fixtures/doc-authority/documents/linked.md
+++ b/tests/fixtures/doc-authority/documents/linked.md
@@ -1,0 +1,3 @@
+# Linked standard
+
+**Status:** AUTHORITATIVE - Single Source of Truth

--- a/tests/fixtures/doc-authority/documents/masked.md
+++ b/tests/fixtures/doc-authority/documents/masked.md
@@ -1,0 +1,4 @@
+# Masked claim
+
+**Status:** DRAFT
+**Status:** AUTHORITATIVE

--- a/tests/fixtures/doc-authority/documents/near-frozen.md
+++ b/tests/fixtures/doc-authority/documents/near-frozen.md
@@ -1,0 +1,5 @@
+> **SUPERSEDED FROZEN.** This malformed banner lacks the required separator.
+
+# Near-frozen document
+
+**Status:** CANONICAL

--- a/tests/fixtures/doc-authority/documents/ordinary.md
+++ b/tests/fixtures/doc-authority/documents/ordinary.md
@@ -1,0 +1,3 @@
+# Ordinary record
+
+This record compares canonical URLs with authoritative upstream sources without claiming authority.

--- a/tests/fixtures/doc-authority/documents/reference.md
+++ b/tests/fixtures/doc-authority/documents/reference.md
@@ -1,0 +1,7 @@
+# Reference diagrams
+
+**Status**: REFERENCE (non-authoritative structural diagrams)
+
+## Historical footer
+
+**Status**: CANONICAL (legacy footer)

--- a/tests/fixtures/doc-authority/documents/unlinked.md
+++ b/tests/fixtures/doc-authority/documents/unlinked.md
@@ -1,0 +1,3 @@
+# Unlinked standard
+
+**Status**: CANONICAL


### PR DESCRIPTION
## Bead and authority\n\n- Bead: claude-hedb.2\n- Blueprint: 727 § Epic 2.3\n- Base: 80da5012bce3473dbdbc76c61b31d9b850f046c3\n- Head: d38fac6d7929c0d3a0cc8d164ab4bc54e74380ae\n\n## Scope\n\nAdds one fail-closed document-authority validator, fixture-driven red/green tests, and wiring inside the existing Validate Plugins doc-governance job. Demotes document 264 from self-declared authority to REFERENCE because SCHEMA_CHANGELOG.md and 6767-b already own those facts. Updates CHANGELOG.\n\nBefore: 3 effective status claimants, 1 unlinked violation, 10 canonical-table links.\nAfter: 2 effective status claimants, 0 violations, 10 canonical-table links.\n\nThe earlier blueprint count of three self-declarations uses a stale/different cohort and is deferred to E2.6; doc-class canonical is not treated as an authority grant.\n\n## Evidence\n\n- node --test scripts/check-doc-authority.test.mjs: PASS, 8/8\n- node scripts/check-doc-authority.mjs: PASS, 2 claimants / 10 links\n- Detached-base red proof: exit 1, document 264 unlinked, 1 violation among 3 claimants\n- actionlint .github/workflows/validate-plugins.yml: PASS\n- pnpm run format:check: PASS\n- pnpm lint: PASS\n- pnpm typecheck: PASS\n- pnpm run verify: PASS\n- doc ignore/citation/generated-artifact checks: PASS\n- gitleaks exact commit: PASS, no leaks\n- Hostile review after two correction rounds: PASS\n\npnpm test reaches an unchanged packages/cli Vitest transform ReferenceError before tests; this PR changes no CLI/package files. quick-test build and lint pass and report the existing 413-error standard-tier corpus baseline.\n\n## Security and licensing\n\nThe gate parses tracked repository Markdown only, rejects malformed or ambiguous authority data, and makes no network calls. No mirrored content, package, license, registry, credential, contributor, Plane, branch-protection, or production state changed.\n\n## Non-scope\n\nNo frozen 6767 body edits, STANDARDS authority-graph rewrite, fourth required status context, workflow path filter, E2.4+, or other Epic work.\n\n## Rollback\n\nRevert the eventual merge commit. Confirm document 264 returns to AUTHORITATIVE and the new validator, fixtures, workflow step, and changelog entry are absent. To prove the expected authority regression after rollback, create a detached temporary worktree at reviewed head d38fac6d7929c0d3a0cc8d164ab4bc54e74380ae and run that worktree's scripts/check-doc-authority.mjs against the reverted checkout; it must report document 264 as unlinked and exit nonzero. Remove the temporary worktree afterward.\n