### PR TITLE
feat(docs-governance): require complete supersession records

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1450,6 +1450,13 @@ jobs:
           node --test scripts/check-doc-authority.test.mjs
           node scripts/check-doc-authority.mjs
 
+      # Supersession is one atomic record, not a status-only edit. Keep the
+      # frozen header, per-section disposition, and canonical pointer together.
+      - name: Check document supersession record template
+        run: |
+          node --test scripts/check-supersession-template.test.mjs
+          node scripts/check-supersession-template.mjs --all
+
       # The documentation estate index is a generated projection of Git's
       # tracked inventory; hand-edited counts or rows must never drift.
       - name: Check generated documentation index is current

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -42,3 +42,4 @@
 !743-AA-AACR-epic-1-measurement-harness.md
 !744-AA-AACR-epic-1-corpus-resolver.md
 !745-AA-AACR-epic-1-readme-writer.md
+!746-DR-TMPL-document-supersession.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (185 files). Local-only working
+Covers the **tracked** documentation estate (186 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -167,6 +167,7 @@ index and `000-docs/.gitignore`.
 - [743-AA-AACR-epic-1-measurement-harness.md](743-AA-AACR-epic-1-measurement-harness.md)
 - [744-AA-AACR-epic-1-corpus-resolver.md](744-AA-AACR-epic-1-corpus-resolver.md)
 - [745-AA-AACR-epic-1-readme-writer.md](745-AA-AACR-epic-1-readme-writer.md)
+- [746-DR-TMPL-document-supersession.md](746-DR-TMPL-document-supersession.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/6767-a-SPEC-DR-STND-claude-code-plugins-standard.md
+++ b/000-docs/6767-a-SPEC-DR-STND-claude-code-plugins-standard.md
@@ -1,3 +1,5 @@
+<!-- doc-class: frozen -->
+
 > **SUPERSEDED–FROZEN (Epic 2 bead 2.1; 2026-08-15).** This historical standard is retained for citation and anchor compatibility; it is not authoritative. The governing platform standard is [727](727-AT-ARCH-master-modernization-blueprint.md). Its known-false rule is its self-declared canonical authority: 727 records this document as superseded ([727:65](727-AT-ARCH-master-modernization-blueprint.md#L65)) and records why an unlinked `CANONICAL` declaration is invalid ([727:862](727-AT-ARCH-master-modernization-blueprint.md#L862)). Its legacy examples do not establish the current schema. Do not edit below this banner; preserve the body and section anchors byte-for-byte.
 
 # Global Master Standard – Claude Code Plugins & Marketplace Specification

--- a/000-docs/6767-c-DR-STND-claude-code-extensions-standard.md
+++ b/000-docs/6767-c-DR-STND-claude-code-extensions-standard.md
@@ -1,3 +1,5 @@
+<!-- doc-class: frozen -->
+
 > **SUPERSEDED–FROZEN (Epic 2 bead 2.1; 2026-08-15).** This historical standard is retained for citation and anchor compatibility; it is not authoritative. The governing platform standard is [727](727-AT-ARCH-master-modernization-blueprint.md). Its known-false rules are that `allowed-tools` must be CSV rather than a valid YAML list ([727:38](727-AT-ARCH-master-modernization-blueprint.md#L38)) and that this unlinked document may self-declare `CANONICAL` ([727:862](727-AT-ARCH-master-modernization-blueprint.md#L862)). Do not edit below this banner; preserve the body and section anchors byte-for-byte.
 
 # 6767-c-DR-STND-claude-code-extensions-standard.md

--- a/000-docs/6767-d-AT-APIS-claude-code-extensions-schema.md
+++ b/000-docs/6767-d-AT-APIS-claude-code-extensions-schema.md
@@ -1,3 +1,5 @@
+<!-- doc-class: frozen -->
+
 > **SUPERSEDED–FROZEN (Epic 2 bead 2.1; 2026-08-15).** This historical schema is retained for citation and anchor compatibility; it is not authoritative. The governing platform standard is [727](727-AT-ARCH-master-modernization-blueprint.md). Its known-false rules are that `allowed-tools` must be CSV rather than a valid YAML list ([727:38](727-AT-ARCH-master-modernization-blueprint.md#L38)) and that this unlinked document may self-declare `CANONICAL` ([727:862](727-AT-ARCH-master-modernization-blueprint.md#L862)). Do not edit below this banner; preserve the body and section anchors byte-for-byte.
 
 # 6767-d-AT-APIS-at-stnd-claude-code-extensions.md

--- a/000-docs/6767-e-WA-WFLW-extensions-validation-ci-gates.md
+++ b/000-docs/6767-e-WA-WFLW-extensions-validation-ci-gates.md
@@ -1,3 +1,5 @@
+<!-- doc-class: frozen -->
+
 > **SUPERSEDED–FROZEN (Epic 2 bead 2.1; 2026-08-15).** This historical CI-gate document is retained for citation and anchor compatibility; it is not authoritative. The governing platform standard is [727](727-AT-ARCH-master-modernization-blueprint.md). Its known-false rules are that `allowed-tools` must be CSV rather than a valid YAML list ([727:38](727-AT-ARCH-master-modernization-blueprint.md#L38)) and that this unlinked document may self-declare `CANONICAL` ([727:862](727-AT-ARCH-master-modernization-blueprint.md#L862)). Do not edit below this banner; preserve the body and section anchors byte-for-byte.
 
 # 6767-e-WA-WFLW-wa-stnd-extensions-validation-ci.md

--- a/000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md
+++ b/000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md
@@ -1,3 +1,5 @@
+<!-- doc-class: frozen -->
+
 > **SUPERSEDED–FROZEN (Epic 2 bead 2.1; 2026-08-15).** This historical standard is retained for citation and anchor compatibility; it is not authoritative. The governing platform standard is [727](727-AT-ARCH-master-modernization-blueprint.md). Its known-false rules are: CSV-only `allowed-tools` ([727:38](727-AT-ARCH-master-modernization-blueprint.md#L38)); six required fields instead of eight ([727:39](727-AT-ARCH-master-modernization-blueprint.md#L39)); the nonexistent `scripts/validate-frontmatter.py` and the wrong package manager for `marketplace/` ([727:40](727-AT-ARCH-master-modernization-blueprint.md#L40)); authority assigned to dead `claudecodeplugins.io` rather than live `tonsofskills.com` ([727:36](727-AT-ARCH-master-modernization-blueprint.md#L36)); and supersession of the still-canonical 6767-b rubric ([727:43](727-AT-ARCH-master-modernization-blueprint.md#L43)). Do not edit below this banner; preserve the body and section anchors byte-for-byte.
 
 # Global Master Standard – Claude Code Extensions (Plugins + Skills) Specification

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23014
+        "tracked_files": 23032
       }
     },
     "2": {
@@ -2249,10 +2249,10 @@
       "source": ["000-docs/000-INDEX.md"],
       "status": "measured",
       "values": {
-        "index_entries": 185,
+        "index_entries": 186,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 185,
+        "tracked_documents": 186,
         "untracked_index_entries": []
       }
     },
@@ -2276,9 +2276,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15503,
+        "invisible_files": 15520,
         "target_invisible_files": 0,
-        "tracked_files": 23014
+        "tracked_files": 23032
       }
     },
     "47": {

--- a/000-docs/746-DR-TMPL-document-supersession.md
+++ b/000-docs/746-DR-TMPL-document-supersession.md
@@ -1,0 +1,112 @@
+<!-- doc-class: record -->
+
+# Document Supersession Record Template
+
+Use this record whenever one governed document replaces all or part of another. Supersession is
+one atomic pull request, not a status-only edit: the old document is frozen, the new authority
+disposes every affected section, `STANDARDS.md` points to the new owner, and the old document gains
+the machine-readable frozen class.
+
+## Copyable record
+
+Copy the block below into the superseding document, replace every angle-bracket placeholder, and
+run `node scripts/check-supersession-template.mjs <document>`. The checker ignores this fenced
+example and rejects placeholders in a completed record. Keep the structural label
+`**Frozen header:**` exact unless the record embeds a title-only
+`> **SUPERSEDED–FROZEN (...).**` blockquote. Do not append or continue prose in that blockquote;
+the checker intentionally rejects natural-language evidence.
+
+Repository review runs `node scripts/check-supersession-template.mjs --all`, which discovers
+tracked Markdown under `000-docs/` and validates every visible completed-record block or malformed
+record attempt. Ordinary documents and fenced or commented examples do not enter that cohort. The
+gate fails closed if no completed record remains; remove the worked example only in the same change
+that files a replacement record.
+
+```markdown
+<!-- BEGIN SUPERSESSION RECORD -->
+
+## Supersession record: <old document> to <new document>
+
+- **Atomic PR:** This one pull request carries every checked item below.
+- **Frozen document(s):** `<path to each old document>`
+- **Superseding document:** `<path to new document>`
+- **Frozen header:** `<!-- doc-class: frozen -->` followed by a `SUPERSEDED–FROZEN` banner.
+- **STANDARDS.md Canonical documents pointer:** `<table row linking the new document>`
+
+### Section disposition
+
+| Superseded section            | Disposition                                                                    | New authority                    |
+| ----------------------------- | ------------------------------------------------------------------------------ | -------------------------------- |
+| `<old section or fact class>` | `CARRIED FORWARD`, `REPLACED`, `REVERSED`, or `SUPERSEDED WITHOUT REPLACEMENT` | `<new section or explicit none>` |
+
+### Required checklist
+
+- [ ] The old document starts with `<!-- doc-class: frozen -->`.
+- [ ] A `SUPERSEDED–FROZEN` banner names the new authority and known-false rules.
+- [ ] Every affected section appears in the disposition table.
+- [ ] `STANDARDS.md` § Canonical documents links the new fact owner.
+- [ ] All four changes are present in this one pull request.
+- [ ] Content below the frozen banner and all frozen section anchors are byte-identical.
+<!-- END SUPERSESSION RECORD -->
+```
+
+Do not delete or renumber the old document. If the new document does not own a displaced fact,
+write `SUPERSEDED WITHOUT REPLACEMENT` and `none`; never invent a replacement pointer.
+
+## Worked example: the five-document 6767 reconciliation
+
+This is a normalized example of the required record shape, not a claim that the historical
+ratification and freeze changes landed atomically. It records all five standards that 727 § 0
+already supersedes and freezes. Future supersessions must land the four components in one PR.
+
+<!-- BEGIN SUPERSESSION RECORD -->
+
+## Supersession record: 6767-a/c/d/e/h to 727
+
+- **Atomic PR:** A conforming transaction carries every checked item below in one pull request.
+- **Frozen document(s):** `000-docs/6767-a-SPEC-DR-STND-claude-code-plugins-standard.md`,
+  `000-docs/6767-c-DR-STND-claude-code-extensions-standard.md`,
+  `000-docs/6767-d-AT-APIS-claude-code-extensions-schema.md`,
+  `000-docs/6767-e-WA-WFLW-extensions-validation-ci-gates.md`, and
+  `000-docs/6767-h-SPEC-DR-STND-claude-code-extensions-master.md`.
+- **Superseding document:** `000-docs/727-AT-ARCH-master-modernization-blueprint.md`
+- **Frozen header:** `<!-- doc-class: frozen -->` followed by the existing
+  `SUPERSEDED–FROZEN` banner.
+- **STANDARDS.md Canonical documents pointer:** the Platform master standard row links
+  `000-docs/727-AT-ARCH-master-modernization-blueprint.md`.
+
+### Section disposition
+
+| Superseded section                    | Disposition                    | New authority                      |
+| ------------------------------------- | ------------------------------ | ---------------------------------- |
+| 6767-a canonical platform claim       | REPLACED                       | 727 § 0 and § 11                   |
+| 6767-c CSV-only tool rule             | REVERSED                       | 727 § 0 and § 5                    |
+| 6767-d CSV-only schema rule           | REVERSED                       | 727 § 0 and § 5                    |
+| 6767-e CSV-only validation rule       | REVERSED                       | 727 § 0 and § 5                    |
+| § 1 plugin and skill anatomy          | CARRIED FORWARD                | 727 § 0, section-level disposition |
+| Invariant 1, CSV-only `allowed-tools` | REVERSED                       | 727 § 0 and § 5                    |
+| § 2.1, § 3.1, and § 5 required fields | REPLACED                       | 727 § 0 and § 5                    |
+| § 4.3 website gates                   | REPLACED                       | 727 § 0 and § 11                   |
+| Obsolete tooling references           | SUPERSEDED WITHOUT REPLACEMENT | none                               |
+
+### Required checklist
+
+- [x] The old document starts with `<!-- doc-class: frozen -->`.
+- [x] Its `SUPERSEDED–FROZEN` banner names 727 and the known-false rules.
+- [x] 727 § 0 disposes all affected 6767-a/c/d/e/h claims and sections.
+- [x] `STANDARDS.md` § Canonical documents links 727 as the platform master standard.
+- [x] This normalized record binds all four components into one review shape.
+- [x] Frozen prose-anchor tests preserve the body and section namespace.
+<!-- END SUPERSESSION RECORD -->
+
+## Reviewer checklist
+
+1. Run the checker against the completed record; a missing component must exit non-zero with a
+   stable reason code.
+2. Run corpus mode and confirm the new record is discovered from the tracked-document inventory.
+3. Diff the old document against the base after removing only the newly prepended class marker and
+   banner. Content below the banner must be byte-identical.
+4. Run `node scripts/check-doc-authority.mjs` and the frozen prose-anchor suite.
+5. Verify the complete PR diff contains the frozen header, disposition, canonical pointer, and
+   completed record together.
+6. Return the PR if any component is deferred to a follow-up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (2026-08-16 — required supersession records)
+
+- **Document supersession now has one reviewable record shape.** A filed template binds the frozen
+  class marker, `SUPERSEDED–FROZEN` banner, per-section disposition, and `STANDARDS.md` canonical
+  pointer into one pull request. A fixture-driven checker rejects missing components, placeholders,
+  and fenced or commented decoys inside the existing documentation-governance gate. The same gate
+  discovers every tracked completed record or malformed attempt; the five-document 6767 to 727
+  reconciliation is the worked example. The corpus gate fails closed if no completed record remains,
+  so removing that example requires filing a replacement record in the same change.
+
 ### Changed (2026-08-16 — single README metrics writer)
 
 - **README counts now have one enforced writer.** The orphaned

--- a/scripts/check-supersession-template.mjs
+++ b/scripts/check-supersession-template.mjs
@@ -1,0 +1,561 @@
+#!/usr/bin/env node
+
+/** Validate completed supersession records without interpreting frozen documents. */
+import { spawnSync } from 'node:child_process';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_TEMPLATE = '000-docs/746-DR-TMPL-document-supersession.md';
+const BEGIN = '<!-- BEGIN SUPERSESSION RECORD -->';
+const END = '<!-- END SUPERSESSION RECORD -->';
+const FROZEN_MARKER = '<!-- doc-class: frozen -->';
+const EXPECTED_COLUMNS = ['superseded section', 'disposition', 'new authority'];
+const ALLOWED_DISPOSITIONS = new Set([
+  'CARRIED FORWARD',
+  'REPLACED',
+  'REVERSED',
+  'SUPERSEDED WITHOUT REPLACEMENT',
+]);
+const RECORD_MISSING = 'SUPERSESSION_RECORD_MISSING';
+
+function finding(code, message, line = null, record = null) {
+  return {
+    code,
+    message,
+    ...(line === null ? {} : { line }),
+    ...(record === null ? {} : { record }),
+  };
+}
+
+function stripComments(rawLine, state) {
+  let line = rawLine;
+  let visible = '';
+  while (line.length) {
+    if (state.htmlComment > 0) {
+      const start = line.indexOf('<!--');
+      const end = line.indexOf('-->');
+      if (start !== -1 && (end === -1 || start < end)) {
+        state.htmlComment += 1;
+        line = line.slice(start + 4);
+        continue;
+      }
+      if (end === -1) return visible;
+      state.htmlComment -= 1;
+      line = line.slice(end + 3);
+      continue;
+    }
+    const start = line.indexOf('<!--');
+    if (start === -1) return visible + line;
+    visible += line.slice(0, start);
+    state.htmlComment += 1;
+    line = line.slice(start + 4);
+  }
+  return visible;
+}
+
+function fenceToken(line) {
+  return line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+}
+
+function hasVisibleInlineMachineMarker(rawLine, initialCommentDepth) {
+  const target = `\`${FROZEN_MARKER}\``;
+  let line = rawLine;
+  let depth = initialCommentDepth;
+
+  while (line.length) {
+    if (depth > 0) {
+      const start = line.indexOf('<!--');
+      const end = line.indexOf('-->');
+      if (start !== -1 && (end === -1 || start < end)) {
+        depth += 1;
+        line = line.slice(start + 4);
+        continue;
+      }
+      if (end === -1) return false;
+      depth -= 1;
+      line = line.slice(end + 3);
+      continue;
+    }
+
+    const targetIndex = line.indexOf(target);
+    const commentIndex = line.indexOf('<!--');
+    if (targetIndex !== -1 && (commentIndex === -1 || targetIndex < commentIndex)) return true;
+    if (commentIndex === -1) return false;
+    depth += 1;
+    line = line.slice(commentIndex + 4);
+  }
+
+  return false;
+}
+
+/** Extract exact, visible completed-record blocks and delimiter errors. */
+export function parseSupersessionRecords(markdown) {
+  if (typeof markdown !== 'string') throw new TypeError('markdown must be a string');
+
+  const records = [];
+  const findings = [];
+  const state = { fence: null, htmlComment: 0 };
+  let current = null;
+  const lines = markdown.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    const lineNumber = index + 1;
+
+    if (state.fence) {
+      const close = raw.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/)?.[1] ?? null;
+      if (close && close[0] === state.fence.character && close.length >= state.fence.length)
+        state.fence = null;
+      if (current) current.lines.push({ line: lineNumber, raw, visible: '' });
+      continue;
+    }
+
+    const trimmed = raw.trim();
+    if (!state.htmlComment && (trimmed === BEGIN || trimmed === END)) {
+      if (trimmed === BEGIN) {
+        if (current) {
+          findings.push(
+            finding(
+              'SUPERSESSION_RECORD_NESTED_BEGIN',
+              'a completed record cannot contain another begin marker',
+              lineNumber,
+              current.index,
+            ),
+          );
+        } else {
+          current = { index: records.length + 1, startLine: lineNumber, endLine: null, lines: [] };
+        }
+      } else if (!current) {
+        findings.push(
+          finding(
+            'SUPERSESSION_RECORD_UNEXPECTED_END',
+            'end marker has no matching visible begin marker',
+            lineNumber,
+          ),
+        );
+      } else {
+        current.endLine = lineNumber;
+        records.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    if (!state.htmlComment && current && trimmed === FROZEN_MARKER) {
+      current.lines.push({ line: lineNumber, raw, visible: '', machineMarker: true });
+      continue;
+    }
+
+    const inlineMachineMarker = current && hasVisibleInlineMachineMarker(raw, state.htmlComment);
+    const visible = stripComments(raw, state);
+    const opening = !state.htmlComment && fenceToken(visible);
+    if (opening && !(opening[1][0] === '`' && opening[2].includes('`'))) {
+      state.fence = { character: opening[1][0], length: opening[1].length };
+      if (current) current.lines.push({ line: lineNumber, raw, visible: '' });
+      continue;
+    }
+    if (current)
+      current.lines.push({ line: lineNumber, raw, visible, machineMarker: inlineMachineMarker });
+  }
+
+  if (current)
+    findings.push(
+      finding(
+        'SUPERSESSION_RECORD_UNCLOSED',
+        'completed record is missing its exact end marker',
+        current.startLine,
+        current.index,
+      ),
+    );
+  if (records.length === 0)
+    findings.push(
+      finding(
+        'SUPERSESSION_RECORD_MISSING',
+        'no visible completed supersession record block was found',
+      ),
+    );
+
+  return { records, findings };
+}
+
+function tableCells(line) {
+  if (!/^\s*\|.*\|\s*$/.test(line)) return null;
+  return line
+    .trim()
+    .slice(1, -1)
+    .split('|')
+    .map((cell) => cell.trim());
+}
+
+function normalizedHeader(cell) {
+  return cell.replace(/[*_`]/g, '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function normalizedDisposition(cell) {
+  return cell.replace(/[*_`]/g, '').trim().toUpperCase().replace(/\s+/g, ' ');
+}
+
+function isNegated(text) {
+  const normalized = text
+    .replace(/\bdo(?:\s+not|n['’]t)\s+forget\s+to\b/gi, 'must')
+    .replace(/\bnot\s+only\b/gi, '')
+    .replace(/\bunchanged\s+from\b/gi, 'consistent with');
+  return /\b(?:(?:is|are|was|were|do|does|did|has|have|had|could|should|would|must)n['’]t|can['’]t|won['’]t|do\s+not|does\s+not|did\s+not|fail(?:s|ed)?\s+to|cannot|not|never|without|avoid(?:s|ed|ing)?|refus(?:e|es|ed|ing)|prohibit(?:s|ed|ing)?|forbid(?:s|den|ding)?|omit(?:s|ted|ting)?|skip(?:s|ped|ping)?|unchanged)\b/i.test(
+    normalized,
+  );
+}
+
+function isDirectBannerEvidence(text) {
+  // A title-only controlled blockquote is the evidence. Prose belongs in the
+  // structured record fields; accepting it here would require interpreting an
+  // unbounded set of contradictory or obfuscated natural-language claims.
+  return /^ {0,3}>[ \t]+\*\*SUPERSEDED–FROZEN(?: \([A-Za-z0-9][A-Za-z0-9 .;:/#-]*\))?\.\*\*[ \t]*$/.test(
+    text,
+  );
+}
+
+function directBannerBlockText(lines, startIndex) {
+  const parts = [];
+  for (let index = startIndex - 1; index >= 0; index -= 1) {
+    const item = lines[index];
+    const visible = item.visible.trim();
+    const raw = item.raw.trim();
+    if (/^(?:#{1,6}\s|[-+*]\s|\d+[.)]\s|\|)/.test(visible)) break;
+    if (raw && !item.machineMarker) parts.unshift(item.raw.trimEnd());
+  }
+  parts.push(lines[startIndex].raw.trimEnd());
+  for (const item of lines.slice(startIndex + 1)) {
+    const visible = item.visible.trim();
+    const raw = item.raw.trim();
+    if (!visible) {
+      if (raw && !item.machineMarker) parts.push(raw);
+      continue;
+    }
+    // Markdown permits lazy continuations and separate blockquote paragraphs.
+    // Inspect everything until the next record structure so neither can append
+    // a contradictory claim to an otherwise valid title.
+    if (/^(?:#{1,6}\s|[-+*]\s|\d+[.)]\s|\|)/.test(visible)) break;
+    parts.push(item.raw.trimEnd());
+  }
+  return parts.join('\n');
+}
+
+function isPlaceholder(text) {
+  return (
+    /\b(?:TODO|TBD|TBC|FIXME|CHANGEME|PLACEHOLDER|REPLACE\s+ME|NNN)\b/i.test(text) ||
+    /\bYYYY-MM-DD\b/i.test(text) ||
+    /<(?:insert|replace|old|new|path|table|document|section|authority|date|value)[^>]*>/i.test(
+      text,
+    ) ||
+    /\[(?:insert|placeholder|section|new authority|document|path|date)[^\]]*\]/i.test(text)
+  );
+}
+
+function checkedItems(record) {
+  return record.lines
+    .map((item) => ({ line: item.line, match: item.visible.match(/^\s*[-+*]\s+\[[xX]\]\s+(.+)$/) }))
+    .filter((item) => item.match)
+    .map((item) => ({ line: item.line, text: item.match[1].trim() }));
+}
+
+function continuedListItemText(lines, startIndex) {
+  const parts = [lines[startIndex].visible.trim()];
+  for (const item of lines.slice(startIndex + 1)) {
+    const text = item.visible.trim();
+    if (!text || /^(?:[-+*]\s|>|#|\|)/.test(text)) break;
+    parts.push(text);
+  }
+  return parts.join(' ');
+}
+
+function inspectRecord(record) {
+  const findings = [];
+  const markerLines = record.lines.filter((item) => item.machineMarker);
+  if (markerLines.length === 0)
+    findings.push(
+      finding(
+        'SUPERSESSION_FROZEN_MARKER_MISSING',
+        `record must contain the exact marker ${FROZEN_MARKER}`,
+        record.startLine,
+        record.index,
+      ),
+    );
+
+  const bannerLines = record.lines.filter((item, index) => {
+    if (/^\s*>\s+\*\*SUPERSEDED–FROZEN\b/.test(item.visible))
+      return isDirectBannerEvidence(directBannerBlockText(record.lines, index));
+    if (!/^\s*[-+*]\s+\*\*Frozen header:\*\*/i.test(item.visible)) return false;
+    const field = continuedListItemText(record.lines, index);
+    return /\bSUPERSEDED–FROZEN\b/.test(field) && !isNegated(field);
+  });
+  if (bannerLines.length === 0)
+    findings.push(
+      finding(
+        'SUPERSESSION_FROZEN_BANNER_MISSING',
+        'record must contain a visible SUPERSEDED–FROZEN banner',
+        record.startLine,
+        record.index,
+      ),
+    );
+
+  const visibleText = record.lines.map((item) => item.visible).join('\n');
+  const placeholderLine = record.lines.find((item) => isPlaceholder(item.visible));
+  if (placeholderLine)
+    findings.push(
+      finding(
+        'SUPERSESSION_PLACEHOLDER_PRESENT',
+        'completed records cannot contain placeholder tokens',
+        placeholderLine.line,
+        record.index,
+      ),
+    );
+
+  const headers = record.lines.filter((item) => {
+    const cells = tableCells(item.visible);
+    return cells && cells.map(normalizedHeader).join('\0') === EXPECTED_COLUMNS.join('\0');
+  });
+  let dispositionRows = [];
+  if (headers.length === 0) {
+    findings.push(
+      finding(
+        'SUPERSESSION_DISPOSITION_TABLE_MISSING',
+        `record must contain the columns ${EXPECTED_COLUMNS.join(' | ')}`,
+        record.startLine,
+        record.index,
+      ),
+    );
+  } else if (headers.length > 1) {
+    findings.push(
+      finding(
+        'SUPERSESSION_DISPOSITION_TABLE_AMBIGUOUS',
+        'record must contain exactly one disposition table',
+        headers[1].line,
+        record.index,
+      ),
+    );
+  } else {
+    const headerIndex = record.lines.indexOf(headers[0]);
+    const delimiter = record.lines[headerIndex + 1];
+    const delimiterCells = delimiter ? tableCells(delimiter.visible) : null;
+    if (
+      !delimiterCells ||
+      delimiterCells.length !== EXPECTED_COLUMNS.length ||
+      delimiterCells.some((cell) => !/^:?-{3,}:?$/.test(cell))
+    ) {
+      findings.push(
+        finding(
+          'SUPERSESSION_DISPOSITION_TABLE_MALFORMED',
+          'disposition table requires a three-column Markdown delimiter row',
+          delimiter?.line ?? headers[0].line,
+          record.index,
+        ),
+      );
+    } else {
+      for (const item of record.lines.slice(headerIndex + 2)) {
+        if (!item.visible.trim()) break;
+        const cells = tableCells(item.visible);
+        if (!cells) break;
+        if (cells.length !== EXPECTED_COLUMNS.length || cells.some((cell) => !cell)) {
+          findings.push(
+            finding(
+              'SUPERSESSION_DISPOSITION_TABLE_MALFORMED',
+              'each disposition row must contain exactly three nonempty cells',
+              item.line,
+              record.index,
+            ),
+          );
+          continue;
+        }
+        const disposition = normalizedDisposition(cells[1]);
+        if (!ALLOWED_DISPOSITIONS.has(disposition)) {
+          findings.push(
+            finding(
+              'SUPERSESSION_DISPOSITION_INVALID',
+              `disposition must be one of ${[...ALLOWED_DISPOSITIONS].join(', ')}`,
+              item.line,
+              record.index,
+            ),
+          );
+        }
+        dispositionRows.push({ line: item.line, cells, disposition });
+      }
+      if (dispositionRows.length === 0)
+        findings.push(
+          finding(
+            'SUPERSESSION_DISPOSITION_ROW_MISSING',
+            'disposition table must contain at least one completed data row',
+            headers[0].line,
+            record.index,
+          ),
+        );
+      else if (dispositionRows.every((row) => row.cells.some(isPlaceholder)))
+        findings.push(
+          finding(
+            'SUPERSESSION_DISPOSITION_ROW_MISSING',
+            'disposition table must contain at least one non-placeholder data row',
+            dispositionRows[0].line,
+            record.index,
+          ),
+        );
+    }
+  }
+
+  const checklist = checkedItems(record);
+  const pointer = checklist.find(
+    (item) =>
+      /\bSTANDARDS\.md\b/i.test(item.text) &&
+      /\bCanonical documents\b/i.test(item.text) &&
+      /\b(?:pointer|link(?:s|ed|ing)?|update[sd]?)\b/i.test(item.text) &&
+      !isNegated(item.text),
+  );
+  if (!pointer)
+    findings.push(
+      finding(
+        'SUPERSESSION_CANONICAL_POINTER_TASK_MISSING',
+        'record requires a checked STANDARDS.md Canonical documents pointer task',
+        record.startLine,
+        record.index,
+      ),
+    );
+
+  const atomicity = record.lines.find(
+    (item) =>
+      /\batomic(?:\s+PR|ity|ally)?\b/i.test(item.visible) &&
+      /\b(?:one|same|single)\s+(?:pull request|PR)\b/i.test(item.visible) &&
+      !isNegated(item.visible),
+  );
+  if (!atomicity)
+    findings.push(
+      finding(
+        'SUPERSESSION_ONE_PR_ATOMICITY_MISSING',
+        'record requires a checked atomicity statement naming one PR',
+        record.startLine,
+        record.index,
+      ),
+    );
+
+  return {
+    index: record.index,
+    startLine: record.startLine,
+    endLine: record.endLine,
+    elements: {
+      frozenMarker: markerLines.length > 0,
+      frozenBanner: bannerLines.length > 0,
+      dispositionRows: dispositionRows.length,
+      canonicalPointerTask: pointer?.line ?? null,
+      onePrAtomicity: atomicity?.line ?? null,
+    },
+    findings,
+    text: visibleText,
+  };
+}
+
+/** Check all visible completed record blocks in a Markdown document. */
+export function checkSupersessionTemplate(markdown) {
+  const parsed = parseSupersessionRecords(markdown);
+  const records = parsed.records.map(inspectRecord);
+  const findings = [...parsed.findings, ...records.flatMap((record) => record.findings)];
+  return { ok: findings.length === 0, records, findings };
+}
+
+/** Check only documents that contain or attempt a visible completed-record block. */
+export function checkSupersessionCorpus(documents) {
+  if (!Array.isArray(documents)) throw new TypeError('documents must be an array');
+  const checked = [];
+  for (const document of documents) {
+    if (!document || typeof document.path !== 'string' || typeof document.markdown !== 'string')
+      throw new TypeError('each document requires string path and markdown fields');
+    const result = checkSupersessionTemplate(document.markdown);
+    const applicable =
+      result.records.length > 0 || result.findings.some((item) => item.code !== RECORD_MISSING);
+    if (applicable) checked.push({ path: document.path, ...result });
+  }
+  return {
+    ok: checked.length > 0 && checked.every((document) => document.ok),
+    documents: checked,
+    recordCount: checked.reduce((sum, document) => sum + document.records.length, 0),
+  };
+}
+
+export function trackedDocumentationPaths(root = repositoryRoot) {
+  const listed = spawnSync('git', ['ls-files', '-z', '--', '000-docs'], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (listed.error || listed.status !== 0)
+    throw new Error(`cannot list tracked documentation: ${listed.error?.message ?? listed.stderr}`);
+  return listed.stdout
+    .split('\0')
+    .filter((path) => path.endsWith('.md'))
+    .sort();
+}
+
+export function readTrackedDocumentation(root = repositoryRoot) {
+  const lexicalRoot = resolve(root);
+  const physicalRoot = realpathSync(lexicalRoot);
+  return trackedDocumentationPaths(root).map((path) => {
+    const absolute = resolve(lexicalRoot, path);
+    if (!absolute.startsWith(`${lexicalRoot}${sep}`))
+      throw new Error(`tracked documentation path escapes repository: ${path}`);
+    const metadata = lstatSync(absolute);
+    if (!metadata.isFile() || metadata.isSymbolicLink())
+      throw new Error(`tracked documentation path is not a regular file: ${path}`);
+    const physicalPath = realpathSync(absolute);
+    if (!physicalPath.startsWith(`${physicalRoot}${sep}`))
+      throw new Error(`tracked documentation path resolves outside repository: ${path}`);
+    return { path, markdown: readFileSync(absolute, 'utf8') };
+  });
+}
+
+export function formatSupersessionReport(result, path = DEFAULT_TEMPLATE) {
+  if (result.ok)
+    return `supersession-template: OK (${result.records.length} completed record(s)) ${path}`;
+  const lines = result.findings.map((item) => {
+    const location = item.line ? `:${item.line}` : '';
+    const record = item.record ? ` record=${item.record}` : '';
+    return `${item.code} ${path}${location}${record} ${item.message}`;
+  });
+  lines.push(`supersession-template: ${result.findings.length} violation(s) ${path}`);
+  return lines.join('\n');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const args = process.argv.slice(2);
+    if (args.length > 1 || (args.length === 1 && args[0].startsWith('--') && args[0] !== '--all'))
+      throw new Error('usage: check-supersession-template.mjs [--all | <document>]');
+    if (args[0] === '--all') {
+      const corpus = checkSupersessionCorpus(readTrackedDocumentation());
+      for (const document of corpus.documents) {
+        if (!document.ok) console.error(formatSupersessionReport(document, document.path));
+      }
+      if (!corpus.ok) {
+        if (corpus.documents.length === 0)
+          console.error('SUPERSESSION_CORPUS_RECORD_MISSING no tracked completed record was found');
+        process.exitCode = 1;
+      } else {
+        console.log(
+          `supersession-corpus: OK (${corpus.recordCount} completed record(s) in ${corpus.documents.length} tracked document(s))`,
+        );
+      }
+    } else {
+      const suppliedPath = args[0] ?? DEFAULT_TEMPLATE;
+      const templatePath = args[0]
+        ? resolve(process.cwd(), suppliedPath)
+        : resolve(repositoryRoot, DEFAULT_TEMPLATE);
+      const result = checkSupersessionTemplate(readFileSync(templatePath, 'utf8'));
+      const report = formatSupersessionReport(result, suppliedPath);
+      if (result.ok) console.log(report);
+      else {
+        console.error(report);
+        process.exitCode = 1;
+      }
+    }
+  } catch (error) {
+    console.error(`SUPERSESSION_TEMPLATE_IO_ERROR ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-supersession-template.test.mjs
+++ b/scripts/check-supersession-template.test.mjs
@@ -1,0 +1,318 @@
+import { deepEqual, equal, match, throws } from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import {
+  checkSupersessionCorpus,
+  checkSupersessionTemplate,
+  parseSupersessionRecords,
+  readTrackedDocumentation,
+  trackedDocumentationPaths,
+} from './check-supersession-template.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const fixtureRoot = join(repositoryRoot, 'tests', 'fixtures', 'supersession-template');
+const fixture = (name) => readFileSync(join(fixtureRoot, `${name}.md`), 'utf8');
+const codes = (name) => checkSupersessionTemplate(fixture(name)).findings.map((item) => item.code);
+
+test('completed worked-example record passes with structured element evidence', () => {
+  const result = checkSupersessionTemplate(fixture('valid'));
+  equal(result.ok, true);
+  equal(result.records.length, 1);
+  deepEqual(result.records[0].elements, {
+    frozenMarker: true,
+    frozenBanner: true,
+    dispositionRows: 2,
+    canonicalPointerTask: 13,
+    onePrAtomicity: 5,
+  });
+  deepEqual(result.findings, []);
+});
+
+test('each required record element fails with a stable reason code', () => {
+  const cases = [
+    ['missing-marker', 'SUPERSESSION_FROZEN_MARKER_MISSING'],
+    ['missing-banner', 'SUPERSESSION_FROZEN_BANNER_MISSING'],
+    ['missing-disposition', 'SUPERSESSION_DISPOSITION_TABLE_MISSING'],
+    ['missing-pointer', 'SUPERSESSION_CANONICAL_POINTER_TASK_MISSING'],
+    ['missing-one-pr', 'SUPERSESSION_ONE_PR_ATOMICITY_MISSING'],
+  ];
+  for (const [name, code] of cases) {
+    const result = checkSupersessionTemplate(fixture(name));
+    equal(result.ok, false, name);
+    equal(
+      result.findings.some((item) => item.code === code),
+      true,
+      name,
+    );
+  }
+});
+
+test('malformed and empty disposition tables fail closed', () => {
+  equal(codes('malformed-table').includes('SUPERSESSION_DISPOSITION_TABLE_MALFORMED'), true);
+  equal(codes('empty-table').includes('SUPERSESSION_DISPOSITION_ROW_MISSING'), true);
+  equal(codes('placeholder-row').includes('SUPERSESSION_PLACEHOLDER_PRESENT'), true);
+  equal(codes('placeholder-row').includes('SUPERSESSION_DISPOSITION_ROW_MISSING'), true);
+  equal(codes('invalid-disposition').includes('SUPERSESSION_DISPOSITION_INVALID'), true);
+});
+
+test('comment-wrapped and negated requirements fail closed', () => {
+  equal(codes('comment-wrapped-marker').includes('SUPERSESSION_FROZEN_MARKER_MISSING'), true);
+  equal(codes('negated-pointer').includes('SUPERSESSION_CANONICAL_POINTER_TASK_MISSING'), true);
+  equal(codes('negated-one-pr').includes('SUPERSESSION_ONE_PR_ATOMICITY_MISSING'), true);
+
+  const negatedBanner = checkSupersessionTemplate(
+    fixture('valid').replace(
+      /^- \*\*Frozen header:\*\*.*$/m,
+      '- **Frozen header:** `<!-- doc-class: frozen -->` is not a `SUPERSEDED–FROZEN` banner.',
+    ),
+  );
+  equal(
+    negatedBanner.findings.some((item) => item.code === 'SUPERSESSION_FROZEN_BANNER_MISSING'),
+    true,
+  );
+
+  const contractedCases = [
+    [
+      'pointer',
+      fixture('valid').replace(
+        'Update the `STANDARDS.md` Canonical documents pointer to the new authority.',
+        "The `STANDARDS.md` Canonical documents pointer isn't updated to the new authority.",
+      ),
+      'SUPERSESSION_CANONICAL_POINTER_TASK_MISSING',
+    ],
+    [
+      'atomicity',
+      fixture('valid').replace(
+        '**Atomic PR:** This one pull request carries every checked item below.',
+        "**Atomic PR:** This record isn't atomic in one pull request.",
+      ),
+      'SUPERSESSION_ONE_PR_ATOMICITY_MISSING',
+    ],
+    [
+      'frozen header',
+      fixture('valid').replace(
+        /^- \*\*Frozen header:\*\*.*$/m,
+        "- **Frozen header:** `<!-- doc-class: frozen -->` isn't a `SUPERSEDED–FROZEN` banner.",
+      ),
+      'SUPERSESSION_FROZEN_BANNER_MISSING',
+    ],
+  ];
+  for (const [name, markdown, code] of contractedCases) {
+    const result = checkSupersessionTemplate(markdown);
+    equal(
+      result.findings.some((item) => item.code === code),
+      true,
+      name,
+    );
+  }
+
+  const invalidDirectBanners = [
+    '> **SUPERSEDED–FROZEN (test).** This is not a valid supersession banner.',
+    "> **SUPERSEDED–FROZEN (test).** This supersession banner isn't valid.",
+    '> **SUPERSEDED–FROZEN (test).** This does not qualify as a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This supersession banner is invalid.',
+    '> **SUPERSEDED–FROZEN (test).** This is not an effective supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This does not constitute a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This banner is not valid as a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This cannot serve as a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This is a purported supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This is no supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This does not amount to a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This supersession banner is void.',
+    '> **SUPERSEDED–FROZEN (test).** This banner must not be treated as a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This is not really a supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This supersession banner lacks validity.',
+    '> **SUPERSEDED–FROZEN (test).**\n> This is not a valid supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).**\nThis is not a valid supersession banner.',
+    '> **SUPERSEDED–FROZEN (test).** This is not a supersession-banner.',
+    '> **SUPERSEDED–FROZEN (test).** This is not one of the supersession banners.',
+    '> **SUPERSEDED–FROZEN (test).** This is not a supersession **banner**.',
+    '> **SUPERSEDED–FROZEN (test).** This is not a supersession&nbsp;banner.',
+    '> **SUPERSEDED–FROZEN (test).** This is not a supersession notice.',
+    '> **SUPERSEDED–FROZEN (test).** No supersession applies here.',
+    '> **SUPERSEDED–FROZEN (test).** No super&#115;ession applies here.',
+    '> **SUPERSEDED–FROZEN (test).** No super&#x73;ession applies here.',
+    '> **SUPERSEDED–FROZEN (test).** No super<em>session</em> applies here.',
+    '> **SUPERSEDED–FROZEN (test).** No super[session](https://example.invalid) applies here.',
+    '> **SUPERSEDED–FROZEN (test).** No super­session applies here.',
+    '> **SUPERSEDED–FROZEN (test).**\n\n> This is not a valid supersession banner.',
+    '    > **SUPERSEDED–FROZEN.**',
+    '> **SUPERSEDED–FROZEN (test **not controlled**).**',
+    '> **SUPERSEDED–FROZEN (test _not controlled_).**',
+    '> **SUPERSEDED–FROZEN (test __not controlled__).**',
+    '> **SUPERSEDED–FROZEN (test <!-- hidden -->).**',
+    '<!-- hidden --> > **SUPERSEDED–FROZEN.**',
+    '<!-- hidden -->\n> **SUPERSEDED–FROZEN.**',
+    '<!-- hidden -->\n\n> **SUPERSEDED–FROZEN.**',
+    '> <!-- hidden -->\n> **SUPERSEDED–FROZEN.**',
+  ];
+  const directBanner = checkSupersessionTemplate(
+    fixture('valid').replace(
+      /^- \*\*Frozen header:\*\*.*$/m,
+      '- **Frozen marker:** `<!-- doc-class: frozen -->`\n\n> **SUPERSEDED–FROZEN (test).**',
+    ),
+  );
+  equal(
+    directBanner.findings.some((item) => item.code === 'SUPERSESSION_FROZEN_BANNER_MISSING'),
+    false,
+    'controlled direct banner',
+  );
+  for (const banner of invalidDirectBanners) {
+    const result = checkSupersessionTemplate(
+      fixture('valid').replace(
+        /^- \*\*Frozen header:\*\*.*$/m,
+        `- **Frozen marker:** \`<!-- doc-class: frozen -->\`\n\n${banner}`,
+      ),
+    );
+    equal(
+      result.findings.some((item) => item.code === 'SUPERSESSION_FROZEN_BANNER_MISSING'),
+      true,
+      banner,
+    );
+  }
+
+  const naturalPositiveWording = checkSupersessionTemplate(
+    fixture('valid')
+      .replace(
+        'Update the `STANDARDS.md` Canonical documents pointer to the new authority.',
+        "Don't forget to update the `STANDARDS.md` Canonical documents pointer to the new authority.",
+      )
+      .replace(
+        '**Atomic PR:** This one pull request carries every checked item below.',
+        '**Atomic PR:** This one pull request is unchanged from the planned atomic transaction.',
+      ),
+  );
+  equal(naturalPositiveWording.ok, true);
+
+  const repositoryBannerShape = checkSupersessionTemplate(
+    fixture('valid').replace(
+      /^- \*\*Frozen header:\*\*.*$/m,
+      '- **Frozen marker:** `<!-- doc-class: frozen -->`\n\n> **SUPERSEDED–FROZEN (Epic 2 bead 2.12; historical evidence only).**',
+    ),
+  );
+  equal(repositoryBannerShape.ok, true);
+});
+
+test('fenced and surrounding-comment decoys are not completed records', () => {
+  const parsed = parseSupersessionRecords(fixture('decoys-only'));
+  equal(parsed.records.length, 0);
+  deepEqual(
+    parsed.findings.map((item) => item.code),
+    ['SUPERSESSION_RECORD_MISSING'],
+  );
+});
+
+test('requirements present only in fenced or commented decoys cannot satisfy a real block', () => {
+  const result = checkSupersessionTemplate(fixture('decoy-elements'));
+  equal(result.ok, false);
+  for (const code of [
+    'SUPERSESSION_FROZEN_MARKER_MISSING',
+    'SUPERSESSION_FROZEN_BANNER_MISSING',
+    'SUPERSESSION_DISPOSITION_TABLE_MISSING',
+    'SUPERSESSION_CANONICAL_POINTER_TASK_MISSING',
+    'SUPERSESSION_ONE_PR_ATOMICITY_MISSING',
+  ])
+    equal(
+      result.findings.some((item) => item.code === code),
+      true,
+      code,
+    );
+});
+
+test('placeholder form outside completed blocks is ignored', () => {
+  const markdown = `${fixture('valid')}\n\n\`\`\`markdown\n${fixture('placeholder-row')}\n\`\`\`\n`;
+  const result = checkSupersessionTemplate(markdown);
+  equal(result.ok, true);
+  equal(result.records.length, 1);
+});
+
+test('corpus mode checks every visible record attempt and ignores ordinary or decoy-only docs', () => {
+  const empty = checkSupersessionCorpus([
+    { path: 'plain.md', markdown: '# No supersession here\n' },
+    { path: 'decoy.md', markdown: fixture('decoys-only') },
+  ]);
+  equal(empty.ok, false);
+  equal(empty.recordCount, 0);
+  deepEqual(empty.documents, []);
+
+  const result = checkSupersessionCorpus([
+    { path: 'plain.md', markdown: '# No supersession here\n' },
+    { path: 'decoy.md', markdown: fixture('decoys-only') },
+    { path: 'valid.md', markdown: fixture('valid') },
+    { path: 'invalid.md', markdown: fixture('missing-pointer') },
+    { path: 'unclosed.md', markdown: '<!-- BEGIN SUPERSESSION RECORD -->\n' },
+  ]);
+  equal(result.ok, false);
+  equal(result.recordCount, 2);
+  deepEqual(
+    result.documents.map((document) => document.path),
+    ['valid.md', 'invalid.md', 'unclosed.md'],
+  );
+  equal(
+    result.documents[1].findings.some(
+      (item) => item.code === 'SUPERSESSION_CANONICAL_POINTER_TASK_MISSING',
+    ),
+    true,
+  );
+  equal(
+    result.documents[2].findings.some((item) => item.code === 'SUPERSESSION_RECORD_UNCLOSED'),
+    true,
+  );
+});
+
+test('tracked corpus CLI validates every filed record in repository order', () => {
+  const paths = trackedDocumentationPaths(repositoryRoot);
+  equal(paths.includes('000-docs/746-DR-TMPL-document-supersession.md'), true);
+
+  const script = join(repositoryRoot, 'scripts', 'check-supersession-template.mjs');
+  const checked = spawnSync(process.execPath, [script, '--all'], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  });
+  equal(checked.status, 0);
+  match(
+    checked.stdout,
+    /supersession-corpus: OK \([1-9]\d* completed record\(s\) in [1-9]\d* tracked document\(s\)\)/,
+  );
+});
+
+test('tracked symlinks cannot escape the physical repository boundary', (context) => {
+  const root = mkdtempSync(join(tmpdir(), 'supersession-corpus-root-'));
+  const outside = mkdtempSync(join(tmpdir(), 'supersession-corpus-outside-'));
+  context.after(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(root, '000-docs'));
+  const outsideRecord = join(outside, 'record.md');
+  writeFileSync(outsideRecord, fixture('valid'));
+  symlinkSync(outsideRecord, join(root, '000-docs', 'escape.md'));
+  execFileSync('git', ['init', '--quiet'], { cwd: root });
+  execFileSync('git', ['add', '000-docs/escape.md'], { cwd: root });
+
+  throws(
+    () => readTrackedDocumentation(root),
+    /tracked documentation path is not a regular file: 000-docs\/escape\.md/,
+  );
+});
+
+test('CLI returns zero for a valid record and nonzero red proof for an incomplete one', () => {
+  const script = join(repositoryRoot, 'scripts', 'check-supersession-template.mjs');
+  const pass = spawnSync(process.execPath, [script, join(fixtureRoot, 'valid.md')], {
+    encoding: 'utf8',
+  });
+  equal(pass.status, 0);
+  match(pass.stdout, /supersession-template: OK \(1 completed record\(s\)\)/);
+
+  const red = spawnSync(process.execPath, [script, join(fixtureRoot, 'missing-pointer.md')], {
+    encoding: 'utf8',
+  });
+  equal(red.status, 1);
+  match(red.stderr, /SUPERSESSION_CANONICAL_POINTER_TASK_MISSING/);
+  match(red.stderr, /supersession-template: 1 violation\(s\)/);
+});

--- a/tests/fixtures/supersession-template/comment-wrapped-marker.md
+++ b/tests/fixtures/supersession-template/comment-wrapped-marker.md
@@ -1,0 +1,13 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+
+<!-- `<!-- doc-class: frozen -->` -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/decoy-elements.md
+++ b/tests/fixtures/supersession-template/decoy-elements.md
@@ -1,0 +1,27 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+
+```markdown
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.** Fenced decoy.
+> | Superseded section | Disposition | New authority |
+> | --- | --- | --- |
+> | § 2 | Superseded | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+```
+
+<!--
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.** Commented decoy.
+> | Superseded section | Disposition | New authority |
+> | --- | --- | --- |
+> | § 2 | Superseded | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+      -->
+
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/decoys-only.md
+++ b/tests/fixtures/supersession-template/decoys-only.md
@@ -1,0 +1,19 @@
+# Copyable form and commented example
+
+```markdown
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.** Fenced decoy.
+
+<!-- END SUPERSESSION RECORD -->
+```
+
+<!--
+<!-- BEGIN SUPERSESSION RECORD -->
+
+> **SUPERSEDED–FROZEN.** Commented decoy.
+
+<!-- END SUPERSESSION RECORD -->
+
+-->

--- a/tests/fixtures/supersession-template/empty-table.md
+++ b/tests/fixtures/supersession-template/empty-table.md
@@ -1,0 +1,11 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority |
+| ------------------ | ----------- | ------------- |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/invalid-disposition.md
+++ b/tests/fixtures/supersession-template/invalid-disposition.md
@@ -1,0 +1,12 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition   | New authority     |
+| ------------------ | ------------- | ----------------- |
+| § 2                | MAYBE SOMEDAY | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/malformed-table.md
+++ b/tests/fixtures/supersession-template/malformed-table.md
@@ -1,0 +1,12 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority |
+| ------------------ | malformed | ----------------- |
+| § 2 | Superseded | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/missing-banner.md
+++ b/tests/fixtures/supersession-template/missing-banner.md
@@ -1,0 +1,10 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/missing-disposition.md
+++ b/tests/fixtures/supersession-template/missing-disposition.md
@@ -1,0 +1,8 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/missing-marker.md
+++ b/tests/fixtures/supersession-template/missing-marker.md
@@ -1,0 +1,11 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/missing-one-pr.md
+++ b/tests/fixtures/supersession-template/missing-one-pr.md
@@ -1,0 +1,11 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/missing-pointer.md
+++ b/tests/fixtures/supersession-template/missing-pointer.md
@@ -1,0 +1,11 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/negated-one-pr.md
+++ b/tests/fixtures/supersession-template/negated-one-pr.md
@@ -1,0 +1,12 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] This record is not atomic in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/negated-pointer.md
+++ b/tests/fixtures/supersession-template/negated-pointer.md
@@ -1,0 +1,12 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section | Disposition | New authority     |
+| ------------------ | ----------- | ----------------- |
+| § 2                | REPLACED    | Blueprint 727 § 5 |
+
+- [x] Do not update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/placeholder-row.md
+++ b/tests/fixtures/supersession-template/placeholder-row.md
@@ -1,0 +1,12 @@
+<!-- BEGIN SUPERSESSION RECORD -->
+<!-- doc-class: frozen -->
+
+> **SUPERSEDED–FROZEN.**
+
+| Superseded section            | Disposition | New authority                    |
+| ----------------------------- | ----------- | -------------------------------- |
+| `<old section or fact class>` | REPLACED    | `<new section or explicit none>` |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer.
+- [x] Atomicity: complete every element in one PR.
+<!-- END SUPERSESSION RECORD -->

--- a/tests/fixtures/supersession-template/valid.md
+++ b/tests/fixtures/supersession-template/valid.md
@@ -1,0 +1,15 @@
+# Completed 6767 reconciliation
+
+<!-- BEGIN SUPERSESSION RECORD -->
+
+- **Atomic PR:** This one pull request carries every checked item below.
+- **Frozen header:** `<!-- doc-class: frozen -->` followed by a `SUPERSEDED–FROZEN` banner.
+
+| Superseded section | Disposition     | New authority     |
+| ------------------ | --------------- | ----------------- |
+| § 2 frontmatter    | CARRIED FORWARD | `6767-b` § 3      |
+| § 5 adapters       | REPLACED        | Blueprint 727 § 5 |
+
+- [x] Update the `STANDARDS.md` Canonical documents pointer to the new authority.
+- [x] Every affected section is recorded above.
+<!-- END SUPERSESSION RECORD -->


### PR DESCRIPTION
## Authority and scope

Bead: claude-hedb.5  
Blueprint: 727 Epic 2 bead 2.12

This focused slice files one supersession-record template, adds one shared fixture-driven checker to the existing doc-governance job, and completes the machine-readable frozen marker on 6767-a/c/d/e/h. Corpus mode discovers every tracked completed record or malformed attempt. It does not activate another bead.

## Before and after

- Completed supersession record blocks: 0 -> 1 worked example.
- Tracked record cohort: 1 completed record in 1 tracked document; future tracked records are discovered automatically.
- Frozen-class markers: 0 -> 5 across the five 6767 standards superseded by 727. Blueprint 727 keeps 6767-b as the rubric authority, so it is outside this supersession cohort and intentionally untouched.
- Documentation index: 185 -> 186, generated from the staged Git inventory.
- Scorecard entry `n=46`: 23,032 tracked files, 15,520 gitleaks-invisible paths, 25 unchanged `.gitleaks.toml` allowlist patterns.
- Frozen content below each prepended marker: 5 of 5 byte-identical to base SHA `3978bfd38cbe48a22051f40667fca4ff0cedeff1`.
- Required status contexts: unchanged at `ci-required`, `gitleaks`, and `skill-conform`.

## Verification

- `node --test scripts/check-supersession-template.test.mjs`: 11/11 PASS.
- `node scripts/check-supersession-template.mjs --all`: PASS; 1 completed record in 1 tracked document.
- Deliberate red proofs refuse a missing pointer, comment-wrapped marker, negated pointer, negated atomicity, invalid disposition, and unclosed record attempt.
- Combined authority, supersession, and index tests: 26/26 PASS.
- Frozen prose anchors and the base-body comparison `for f in 000-docs/6767-{a-SPEC-DR-STND-claude-code-plugins-standard,c-DR-STND-claude-code-extensions-standard,d-AT-APIS-claude-code-extensions-schema,e-WA-WFLW-extensions-validation-ci-gates,h-SPEC-DR-STND-claude-code-extensions-master}.md; do cmp <(git show 3978bfd38cbe48a22051f40667fca4ff0cedeff1:"$f") <(tail -n +3 "$f"); done`: 5/5 PASS.
- Epic 1 scorecard measurement and generated-scorecard check: PASS.
- Docs authority, generated index, Prettier, ESLint, typecheck, actionlint, and dry-run verification: PASS.
- Earlier quick-test build/lint and gitleaks passed; quick-test retained the pre-existing 413 standard-tier advisory errors.
- Runtime evidence from the preceding candidate: [Validate Plugins](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/31961775654), [MiniMax](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/31961796599), [gitleaks](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/31961775566), [skill-conform](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/31961775546), and [actionlint](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/31961775547). Exact-head runs after `2795a25a5418d62a05ba7c1e22f655e15e6e6150` are the merge authority.
- Exact-head GitHub checks, Greptile inspection, and independent clean-checkout review are merge gates.

## Security and licensing

This PR adds one new supersession-record validation rule and does not modify existing validator semantics, provenance, packages, licenses, registries, credentials, contributors, or production surfaces. The parser fails closed on missing elements, malformed or empty tables, placeholders, negated or comment-wrapped evidence, and fenced/commented decoys. Corpus mode uses Git-tracked paths, rejects lexical and physical path escape, refuses symlinks and non-regular files, and validates malformed record attempts.

Blueprint 727 section 2.5 explicitly defines the `canonical|generated|frozen|record` document-class taxonomy; `doc-class: record` is therefore governed, not a new unregistered class.

## Review findings resolved

- MiniMax tree-wide enforcement concern: fixed with tracked-document corpus mode in the existing job.
- Frozen scope: each banner permits only edits above it; 5/5 bodies remain byte-identical below the marker.
- Scorecard provenance: regenerated by the canonical `measure-epic-1` writer and identified by entry key `n=46`.
- Loose banner reference: the checker accepts the repository banner shape or an affirmative Frozen-header field.
- Natural positive prose: `do not forget to`, `not only`, and `unchanged from` no longer create false negation failures; explicit inversions still fail closed.
- Independent hostile contractions: `isn't`, `can't`, `won't`, and related negative contractions now fail closed; a structurally shaped banner that disclaims being a valid supersession banner is also refused.
- Direct-banner evidence is structural: only a title-only controlled `SUPERSEDED–FROZEN` blockquote is accepted. Trailing, lazy-continuation, or separate blockquote prose is refused, eliminating natural-language and rendered-Markdown interpretation. A temporary-Git red proof tracks a symlink to an external valid record and verifies corpus loading refuses it before reading.
- Generated artifacts: `node scripts/generate-docs-index.mjs --check` reports 186 tracked documents, and `pnpm run measure:e1:check` passes 36/36 tests plus the generated-scorecard byte check. No `6767-a/c/d/e/h#L...` references exist in the governed docs cohort.
- Template consistency: singular/plural cases use `Frozen document(s)`, and the exact `Frozen header:` structural label is documented rather than left as an implicit CI constraint.

## Rollback

Revert the later AAR filing first, then revert this implementation merge. Regenerate documents `000-INDEX` and `742` and rerun the doc-governance and frozen-anchor suites.

## Explicit non-scope

No content below a frozen marker changed; 6767-b is untouched; no mirror content changed; no fourth required context, paths filter, permissive fallback, baseline lowering, Plane mutation, branch-protection change, release, billing, registry, credential, contributor contact, or production mutation occurred.
