### PR TITLE
test(docs-governance): gate frozen prose anchors

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1420,6 +1420,11 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       # 000-docs ignore-policy invariant (ownership + filing-ledger model —
       # 000-docs/.gitignore header; Mission 01 bead claude-5awj.6) plus the
       # citation gate: no governance-scope file may cite an untracked doc.
@@ -1442,6 +1447,11 @@ jobs:
         run: |
           node --test scripts/generate-docs-index.test.mjs
           node scripts/generate-docs-index.mjs --check
+
+      # 6767-h is a frozen historical standard that remains cited by schemas.
+      # Pin its section map and prove every cited heading still resolves.
+      - name: Check frozen prose anchors remain valid
+        run: python3 -m unittest tests.test_prose_anchors -v
 
       # Recurrence prevention for the tracked-generated-artifact class: a
       # projection that is also committed has two claimants to one fact and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (2026-08-15 — frozen prose-anchor gate)
+
+- **Frozen 6767-h section anchors are now regression-gated.** The existing `doc-governance` job
+  verifies the exact 21-section manifest, exercises valid and invalid citation fixtures, and proves
+  that renaming a cited heading fails closed before schema references can silently drift.
+
 ### Added (2026-08-15 — generated documentation index)
 
 - **The documentation estate index is now generated and drift-gated.** A deterministic generator

--- a/tests/fixtures/prose-anchors/expected-output.json
+++ b/tests/fixtures/prose-anchors/expected-output.json
@@ -1,5 +1,36 @@
 {
-  "_description": "Expected check-prose-anchors.py output (--json mode) for the two fixture schemas. Run against the live 6767-h index produced by parse-prose-anchors.py. The 'parsed_at' and 'doc_sha256' fields in the parser output are not captured here — only the check results are normalized.",
+  "_description": "Expected 6767-h anchor manifest and check-prose-anchors.py output (--json mode) for the two fixture schemas. The transient 'parsed_at' and whole-document 'doc_sha256' fields are intentionally not frozen.",
+  "anchor_manifest": [
+    {
+      "id": "0.1",
+      "title": "Global Master Standard – Claude Code Extensions (Plugins + Skills) Specification",
+      "level": 1
+    },
+    { "id": "0.0.1", "title": "Executive Summary", "level": 2 },
+    { "id": "0.0.0.1", "title": "What Is a Claude Code Extension?", "level": 3 },
+    { "id": "0.0.0.2", "title": "What Is a Skill?", "level": 3 },
+    { "id": "0.0.0.3", "title": "Non‑Negotiable Invariants (Enterprise Mode)", "level": 3 },
+    { "id": "1", "title": "Canonical Directory Structure", "level": 2 },
+    { "id": "1.1", "title": "Plugin Root Anatomy (Repository Standard)", "level": 3 },
+    { "id": "1.2", "title": "Skill Folder Anatomy", "level": 3 },
+    { "id": "2", "title": "Plugin Manifest: .claude-plugin/plugin.json", "level": 2 },
+    { "id": "2.1", "title": "Required Fields (Enterprise Marketplace)", "level": 3 },
+    { "id": "2.2", "title": "Path Resolution", "level": 3 },
+    { "id": "3", "title": "Skill Definition: skills/<skill-name>/SKILL.md", "level": 2 },
+    { "id": "3.1", "title": "YAML Frontmatter (Required)", "level": 3 },
+    { "id": "3.2", "title": "Instruction Body (Required Sections)", "level": 3 },
+    { "id": "3.3", "title": "{baseDir} and Bundled Files (References/Assets/Scripts)", "level": 3 },
+    {
+      "id": "4",
+      "title": "Marketplace & Website (claudecodeplugins.io) Safety Contract",
+      "level": 2
+    },
+    { "id": "4.1", "title": "Source of Truth for Published Plugins", "level": 3 },
+    { "id": "4.2", "title": "Skills/Explore Index Generation", "level": 3 },
+    { "id": "4.3", "title": "Required Website Gates (Zero Warnings Policy)", "level": 3 },
+    { "id": "5", "title": "Compliance Checklist (PASS/FAIL)", "level": 2 },
+    { "id": "A", "title": "In-Repo Canonical References", "level": 2 }
+  ],
   "valid_schema": {
     "input": "tests/fixtures/prose-anchors/valid-schema.json",
     "expected_exit_code": 0,

--- a/tests/test_prose_anchors.py
+++ b/tests/test_prose_anchors.py
@@ -1,0 +1,152 @@
+"""Regression gate for the frozen 6767-h prose anchors.
+
+Run: python3 -m unittest tests.test_prose_anchors -v
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PARSER = ROOT / "scripts" / "parse-prose-anchors.py"
+CHECKER = ROOT / "scripts" / "check-prose-anchors.py"
+DOC = ROOT / "000-docs" / "6767-h-SPEC-DR-STND-claude-code-extensions-master.md"
+FIXTURES = ROOT / "tests" / "fixtures" / "prose-anchors"
+EXPECTED = json.loads((FIXTURES / "expected-output.json").read_text(encoding="utf-8"))
+
+
+def run_script(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+
+class FrozenProseAnchorTests(unittest.TestCase):
+    def test_live_document_matches_frozen_anchor_manifest(self) -> None:
+        for args in ((), ("--doc", str(DOC))):
+            with self.subTest(arguments=args):
+                result = run_script(PARSER, *args)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+                parsed = json.loads(result.stdout)
+                manifest = [
+                    {key: section[key] for key in ("id", "title", "level")} for section in parsed["sections"]
+                ]
+                self.assertEqual(manifest, EXPECTED["anchor_manifest"])
+                ids = [section["id"] for section in manifest]
+                self.assertEqual(len(ids), 21)
+                self.assertEqual(len(ids), len(set(ids)), "anchor IDs must be unique")
+                self.assertEqual(parsed["doc_path"], str(DOC.relative_to(ROOT)))
+                self.assertEqual(parsed["doc_sha256"], hashlib.sha256(DOC.read_bytes()).hexdigest())
+                self.assertIsNotNone(datetime.fromisoformat(parsed["parsed_at"]).tzinfo)
+
+    def test_valid_and_invalid_schema_fixtures(self) -> None:
+        for fixture_name in ("valid_schema", "invalid_schema"):
+            with self.subTest(fixture=fixture_name):
+                fixture = EXPECTED[fixture_name]
+                result = run_script(
+                    CHECKER,
+                    "--doc",
+                    str(DOC),
+                    "--schemas",
+                    fixture["input"],
+                    "--json",
+                )
+                self.assertEqual(result.returncode, fixture["expected_exit_code"], result.stderr)
+                self.assertEqual(json.loads(result.stdout), fixture["expected_output"])
+
+    def test_cited_heading_rename_fails_closed(self) -> None:
+        source = DOC.read_text(encoding="utf-8")
+        replacements = {
+            "### 3.1 YAML Frontmatter (Required)": "### 3.9 YAML Frontmatter (Required)",
+            "### 4.3 Required Website Gates (Zero Warnings Policy)": (
+                "### 4.9 Required Website Gates (Zero Warnings Policy)"
+            ),
+        }
+
+        for original, replacement in replacements.items():
+            with self.subTest(anchor=original.split()[1]), tempfile.TemporaryDirectory() as tmp:
+                self.assertIn(original, source)
+                changed_doc = Path(tmp) / DOC.name
+                changed_doc.write_text(source.replace(original, replacement, 1), encoding="utf-8")
+                result = run_script(
+                    CHECKER,
+                    "--doc",
+                    str(changed_doc),
+                    "--schemas",
+                    "tests/fixtures/prose-anchors/valid-schema.json",
+                    "--json",
+                )
+                report = json.loads(result.stdout)
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertFalse(report["valid"])
+                cited_ids = {finding["cited_id"] for finding in report["broken_anchors"]}
+                self.assertIn(original.split()[1], cited_ids)
+
+    def test_missing_document_and_malformed_schema_fail_closed(self) -> None:
+        missing_doc = run_script(
+            CHECKER,
+            "--doc",
+            "tests/fixtures/prose-anchors/missing.md",
+            "--schemas",
+            "tests/fixtures/prose-anchors/valid-schema.json",
+            "--json",
+        )
+        self.assertEqual(missing_doc.returncode, 2)
+        self.assertIn("--doc not found", missing_doc.stderr)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            malformed = Path(tmp) / "malformed.json"
+            malformed.write_text("{not-json", encoding="utf-8")
+            result = run_script(
+                CHECKER,
+                "--doc",
+                str(DOC),
+                "--schemas",
+                str(malformed),
+                "--json",
+            )
+            report = json.loads(result.stdout)
+            self.assertEqual(result.returncode, 1)
+            self.assertFalse(report["valid"])
+            self.assertEqual(report["broken_anchors"][0]["cited_id"], "<parse-error>")
+
+    def test_missing_and_malformed_index_fail_closed(self) -> None:
+        missing_index = run_script(
+            CHECKER,
+            "--index",
+            "tests/fixtures/prose-anchors/missing-index.json",
+            "--schemas",
+            "tests/fixtures/prose-anchors/valid-schema.json",
+        )
+        self.assertNotEqual(missing_index.returncode, 0)
+        self.assertIn("--index not found", missing_index.stderr)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            malformed_index = Path(tmp) / "malformed-index.json"
+            malformed_index.write_text("{not-json", encoding="utf-8")
+            result = run_script(
+                CHECKER,
+                "--index",
+                str(malformed_index),
+                "--schemas",
+                "tests/fixtures/prose-anchors/valid-schema.json",
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("ERROR building index", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Bead and authority

- Bead: claude-hedb.4
- Blueprint: 727 Epic 2.9
- Base: 78f0fab1e47f4305076dd598677a9ecd65de35d2
- Reviewed candidate head: fcdf54ef7a1e7ad6fb935efd1c0438e5f2841ee7

## Scope

Adds a deterministic unittest gate for the frozen 6767-h prose-anchor namespace, wires it into the existing doc-governance job, and records the change in CHANGELOG.md.

## Explicit non-scope

No frozen 6767 document edits; no new job or required context; no paths filter, fallback, or continue-on-error; no E2.5 or other bead; no registry, credential, contributor, Plane, branch-protection, production, mirror, package, or generated timestamp mutation.

## Before and after

Before: parser and checker existed but CI invoked neither; unittest discovery found zero prose-anchor tests. After: 21 ordered unique ID/title/level anchors are pinned, valid and invalid fixtures execute, and cited 3.1/4.3 heading renames plus missing or malformed inputs fail closed.

## Validation

- python3 -m unittest tests.test_prose_anchors -v: PASS, 5/5
- actionlint .github/workflows/validate-plugins.yml: PASS
- existing doc-governance command sequence: PASS
- pnpm run format:check: PASS
- pnpm lint: PASS
- pnpm typecheck: PASS
- pnpm run verify: PASS; command-induced catalog formatting was reversed and is absent from this diff
- gitleaks detect --no-banner --redact --source .: PASS, 1,670 commits, no leaks
- independent hostile working-tree review: PASS

Broad pnpm test has a pre-existing packages/cli Vitest loader failure: __vite_ssr_exportName__ is undefined at program.ts:1 on Node 22 and Node 20.20.2. No CLI, package, or lockfile file differs from base. Required exact-head GitHub checks remain authoritative.

## Security and licensing

Fail-closed documentation compatibility gate only. No provenance, package, mirrored content, licensing, credential, or network publication behavior changes.

## Rollback

Revert the single implementation commit. No generated state or frozen prose needs restoration.

## Remaining gates

Independent clean-checkout review of this exact head and all required GitHub CI and bot checks. Owner-authorized administrator bypass may be used only after those gates pass and will be disclosed.