### PR TITLE
fix(catalog): enforce unique plugin names

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -5443,6 +5443,8 @@
         "name": "Luke Steuber",
         "url": "https://github.com/lukeslp"
       },
+      "homepage": "https://dr.eamer.dev/geepers/",
+      "repository": "https://github.com/lukeslp/geepers",
       "components": {
         "agents": 51,
         "total": 51
@@ -5534,31 +5536,6 @@
         "grade": "A",
         "badge": "gold",
         "lastValidated": "2026-03-10T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "mcp",
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "geepers",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Luke Steuber"
-      },
-      "homepage": "https://dr.eamer.dev/geepers/",
-      "repository": "https://github.com/lukeslp/geepers",
-      "components": {
-        "agents": 51
       }
     },
     {
@@ -10274,27 +10251,6 @@
       "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
       "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
       "license": "Apache-2.0"
-    },    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
     },
     {
       "name": "databricks-workspace-mcp",
@@ -10486,28 +10442,6 @@
       "license": "MIT"
     },
     {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
       "name": "mnemos",
       "source": "./plugins/community/mnemos",
       "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
@@ -10651,28 +10585,6 @@
       },
       "homepage": "https://github.com/el-zachariah/ai-agent-safety-starter-pack#readme",
       "repository": "https://github.com/el-zachariah/ai-agent-safety-starter-pack",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
       "license": "MIT"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5017,7 +5017,9 @@
       "author": {
         "name": "Luke Steuber",
         "url": "https://github.com/lukeslp"
-      }
+      },
+      "homepage": "https://dr.eamer.dev/geepers/",
+      "repository": "https://github.com/lukeslp/geepers"
     },
     {
       "name": "sprint",
@@ -5088,28 +5090,6 @@
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       }
-    },
-    {
-      "name": "geepers-agents",
-      "source": "./plugins/community/geepers-agents",
-      "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-      "version": "1.13.0",
-      "category": "community",
-      "keywords": [
-        "mcp",
-        "orchestration",
-        "multi-agent",
-        "development-workflow",
-        "code-quality",
-        "deployment",
-        "geepers",
-        "claude-code"
-      ],
-      "author": {
-        "name": "Luke Steuber"
-      },
-      "homepage": "https://dr.eamer.dev/geepers/",
-      "repository": "https://github.com/lukeslp/geepers"
     },
     {
       "name": "jeremy-firebase",
@@ -8711,28 +8691,6 @@
       "license": "Apache-2.0"
     },
     {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
       "name": "databricks-workspace-mcp",
       "source": "./plugins/mcp/databricks-workspace-mcp",
       "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
@@ -8921,28 +8879,6 @@
       "license": "MIT"
     },
     {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
-      "license": "MIT"
-    },
-    {
       "name": "mnemos",
       "source": "./plugins/community/mnemos",
       "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
@@ -9074,28 +9010,6 @@
       },
       "homepage": "https://github.com/el-zachariah/ai-agent-safety-starter-pack#readme",
       "repository": "https://github.com/el-zachariah/ai-agent-safety-starter-pack",
-      "license": "MIT"
-    },
-    {
-      "name": "claudebase",
-      "source": "./plugins/productivity/claudebase",
-      "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
-      "version": "0.2.0",
-      "category": "productivity",
-      "keywords": [
-        "github",
-        "sync",
-        "backup",
-        "config",
-        "profiles",
-        "settings"
-      ],
-      "author": {
-        "name": "Rohit Hazra",
-        "url": "https://github.com/rohithzr"
-      },
-      "homepage": "https://github.com/rohithzr/claudebase",
-      "repository": "https://github.com/rohithzr/claudebase",
       "license": "MIT"
     },
     {

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1087,6 +1087,16 @@ Ratification correction 5. The **completed** repository-cleanup **Mission 01** (
 | 1.13 | **STILL REQUIRED**                      | Row 21 correction: 356 case-insensitive occurrences across 125 files at `3543d5d167bd4e8d27666c8893080bca3bd72950`; 292 actionable and 64 retained by machine-readable class                                                                      |
 | 1.14 | **STILL REQUIRED**                      | § 18.7 unchanged; owner-gated                                                                                                                                                                                                                     |
 
+**E1.2 implementation measurement (2026-08-17).** At exact base
+`48894e82d31f8bc160d3157d299e675c538ca0a7`,
+`jq '{rows:(.plugins|length), names:([.plugins[].name]|unique|length), duplicates:([.plugins[].name]|group_by(.)|map(select(length>1)|{name:.[0],count:length}))}' .claude-plugin/marketplace.extended.json`
+reported 471 rows, 467 names, `claudebase` ×4, and `geepers-agents` ×2. E1.2 retains
+one on-disk-source-matching row for each name, merges the non-conflicting Geepers upstream links
+into its richer record, regenerates the two source-owned public catalog surfaces, and adds
+duplicate-name refusal to `scripts/validate-catalog-invariants.py`. The same command then reports
+467 rows, 467 names, and no duplicates. This correction belongs to E1.2; E1.8 consumes the clean
+source but does not claim or duplicate this work.
+
 **Measurements that must be re-run before Epic 1 is claimed complete** (all of them by bead 1.0, none by hand): rows 1, 2, 3, 4, 11, 12, 22, 24, 25, 26, 27 — plus the graded-artifact cohort itself (3,679 vs 3,678, § 3.1). Any Epic 1 exit claim that cites a Mission 01 number rather than a harness number is rejected: Mission 01's numbers were correct **for its HEAD**, and the tree has moved twice since.
 
 **Does the proposed bead count change? No — Epic 1 stays at 15.** Two beads (1.7, 1.8) have **narrower scope**, and one (1.0) is partially informed, but **zero are fully satisfied and zero are superseded**, so there is nothing to remove. This is stated explicitly because the opposite error — inventing filler work to preserve a headline count — is the failure mode this correction exists to prevent. The count that _does_ move is Epic 2's, which gains the README landing-contract bead from § 6A (12 → 13); § 17 carries the new totals.

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -51,20 +51,11 @@
       "reproduce": "pnpm run measure:e1 --row=2 --stdout",
       "source": ".claude-plugin/marketplace.extended.json",
       "status": "measured",
-      "target_status": "fail",
+      "target_status": "pass",
       "values": {
         "distinct_names": 467,
-        "duplicate_names": [
-          {
-            "count": 4,
-            "name": "claudebase"
-          },
-          {
-            "count": 2,
-            "name": "geepers-agents"
-          }
-        ],
-        "entries": 471
+        "duplicate_names": [],
+        "entries": 467
       }
     },
     "3": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The editable plugin catalog now contains 467 rows with 467 unique names.** Three redundant
   `claudebase` rows and one duplicate `geepers-agents` row were collapsed without renaming either
   plugin; the retained Geepers record preserves its richer component metadata and upstream links.
-  The existing catalog invariant validator now fails closed on duplicate, empty, or non-string
-  names, while `marketplace.json` and the README catalog navigation are regenerated from the
-  corrected source.
+  The existing catalog invariant validator now fails closed on exact or normalization-equivalent
+  duplicates, empty names, and non-string names, while `marketplace.json` and the README catalog
+  navigation are regenerated from the corrected source.
 
 ### Fixed (2026-08-17 — README star-history chart)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (2026-08-17 — canonical catalog name uniqueness)
+
+- **The editable plugin catalog now contains 467 rows with 467 unique names.** Three redundant
+  `claudebase` rows and one duplicate `geepers-agents` row were collapsed without renaming either
+  plugin; the retained Geepers record preserves its richer component metadata and upstream links.
+  The existing catalog invariant validator now fails closed on duplicate, empty, or non-string
+  names, while `marketplace.json` and the README catalog navigation are regenerated from the
+  corrected source.
+
 ### Fixed (2026-08-17 — README star-history chart)
 
 - **The README star-history chart now uses the working `star-history.dera.page` mirror.** The

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![Release](https://img.shields.io/badge/release-v4.33.0-green)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/releases/tag/v4.33.0)
 [![CLI](https://img.shields.io/badge/CLI-ccpi-blueviolet?logo=npm)](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
-[![Plugins](https://img.shields.io/badge/plugins-471-blue)](https://tonsofskills.com/explore)
+[![Plugins](https://img.shields.io/badge/plugins-467-blue)](https://tonsofskills.com/explore)
 [![Skills](https://img.shields.io/badge/skills-3068-green)](https://tonsofskills.com/skills)
 [![GitHub Stars](https://img.shields.io/github/stars/jeremylongshore/claude-code-plugins-plus-skills?style=social)](https://github.com/jeremylongshore/claude-code-plugins-plus-skills)
 [![skills.sh](https://skills.sh/b/jeremylongshore/claude-code-plugins-plus-skills)](https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills)
 [![Sponsor: Kobiton](https://img.shields.io/badge/Sponsor-kobiton.com-0487D9)](https://kobiton.com)
 [![Buy me a monster](https://img.shields.io/badge/Buy%20me%20a-Monster-FFDD00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/jeremylongshore)
 
-471 plugins, 3,068 skills, 347 agents, 30 community contributors — validated and ready to install.
+467 plugins, 3,068 skills, 347 agents, 30 community contributors — validated and ready to install.
 
 ## Why this repo
 
@@ -125,7 +125,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | 🎭  | [AI Agents & Agency](#ai-agents--agency)           |      10 |
 | 🔌  | [API Development](#api-development)                |      26 |
 | 💼  | [Business Tools](#business-tools)                  |      21 |
-| 👥  | [Community](#community)                            |      25 |
+| 👥  | [Community](#community)                            |      24 |
 | ₿   | [Crypto & Web3](#crypto--web3)                     |      27 |
 | 💾  | [Database](#database)                              |      26 |
 | 🎨  | [Design](#design)                                  |       8 |
@@ -134,7 +134,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | 🧩  | [MCP Servers](#mcp-servers)                        |      16 |
 | 📦  | [Packages](#packages)                              |       5 |
 | ⚡  | [Performance](#performance)                        |      25 |
-| ✅  | [Productivity](#productivity)                      |      34 |
+| ✅  | [Productivity](#productivity)                      |      31 |
 | 🎁  | [SaaS Skill Packs](#saas-skill-packs)              |     106 |
 | 🔐  | [Security](#security)                              |      27 |
 | ✨  | [Skill Enhancers](#skill-enhancers)                |       9 |
@@ -272,7 +272,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 
 ### Community
 
-👥 **25 plugins** · category slug: `community`
+👥 **24 plugins** · category slug: `community`
 
 | Plugin                   | Description                                                                                                                                 |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -289,7 +289,6 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | `framecraft`             | Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos…  |
 | `gastown`                | Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software…         |
 | `geepers-agents`         | Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and…      |
-| `geepers-agents`         | Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built… |
 | `hermes-tweet`           | Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions                                                          |
 | `jeremy-firebase`        | Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration                                                          |
 | `jeremy-firestore`       | Firestore database specialist for schema design, queries, and real-time sync                                                                |
@@ -526,7 +525,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 
 ### Productivity
 
-✅ **34 plugins** · category slug: `productivity`
+✅ **31 plugins** · category slug: `productivity`
 
 | Plugin                                     | Description                                                                                                                                 |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -538,9 +537,6 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | `ai-commit-gen`                            | AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly                             |
 | `box-cloud-filesystem`                     | Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage…  |
 | `claude-workflow-skills`                   | Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage                                            |
-| `claudebase`                               | Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles                                             |
-| `claudebase`                               | Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles                                             |
-| `claudebase`                               | Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles                                             |
 | `claudebase`                               | Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles                                             |
 | `cli-power-skills`                         | Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools                                                                     |
 | `content-multiplier`                       | Turn one idea, post, or transcript into on-brand, multi-channel, multi-language content in a single command.                                |
@@ -1076,7 +1072,7 @@ The [GitHub wiki](https://github.com/jeremylongshore/claude-code-plugins-plus-sk
 
 ## FAQ
 
-**What is this?** A Claude Code plugin marketplace: 471 plugins, 3,068 skills, 347 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
+**What is this?** A Claude Code plugin marketplace: 467 plugins, 3,068 skills, 347 agents, all validated against the [AgentSkills.io](https://agentskills.io/specification) open standard and the [Claude Code skills](https://code.claude.com/docs/en/skills) / [plugins](https://code.claude.com/docs/en/plugins) references.
 
 **How do I install a plugin?** Use the CLI (`ccpi install <name>`) or Claude Code's built-in `/plugin marketplace add jeremylongshore/claude-code-plugins` followed by `/plugin install <name>@claude-code-plugins-plus`. The [Quick Start](#quick-start) covers both paths.
 

--- a/scripts/validate-catalog-invariants.py
+++ b/scripts/validate-catalog-invariants.py
@@ -11,10 +11,11 @@ Invariants:
    (i.e., ./plugins/<category>/<slug> — FS path is the source of truth.)
 3. No plugin with a source under ./plugins/jeremy-*/ appears in the catalog.
    (personal-prefix directories are FS-only by policy.)
-4. marketplace.extended.json and marketplace.json report the same plugin count.
-5. Every plugin directory in the catalog has a sibling `package.json`. Lets
+4. Every plugin name is a non-empty string and appears exactly once.
+5. marketplace.extended.json and marketplace.json report the same plugin count.
+6. Every plugin directory in the catalog has a sibling `package.json`. Lets
    the npm tracking/publish workflow enumerate a complete set of packages.
-6. The two catalogs named by STANDARDS.md are the only tracked
+7. The two catalogs named by STANDARDS.md are the only tracked
    `.claude-plugin/marketplace*.json*` files; every additional variant is a
    forbidden shadow, regardless of backup/staging suffix.
 
@@ -26,6 +27,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -55,6 +57,27 @@ def fs_category(source: str) -> str | None:
     if len(parts) >= 2 and parts[0] == "plugins":
         return parts[1]
     return None
+
+
+def catalog_name_errors(plugins: list[object]) -> list[str]:
+    """Return fail-closed errors for invalid or duplicate catalog names."""
+    counts: Counter[str] = Counter()
+    errors: list[str] = []
+
+    for index, plugin in enumerate(plugins):
+        if not isinstance(plugin, dict):
+            errors.append(f"catalog row {index}: expected an object")
+            continue
+        name = plugin.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"catalog row {index}: `name` must be a non-empty string")
+            continue
+        counts[name] += 1
+
+    for name, count in sorted(counts.items()):
+        if count > 1:
+            errors.append(f"duplicate plugin name `{name}` appears {count} times; names must be unique")
+    return errors
 
 
 def tracked_catalog_shadows(root: Path | None = None) -> list[str]:
@@ -93,7 +116,7 @@ def main() -> int:
         data = json.load(f)
     plugins = data.get("plugins", [])
 
-    errors: list[str] = []
+    errors: list[str] = catalog_name_errors(plugins)
 
     try:
         for shadow in tracked_catalog_shadows():
@@ -104,6 +127,8 @@ def main() -> int:
         errors.append(str(error))
 
     for p in plugins:
+        if not isinstance(p, dict):
+            continue
         name = p.get("name", "<unnamed>")
         src = get_source(p)
 
@@ -128,7 +153,7 @@ def main() -> int:
         if fs_cat.startswith("jeremy-"):
             errors.append(f"{name}: personal-prefix category `{fs_cat}` is FS-only; remove from catalog")
 
-        # Invariant 5: plugin directory has a sibling package.json (npm tracking).
+        # Invariant 6: plugin directory has a sibling package.json (npm tracking).
         pkg_json = ROOT / fs_path / "package.json"
         if not pkg_json.is_file():
             errors.append(
@@ -136,7 +161,7 @@ def main() -> int:
                 "(run `node scripts/generate-plugin-package-jsons.mjs`)"
             )
 
-    # Invariant 4: extended <-> synced count match
+    # Invariant 5: extended <-> synced count match
     if SYNCED.exists():
         with SYNCED.open() as f:
             synced = json.load(f)

--- a/scripts/validate-catalog-invariants.py
+++ b/scripts/validate-catalog-invariants.py
@@ -72,11 +72,14 @@ def catalog_name_errors(plugins: list[object]) -> list[str]:
         if not isinstance(name, str) or not name.strip():
             errors.append(f"catalog row {index}: `name` must be a non-empty string")
             continue
-        counts[name] += 1
+        counts[name.strip().casefold()] += 1
 
     for name, count in sorted(counts.items()):
         if count > 1:
-            errors.append(f"duplicate plugin name `{name}` appears {count} times; names must be unique")
+            errors.append(
+                f"duplicate plugin identity `{name}` appears {count} times after trimming and case-folding; "
+                "names must be unique"
+            )
     return errors
 
 

--- a/tests/test_validate_catalog_invariants.py
+++ b/tests/test_validate_catalog_invariants.py
@@ -26,6 +26,14 @@ def load_validator():
 
 
 class CatalogInvariantTests(unittest.TestCase):
+    def test_name_validation_normalizes_case_and_surrounding_whitespace(self):
+        validator = load_validator()
+
+        self.assertEqual(
+            validator.catalog_name_errors([{"name": "alpha"}, {"name": " Alpha "}, {"name": "ALPHA"}]),
+            ["duplicate plugin identity `alpha` appears 3 times after trimming and case-folding; names must be unique"],
+        )
+
     def test_name_validation_fails_closed_on_invalid_rows(self):
         validator = load_validator()
 
@@ -69,7 +77,10 @@ class CatalogInvariantTests(unittest.TestCase):
                 result = validator.main()
 
             self.assertEqual(result, 1)
-            self.assertIn("duplicate plugin name `alpha` appears 2 times", output.getvalue())
+            self.assertIn(
+                "duplicate plugin identity `alpha` appears 2 times after trimming and case-folding",
+                output.getvalue(),
+            )
 
     def test_canonical_catalogs_are_not_shadows(self):
         validator = load_validator()

--- a/tests/test_validate_catalog_invariants.py
+++ b/tests/test_validate_catalog_invariants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import json
 import subprocess
 import tempfile
 import unittest
@@ -25,6 +26,51 @@ def load_validator():
 
 
 class CatalogInvariantTests(unittest.TestCase):
+    def test_name_validation_fails_closed_on_invalid_rows(self):
+        validator = load_validator()
+
+        self.assertEqual(
+            validator.catalog_name_errors([{}, {"name": ""}, {"name": 7}, "not-an-object"]),
+            [
+                "catalog row 0: `name` must be a non-empty string",
+                "catalog row 1: `name` must be a non-empty string",
+                "catalog row 2: `name` must be a non-empty string",
+                "catalog row 3: expected an object",
+            ],
+        )
+
+    def test_main_refuses_duplicate_plugin_names(self):
+        validator = load_validator()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            catalog_dir = root / ".claude-plugin"
+            plugin_dir = root / "plugins" / "community" / "alpha"
+            catalog_dir.mkdir()
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "package.json").write_text("{}")
+            duplicate_plugins = [
+                {"name": "alpha", "source": "./plugins/community/alpha", "category": "community"},
+                {"name": "alpha", "source": "./plugins/community/alpha", "category": "community"},
+            ]
+            extended = catalog_dir / "marketplace.extended.json"
+            synced = catalog_dir / "marketplace.json"
+            payload = json.dumps({"plugins": duplicate_plugins})
+            extended.write_text(payload)
+            synced.write_text(payload)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+
+            validator.ROOT = root
+            validator.EXTENDED = extended
+            validator.SYNCED = synced
+            validator.CANONICAL_CATALOGS = {path.relative_to(root).as_posix() for path in (extended, synced)}
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = validator.main()
+
+            self.assertEqual(result, 1)
+            self.assertIn("duplicate plugin name `alpha` appears 2 times", output.getvalue())
+
     def test_canonical_catalogs_are_not_shadows(self):
         validator = load_validator()
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Blueprint and authority

- Bead: `claude-hz8f.12`
- Blueprint: 727, Epic 1 bead 1.2
- Base: `48894e82d31f8bc160d3157d299e675c538ca0a7`
- Exact reviewed head: `df008f3fc4ab9c4fc6828d9c28d3222d9e72f484`

E1.8 is paused at 2/4. This prerequisite owns canonical duplicate cleanup only; the catalog renderer/drift gate remains a later E1.8 slice.

## Scope

- Collapse four excess canonical rows: three redundant `claudebase` rows and one duplicate `geepers-agents` row.
- Preserve one source-matching row per plugin without renaming either plugin.
- Merge the Geepers upstream homepage/repository into the richer contributor/component record.
- Regenerate `.claude-plugin/marketplace.json` and README catalog navigation through `pnpm run sync-marketplace`.
- Make duplicate, empty, non-string, or non-object catalog names fail closed in the existing invariant validator.
- Refresh Epic 1 row 2, blueprint evidence, and CHANGELOG.

## Explicit non-scope

No E1.8 renderer or unified-search implementation; no plugin, skill, mirrored content, provenance, registry, credential, contributor, Plane, branch-rule, package-release, or production mutation.

## Before / after

- Before: 471 rows, 467 distinct names; `claudebase` ×4 and `geepers-agents` ×2.
- After: 467 rows, 467 distinct names; no duplicate-name groups.
- Mirrored/plugin/skill content diff: zero.

Reproduce:

```bash
jq '{rows:(.plugins|length), names:([.plugins[].name]|unique|length), duplicates:([.plugins[].name]|group_by(.)|map(select(length>1)|{name:.[0],count:length}))}' .claude-plugin/marketplace.extended.json
```

## Validation

Passed at the exact reviewed head:

- `python3 -m unittest tests.test_validate_catalog_invariants` — 7/7
- `python3 scripts/validate-catalog-invariants.py` — 467 plugins
- `python3 scripts/check-catalog-format.py`
- deliberately planted duplicate fixture — exit 1, named duplicate
- two `pnpm run sync-marketplace` runs — byte-identical and clean
- `pnpm run measure:e1:check` — 37/37 and scorecard byte-current
- `pnpm run validate:generated-artifacts` — 14/14
- `pnpm run validate:generated-content` — 4/4 plus 3068/3068
- `pnpm lint`, `pnpm typecheck`, `pnpm run format:check`
- `pnpm run verify`
- `pnpm run validate:changelog-coverage` — 10/10, 20/20 releases
- `actionlint`
- `gitleaks git --redact --no-banner --log-opts='HEAD^..HEAD'` — no leaks
- hosted exact-head `ci-required`, `gitleaks`, `skill-conform`, all Validate Plugins jobs, links, prescreen, and all three MiniMax lanes — pass

Broad `pnpm test` reproduces the pre-existing unchanged `packages/cli` Vitest/Vite transform failure (`__vite_ssr_exportName__ is not defined`) before collecting its two suites. The focused and hosted CI-authoritative suites pass. Quick-test completed build and lint, then was stopped before plugin validation when ignored build output exhausted the already-constrained host root filesystem; generated output was removed and the tree restored clean.

## Independent review

A non-implementing reviewer worked from a disposable clean checkout at exact head `df008f3fc4ab9c4fc6828d9c28d3222d9e72f484` and returned **PASS**. It independently reproduced 471/467 → 467/467, planted its own refused duplicate, ran the 7/7 fixtures, two idempotent synchronizations, 37/37 scorecard, 14/14 generated-artifact and 4/4 + 3068/3068 generated-content checks, verified zero plugin/skill/provenance edits, and reverse-applied the exact diff to tree `fc21e9b8c7bf5404ed07a067ee2c0b8f6a61e5eb`, exactly matching the base tree.

## Security and licensing

This changes only catalog identity cardinality and validation. It preserves upstream attribution and links and edits no upstream/mirrored content. No secret or external service is involved.

## Rollback

Revert the focused merge, run `pnpm run sync-marketplace`, then rerun the catalog invariant and Epic 1 measurement gates. The base tree and its 471/467 state are recoverable from the parent SHA.

## Remaining merge gates

Greptile exact-head receipt/verdict and owner merge gate remain required. Do not merge until that evidence is current.