### PR TITLE
fix(content): restore blog list spacing

### DIFF
--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23050
+        "tracked_files": 23051
       }
     },
     "2": {
@@ -1966,7 +1966,7 @@
         "invalid_patterns": 0,
         "invisible_files": 15533,
         "target_invisible_files": 0,
-        "tracked_files": 23050
+        "tracked_files": 23051
       }
     },
     "47": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (2026-08-17 — blog Markdown validation)
+
+- **The newly published failure-diagnostics article now preserves blank-line boundaries around its
+  numbered list.** This restores the repository-wide blocking Markdownlint gate without changing
+  article wording or weakening MD032.
+
 ### Fixed (2026-08-17 — Actionlint bootstrap availability)
 
 - **Actionlint now downloads its pinned release archive directly and verifies the upstream

--- a/marketplace/src/content/blog-posts/the-failure-that-knew-its-own-name.md
+++ b/marketplace/src/content/blog-posts/the-failure-that-knew-its-own-name.md
@@ -33,6 +33,7 @@ The cron script captured only stderr (which was empty), got no JSON from what it
 The fix, commit 15212612: make the failure path name its own cause.
 
 Three changes:
+
 1. `generate_voice` now captures the exit code and classifies failures into named branches: timeout at 124, NOT AUTHENTICATED matched by regex against that banner, empty stdout, non-zero exit with no JSON, exit 0 with no JSON object. Each branch logs the reason plus the first 500 bytes of raw stdout.
 2. That reason rides into the degraded packet's own note AND into the email, so the person on the CC line who can act on it sees it.
 3. A CI test (test_no_vibe_derived_text_in_the_repo) flagging vendored product names in published copy went red. Reworded the affected post; the claim still holds.


### PR DESCRIPTION
## Bead and cause

- Bead: claude-igjk — Restore Markdown list spacing in the new blog post
- Exact base: 2979bd5b5b8700ddf7f60b355902575548ba43f5

Current main introduced a numbered list without the required preceding blank line in marketplace/src/content/blog-posts/the-failure-that-knew-its-own-name.md. Hosted Markdownlint run 32045714543 reproduced MD032 at line 36, blocking every subsequent PR.

## Change

Add the single required blank line and record the correction in CHANGELOG. Article wording and lint policy are unchanged.

## Evidence

- Red proof: current-main hosted markdownlint exited 1 with MD032 at line 36.
- npx -y markdownlint-cli2: PASS, 10,616 files, zero issues.
- Prettier: PASS.
- git diff --check: PASS.
- Gitleaks HEAD^..HEAD: PASS, no leaks.

No lint exclusion, ignore, continue-on-error, status context, credential, registry, contributor, Plane, branch-rule, package, or production mutation. Rollback is the focused revert, which intentionally restores the documented MD032 failure.