### PR TITLE
fix(ci): harden actionlint bootstrap

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,18 +25,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # actionlint releases a single-binary executable; the install script is
-      # fetched FROM THE v1.7.4 TAG (not main HEAD) so the script's content is
-      # immutable for this version — supply-chain hardening. Bump the tag in
-      # BOTH places (URL ref + bash arg) explicitly when updating.
+      # Download the immutable release archive directly instead of executing
+      # an installer fetched from raw.githubusercontent.com. Keep the version,
+      # archive name, URL, and upstream checksum synchronized when updating.
       - name: Install actionlint
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/actionlint"
-          curl -sSL \
-            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.4/scripts/download-actionlint.bash \
-            | bash -s -- 1.7.4 "$RUNNER_TEMP/actionlint"
-          "$RUNNER_TEMP/actionlint/actionlint" -version
+          readonly actionlint_version='1.7.4'
+          readonly actionlint_archive="actionlint_${actionlint_version}_linux_amd64.tar.gz"
+          # Source: https://github.com/rhysd/actionlint/releases/download/v1.7.4/actionlint_1.7.4_checksums.txt
+          readonly actionlint_sha256='fc0a6886bbb9a23a39eeec4b176193cadb54ddbe77cdbb19b637933919545395'
+          readonly actionlint_dir="$RUNNER_TEMP/actionlint"
+          readonly actionlint_path="$actionlint_dir/$actionlint_archive"
+
+          mkdir -p "$actionlint_dir"
+          curl --fail --show-error --silent --location \
+            --retry 3 --retry-all-errors \
+            --output "$actionlint_path" \
+            "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${actionlint_archive}"
+          printf '%s  %s\n' "$actionlint_sha256" "$actionlint_path" | sha256sum --check --strict
+          tar --extract --gzip --file "$actionlint_path" --directory "$actionlint_dir" \
+            --no-same-owner actionlint
+          "$actionlint_dir/actionlint" -version
 
       # BLOCKING — no `|| true`. If a workflow YAML doesn't lint cleanly,
       # the PR cannot merge. This gate protects the workflow split from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (2026-08-17 — Actionlint bootstrap availability)
+
+- **Actionlint now downloads its pinned release archive directly and verifies the upstream
+  SHA-256 before extraction.** This removes the executable installer-script dependency on
+  `raw.githubusercontent.com`, which returned HTTP 429 before lint execution in three consecutive
+  PR runs, while preserving the blocking v1.7.4 lint command and fail-closed behavior.
+
 ### Added (2026-08-17 — deterministic generated skill index)
 
 - **The marketplace L0 skill index now has a fail-closed regenerate-and-diff gate.** A dedicated,


### PR DESCRIPTION
## Bead and cause

- Bead: claude-8085 — Make Actionlint bootstrap survive GitHub Raw rate limits
- Discovered while validating E1.8 PR #1229
- Exact base: e39ed6dcae0e6eead8a018d5b796eae6caba324c

The Actionlint workflow failed before lint execution in three exact-head attempts because raw.githubusercontent.com returned HTTP 429 for the pinned installer script. The same endpoint still returns 429 from this environment, while the official pinned v1.7.4 release asset returns HTTP 200.

## Change

Download the official actionlint_1.7.4_linux_amd64.tar.gz asset directly, fail on HTTP errors, retry bounded transient failures, verify the upstream hardcoded SHA-256 before extraction, and run the unchanged blocking Actionlint command. CHANGELOG is updated.

## Evidence

- Official archive download: PASS
- SHA-256 fc0a6886bbb9a23a39eeec4b176193cadb54ddbe77cdbb19b637933919545395: PASS
- Extracted actionlint -version: 1.7.4, linux/amd64
- Exact v1.7.4 actionlint -color: PASS
- Prettier: PASS
- git diff --check: PASS
- Gitleaks HEAD^..HEAD: PASS, no leaks
- Red proof: deliberately wrong checksum exits 1 with computed checksum did NOT match

## Security and non-scope

This removes execution of a remotely downloaded installer script and verifies the binary archive before execution. No gate is weakened; no continue-on-error, bypass, new context, credential, registry, contributor, Plane, branch-rule, package, or production mutation is included.

Rollback: revert the focused merge, restoring the prior pinned installer-script bootstrap.