### PR TITLE
docs(governance): file plugin catalog drift gate

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -52,3 +52,4 @@
 !753-AA-AACR-skills-index-drift-gate.md
 !756-AA-AACR-skills-catalog-drift-gate.md
 !757-AA-AACR-catalog-name-uniqueness.md
+!758-AA-AACR-plugin-catalog-drift-gate.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (197 files). Local-only working
+Covers the **tracked** documentation estate (198 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -179,6 +179,7 @@ index and `000-docs/.gitignore`.
 - [755-AA-AACR-blog-markdown-scorecard-correction.md](755-AA-AACR-blog-markdown-scorecard-correction.md)
 - [756-AA-AACR-skills-catalog-drift-gate.md](756-AA-AACR-skills-catalog-drift-gate.md)
 - [757-AA-AACR-catalog-name-uniqueness.md](757-AA-AACR-catalog-name-uniqueness.md)
+- [758-AA-AACR-plugin-catalog-drift-gate.md](758-AA-AACR-plugin-catalog-drift-gate.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23056
+        "tracked_files": 23057
       }
     },
     "2": {
@@ -1928,10 +1928,10 @@
       "source": ["000-docs/000-INDEX.md"],
       "status": "measured",
       "values": {
-        "index_entries": 197,
+        "index_entries": 198,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 197,
+        "tracked_documents": 198,
         "untracked_index_entries": []
       }
     },
@@ -1955,9 +1955,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15538,
+        "invisible_files": 15539,
         "target_invisible_files": 0,
-        "tracked_files": 23056
+        "tracked_files": 23057
       }
     },
     "47": {

--- a/000-docs/758-AA-AACR-plugin-catalog-drift-gate.md
+++ b/000-docs/758-AA-AACR-plugin-catalog-drift-gate.md
@@ -1,0 +1,97 @@
+# Plugin Catalog Drift Gate — After-Action Review
+
+- **Date:** 2026-08-17
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.8, third bounded projection slice
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-hz8f.11`
+- **Implementation PR:** [#1237](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1237)
+- **Base:** `98f652ff5ba00181b76d1aae9e6698741b69c132`
+- **Reviewed head:** `26c1f10c9b0bc457264ba320e8acfaa6aaecb006`
+- **Merge commit:** `960d9b2642cb90fee12dff814c173e45aed4ee8c`
+- **Merge method:** merge commit with disclosed, owner-authorized administrator bypass
+- **Status:** implementation merged and post-merge verified; E1.8 remains open at 3/4
+
+## Outcome
+
+`marketplace/src/data/catalog.json` is now a deterministic projection of the 467-row canonical
+extended catalog and the 3,068-row full skill projection. The renderer no longer reads its own
+previous output, carries runtime timestamps, preserves stale flags, or silently accepts malformed
+skill relationships. The stale projection moved from 450 plugins, 3,022 skills, and 81 commands to
+467 plugins, 3,068 distinct skill paths, and 80 commands.
+
+Skill counts join by normalized canonical source path. The two intentional source-alias pairs
+receive equal per-plugin counts, producing an alias-summed 3,074, while the global total counts each
+`SKILL.md` path once at 3,068. Those cohorts are not interchangeable. Canonical plugin order is
+preserved. The two rows without an explicit author retain the compatibility default
+`Claude Code Plugins`, and the governed retired-domain normalizer applies to the complete rendered
+object.
+
+The renderer writes atomically and exposes a non-mutating `--check` that renders from canonical
+inputs and compares exact bytes with the stage-0 Git index. The existing credential-free
+`generated-content-drift` job now checks three of four deterministic tracked marketplace
+projections without adding a required context or path filter. `unified-search-index.json` remains
+the final E1.8 slice.
+
+No plugin, skill, `SKILL.md`, `.source.json`, mirrored content, license, registry, credential,
+contributor, Plane authority, branch rule, release, or production state changed.
+
+## Evidence bundle
+
+| Evidence item         | Result | Reproducing evidence                                                                                                                                                                                  |
+| --------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Execution             | PASS   | `node marketplace/scripts/sync-catalog.mjs` reports 467 plugins, 3,068 distinct skills, and 80 commands.                                                                                              |
+| Before/after          | PASS   | Base projection: 450 / 3,022 / 81. Merged projection: 467 / 3,068 / 80. Canonical and projected name arrays are identical and ordered.                                                                |
+| Cohort reconciliation | PASS   | Independent review computed 3,068 distinct `filePath` values and 3,074 alias-summed per-plugin counts; the global projection uses the distinct cohort.                                                |
+| Happy path            | PASS   | Two successive writes were byte-identical and matched the tracked output. Poisoning the previous output did not influence the next render.                                                            |
+| Failure path          | PASS   | Renderer fixtures refuse duplicate identities and paths, traversal, contradictory ancestry, orphan parents, count mismatch, malformed components, and staged drift.                                   |
+| Red proof             | PASS   | The independent reviewer planted staged catalog drift; `--check` exited 1 and the planted worktree hash remained unchanged.                                                                           |
+| Compatibility         | PASS   | Fixtures preserve the default author on `formatter` and `security-agent` and normalize retired-domain values across description, keyword, and author fields.                                          |
+| Generated gates       | PASS   | Post-merge generated-artifact validation passed 14/14; generated-content validation passed 8/8, 3,068/3,068 skills, and catalog 467/3,068/80.                                                         |
+| Measurement           | PASS   | Post-merge `TMPDIR=/dev/shm pnpm run measure:e1:check` passed 37/37 and reported scorecard 742 byte-current with three of four projections gated.                                                     |
+| Provenance boundary   | PASS   | The exact 12-file diff contains zero plugin, skill, `SKILL.md`, `.source.json`, mirror, license, or credential paths.                                                                                 |
+| Docs versus reality   | PASS   | Blueprint 727, CHANGELOG, CLAUDE.md, registry, workflow, package script, scorecard, renderer, tests, and output agree on the 3/4 result.                                                              |
+| Rollback              | PASS   | Reverse-applying the exact diff produced tree `be6a5fa9e24bb855988ae23c0dec265d5a7be14e`, exactly matching the base tree. Revert merge `960d9b264`, then rerun the three generated/measurement gates. |
+
+## Validation and review
+
+Exact head `26c1f10c9b0bc457264ba320e8acfaa6aaecb006` passed the required `ci-required`,
+`gitleaks`, and `skill-conform` contexts and every substantive hosted job. This included the full
+Validate Plugins matrix, marketplace build and validation, test shards, CLI smoke tests, CodeQL,
+link checking, PR Pre-screen, Actionlint, formatting, Ruff, both kernel advisories, Secret Scan,
+and all three MiniMax lanes.
+
+[Greptile reviewed the exact head](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1237#issuecomment-5321106103)
+at confidence 5/5 and reported no blocking failure. MiniMax initially identified the lost default
+author and incomplete projection normalization. Both were corrected at the final head; its fresh
+Review, Adversarial review, and A-grade coach lanes passed. There were zero review threads.
+
+An independent non-implementing reviewer worked from a clean detached checkout. Its first bounded
+verdict was **BLOCK** because five proofs were incomplete, not because it found a defect. The same
+reviewer then ran only the missing proofs and returned **PASS**: independent population
+reconciliation, planted drift with unchanged worktree bytes, output-poisoning immunity and
+byte-identical renders, scorecard visibility semantics, and exact rollback-tree equality. The
+interim BLOCK was not treated as approval.
+
+GitHub still reported `REVIEW_REQUIRED` because the documented second-human approval topology is
+unavailable. The owner-authorized
+[administrator-bypass disclosure](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1237#issuecomment-5321329531)
+was posted before merge. No branch rule or required context changed.
+
+## Operational notes and follow-up
+
+Root filesystem pressure from disposable test scratch directories constrained an additional local
+Astro build. The ignored scratch population was removed by exact test-prefix, without touching
+repository content. Hosted exact-head marketplace build and all test shards passed. Local
+`pnpm run verify`, formatting, lint, typecheck, dead-domain policy, changelog coverage, Actionlint,
+Gitleaks, generated gates, and Epic 1 measurement passed. The verifier's out-of-scope JSON
+formatting rewrite was removed before commit and did not enter the PR.
+
+Scorecard `invisible_files` counts tracked paths matched by the Gitleaks allowlist; it does not
+count ignored or untracked working-tree files. Filing this ledgered AAR therefore increases both
+`tracked_files` and `invisible_files` by one. The clean staged-index measurement reproduces that
+change independently of ignored build or scratch output.
+
+Keep `claude-hz8f.11` open at 3/4. The next and only E1.8 implementation slice is the deterministic
+`unified-search-index.json` renderer and staged-index drift gate. Do not close the Bead or activate a
+different Epic 1–3 child until that final projection is merged, independently reviewed, filed, and
+verified.


### PR DESCRIPTION
## Scope

File the v4.4 after-action review for PR #1237 / Bead `claude-hz8f.11`, append the public filing ledger, regenerate the documentation index, and refresh the Epic 1 scorecard for the one newly tracked document.

Implementation remains merged at `960d9b2642cb90fee12dff814c173e45aed4ee8c`; E1.8 remains open at 3/4 and `unified-search-index.json` remains the final slice.

## Exact evidence

- base: `960d9b2642cb90fee12dff814c173e45aed4ee8c`
- filing head: `8d59d5fe9d8b7d1477bff7fd8eb8024da11ee242`
- `node scripts/generate-docs-index.mjs --check` — PASS, 198 tracked documents
- `node scripts/check-docs-ignore-policy.mjs` — PASS, 21/21
- `node scripts/check-doc-citations.mjs` — PASS, 20 pre-existing baselined and zero new
- `TMPDIR=/dev/shm pnpm run measure:e1:check` — PASS, 37/37 and scorecard byte-current
- Prettier and `git diff --check` — PASS

## Boundaries

Documentation-only. No plugin, skill, `SKILL.md`, `.source.json`, mirror, license, registry, credential, contributor, Plane, branch rule, release, or production change. No implementation Bead is closed by this PR; E1.8 remains at 3/4.

## Rollback

Revert this focused filing merge, regenerate `000-INDEX.md` and scorecard 742, and rerun the filing and Epic 1 checks. PR #1237 implementation remains independently reversible.
