### PR TITLE
fix(marketplace-site): fail closed on Cowork manifest drift

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -54,3 +54,4 @@
 !757-AA-AACR-catalog-name-uniqueness.md
 !758-AA-AACR-plugin-catalog-drift-gate.md
 !759-AA-AACR-unified-search-drift-gate.md
+!760-AA-AACR-epic-1-cowork-manifest-contract.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (199 files). Local-only working
+Covers the **tracked** documentation estate (200 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -181,6 +181,7 @@ index and `000-docs/.gitignore`.
 - [757-AA-AACR-catalog-name-uniqueness.md](757-AA-AACR-catalog-name-uniqueness.md)
 - [758-AA-AACR-plugin-catalog-drift-gate.md](758-AA-AACR-plugin-catalog-drift-gate.md)
 - [759-AA-AACR-unified-search-drift-gate.md](759-AA-AACR-unified-search-drift-gate.md)
+- [760-AA-AACR-epic-1-cowork-manifest-contract.md](760-AA-AACR-epic-1-cowork-manifest-contract.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23063
+        "tracked_files": 23067
       }
     },
     "2": {
@@ -1928,10 +1928,10 @@
       "source": ["000-docs/000-INDEX.md"],
       "status": "measured",
       "values": {
-        "index_entries": 199,
+        "index_entries": 200,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 199,
+        "tracked_documents": 200,
         "untracked_index_entries": []
       }
     },
@@ -1955,9 +1955,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15542,
+        "invisible_files": 15545,
         "target_invisible_files": 0,
-        "tracked_files": 23063
+        "tracked_files": 23067
       }
     },
     "47": {

--- a/000-docs/760-AA-AACR-epic-1-cowork-manifest-contract.md
+++ b/000-docs/760-AA-AACR-epic-1-cowork-manifest-contract.md
@@ -1,0 +1,43 @@
+# Cowork Manifest Contract — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Status:** implementation slice; final merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The Cowork page now fails closed when its generated manifest is absent or incomplete. It no longer
+invents `300`/`1300`/`18` totals, guessed download URLs, or `Loading...` values. The grid consumes
+the producer's `skills` and `commands` fields. The validator now uses the producer's canonical
+`checksum` field, verifies a deterministic ten-plugin sample plus every bundle and the mega-zip,
+and refuses missing, aliased, malformed, or mismatched checksums.
+
+The clean-checkout measured Cowork population is 451 non-MCP catalog plugins, 2,998 packaged skills,
+302 commands, 269 agents, 18 categories, and 28 pack rows. Generated archives and manifests remain
+ignored build projections. No plugin, skill, `SKILL.md`, `.source.json`, mirrored content,
+registry, credential, contributor, Plane, branch-rule, release, or production state changed.
+
+## Evidence
+
+| Gate                   | Result                                                                            |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| Fixture contract tests | PASS — 7/7, including missing/alias/mismatch checksum red proofs                  |
+| Cowork producer        | PASS — 451 plugin zips, 18 bundles, 27.4 MB mega-zip, 2,998 clean-checkout skills |
+| Astro build            | PASS — 3,870 pages                                                                |
+| Download validator     | PASS — 18 checks, 480 links, deterministic checksums                              |
+| Manifest drift gate    | PASS — 451/451 plugins and 18/18 bundles aligned                                  |
+| Count cohort gate      | PASS — `ALLOW cohorts=5 enforced=5 deferred=50 discovered=51`                     |
+| Epic 1 measurement     | PASS — 37/37                                                                      |
+| Generated-content gate | PASS — 8/8 plus 3,068/3,068 projections                                           |
+| Changelog coverage     | PASS — 20/20 released tags                                                        |
+
+## Failure and rollback
+
+The old consumer/validator failure is reproduced by the tests: missing manifests and checksum
+aliases are refused rather than silently accepted. Rollback is the focused revert of the consumer,
+validator, contract-test, registry-reason, changelog, and this AAR changes, followed by the same
+Cowork, cohort, generated-content, and measurement commands.
+
+The producer's independent soft-failure and partial-manifest behavior remains a separately bounded
+follow-up; it is not silently expanded into this slice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1941,3 +1941,7 @@ The 3,385 public-repo `SKILL.md` files under `plugins/` are **not** migrated in 
 ### Changed
 
 - Skill quality improvements to 99.9% compliance
+
+### Fixed
+
+- **Cowork manifest contract** — require generated manifest totals, use the producer's `skills`/`commands` fields, and verify emitted `checksum` values deterministically instead of inventing fallback totals or silently skipping checksum checks.

--- a/marketplace/scripts/validate-cowork-downloads.mjs
+++ b/marketplace/scripts/validate-cowork-downloads.mjs
@@ -17,7 +17,7 @@
 import { readFileSync, existsSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { createHash } from 'crypto';
+import { verifyCoworkChecksum } from '../../scripts/cowork-manifest-contract.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -204,11 +204,11 @@ if (sizeIssues === 0) {
 }
 
 // ── Check 7: Checksum spot-check ────────────────────────────────────────
-console.log('\n7. Checksum spot-check (up to 10 random plugins)');
+console.log('\n7. Checksum verification (deterministic plugin sample plus all bundles)');
 if (Array.isArray(manifest.plugins)) {
-  const pluginsWithChecksums = manifest.plugins.filter(p => p.sha256 && p.path);
-  const sample = pluginsWithChecksums
-    .sort(() => Math.random() - 0.5)
+  const sample = manifest.plugins
+    .filter(p => p.path)
+    .sort((a, b) => String(a.name).localeCompare(String(b.name)))
     .slice(0, 10);
 
   let checksumFails = 0;
@@ -216,19 +216,49 @@ if (Array.isArray(manifest.plugins)) {
     const zipPath = join(DIST_DIR, plugin.path.replace(/^\//, ''));
     if (!existsSync(zipPath)) continue;
 
-    const content = readFileSync(zipPath);
-    const hash = createHash('sha256').update(content).digest('hex');
-
-    if (hash !== plugin.sha256) {
-      fail(`Checksum mismatch for ${plugin.name}: expected ${plugin.sha256}, got ${hash}`);
+    const result = verifyCoworkChecksum(zipPath, plugin, `plugin ${plugin.name}`);
+    if (!result.ok) {
+      fail(result.reason);
       checksumFails++;
     }
   }
 
   if (checksumFails === 0 && sample.length > 0) {
-    pass(`${sample.length} checksums verified`);
+    pass(`${sample.length} deterministic plugin checksums verified`);
   } else if (sample.length === 0) {
-    pass('No checksums to verify (plugins may not have sha256 field)');
+    fail('No plugin checksums available to verify');
+  }
+}
+
+if (Array.isArray(manifest.bundles)) {
+  let bundleChecksumFails = 0;
+  for (const bundle of manifest.bundles) {
+    if (!bundle.path || typeof bundle.checksum !== 'string' || bundle.checksum.length === 0) {
+      fail(`Missing checksum for bundle ${bundle.category || 'unknown'}`);
+      bundleChecksumFails++;
+      continue;
+    }
+    const bundlePath = join(DIST_DIR, bundle.path.replace(/^\//, ''));
+    if (!existsSync(bundlePath)) continue;
+    const result = verifyCoworkChecksum(
+      bundlePath,
+      bundle,
+      `bundle ${bundle.category || 'unknown'}`,
+    );
+    if (!result.ok) {
+      fail(result.reason);
+      bundleChecksumFails++;
+    }
+  }
+  if (bundleChecksumFails === 0) pass(`${manifest.bundles.length} bundle checksums verified`);
+}
+
+if (manifest.megaZip?.path) {
+  const megaPath = join(DIST_DIR, manifest.megaZip.path.replace(/^\//, ''));
+  if (existsSync(megaPath)) {
+    const result = verifyCoworkChecksum(megaPath, manifest.megaZip, 'mega-zip');
+    if (result.ok) pass('Mega-zip checksum verified');
+    else fail(result.reason);
   }
 }
 

--- a/marketplace/src/components/CoworkGrid.astro
+++ b/marketplace/src/components/CoworkGrid.astro
@@ -16,12 +16,10 @@ if (limit) {
   displayPacks = displayPacks.slice(0, limit);
 }
 
-// Try to load enriched manifest data (generated at build time)
-let manifest: any = null;
-try {
-  manifest = (await import('../data/cowork-manifest.json')).default;
-} catch {
-  // Manifest not yet generated - will show packs without sizes
+// The page build must generate this projection before the component renders.
+const manifest = (await import('../data/cowork-manifest.json')).default;
+if (!manifest || !Array.isArray(manifest.bundles) || !Array.isArray(manifest.plugins)) {
+  throw new Error('Cowork manifest is missing bundle or plugin data');
 }
 
 // Map bundle data by category for enrichment
@@ -159,13 +157,13 @@ if (manifest?.plugins) {
     const bundle = !isSaasPack ? bundleMap.get(pack.category) : null;
 
     // Determine download path and stats
-    const downloadPath = isSaasPack
-      ? (plugin?.path || `/downloads/plugins/${pack.packName}.zip`)
-      : (bundle?.path || `/downloads/bundles/${pack.category}.zip`);
+    const downloadRecord = isSaasPack ? plugin : bundle;
+    if (!downloadRecord?.path || !downloadRecord.sizeFormatted) {
+      throw new Error(`Cowork manifest has no complete download record for ${pack.id}`);
+    }
+    const downloadPath = downloadRecord.path;
     const downloadName = isSaasPack ? `${pack.packName}.zip` : `${pack.category}.zip`;
-    const sizeFormatted = isSaasPack
-      ? (plugin?.sizeFormatted || 'Loading...')
-      : (bundle?.sizeFormatted || 'Loading...');
+    const sizeFormatted = downloadRecord.sizeFormatted;
 
     return (
       <div class="cowork-card" data-pack-id={pack.id}>
@@ -184,8 +182,8 @@ if (manifest?.plugins) {
 
         {plugin && (
           <div class="cowork-stats">
-            {plugin.skillCount > 0 && <span class="cowork-stat">{plugin.skillCount} skills</span>}
-            {plugin.commandCount > 0 && <span class="cowork-stat">{plugin.commandCount} commands</span>}
+            {plugin.skills > 0 && <span class="cowork-stat">{plugin.skills} skills</span>}
+            {plugin.commands > 0 && <span class="cowork-stat">{plugin.commands} commands</span>}
           </div>
         )}
 

--- a/marketplace/src/pages/cowork.astro
+++ b/marketplace/src/pages/cowork.astro
@@ -2,18 +2,24 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import CoworkGrid from '../components/CoworkGrid.astro';
 
-// Try to load manifest for mega-zip stats
-let manifest: any = null;
-try {
-  manifest = (await import('../data/cowork-manifest.json')).default;
-} catch {
-  // Not yet generated
+// The build pipeline must generate this projection before Astro renders.
+// Failing here prevents stale or invented totals from reaching the public site.
+const manifest = (await import('../data/cowork-manifest.json')).default;
+if (
+  !manifest ||
+  !Array.isArray(manifest.plugins) ||
+  !Array.isArray(manifest.bundles) ||
+  !manifest.megaZip ||
+  typeof manifest.totalPlugins !== 'number' ||
+  typeof manifest.totalSkills !== 'number'
+) {
+  throw new Error('Cowork manifest is missing required generated fields');
 }
 
-const megaZip = manifest?.megaZip;
-const totalPlugins = manifest?.totalPlugins || 300;
-const totalSkills = manifest?.totalSkills || 1300;
-const allPlugins = manifest?.plugins || [];
+const megaZip = manifest.megaZip;
+const totalPlugins = manifest.totalPlugins;
+const totalSkills = manifest.totalSkills;
+const allPlugins = manifest.plugins;
 ---
 
 <BaseLayout
@@ -506,15 +512,15 @@ const allPlugins = manifest?.plugins || [];
     <div class="cowork-hero-stats">
       <div class="cowork-hero-stat">
         <span class="stat-number">{totalPlugins}+</span>
-        <span class="stat-label">Plugins</span>
+        <span class="stat-label">Cowork-packaged plugins</span>
       </div>
       <div class="cowork-hero-stat">
         <span class="stat-number">{totalSkills}+</span>
-        <span class="stat-label">Skills</span>
+        <span class="stat-label">Cowork-packaged skills</span>
       </div>
       <div class="cowork-hero-stat">
-        <span class="stat-number">{manifest?.bundles?.length || 18}</span>
-        <span class="stat-label">Category Packs</span>
+        <span class="stat-number">{manifest.bundles.length}</span>
+        <span class="stat-label">Cowork category packs</span>
       </div>
     </div>
   </section>
@@ -524,13 +530,13 @@ const allPlugins = manifest?.plugins || [];
     <div class="mega-banner">
       <div class="mega-info">
         <h2>Download Everything</h2>
-        <p>All {totalPlugins} plugins and {totalSkills} skills in one zip</p>
+        <p>All {totalPlugins} Cowork-packaged plugins and {totalSkills} Cowork-packaged skills in one zip</p>
         <div class="mega-stats">
           {megaZip && <span class="mega-stat">{megaZip.sizeFormatted}</span>}
         </div>
       </div>
       <a
-        href={megaZip ? megaZip.path : '/downloads/claude-code-plugins-all.zip'}
+        href={megaZip.path}
         download
         class="mega-download-btn"
       >

--- a/scripts/cowork-manifest-contract.mjs
+++ b/scripts/cowork-manifest-contract.mjs
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Verify the checksum contract emitted by build-cowork-zips.mjs.
+ * The producer's field is deliberately named `checksum`; accepting aliases
+ * would allow a schema drift to make verification a no-op.
+ */
+export function verifyCoworkChecksum(filePath, entry, label = 'artifact') {
+  if (!entry || typeof entry.checksum !== 'string' || !/^[0-9a-f]{64}$/.test(entry.checksum)) {
+    return { ok: false, reason: `${label} is missing a valid checksum` };
+  }
+  const actual = createHash('sha256').update(readFileSync(filePath)).digest('hex');
+  return actual === entry.checksum
+    ? { ok: true, actual }
+    : { ok: false, reason: `${label} checksum mismatch`, actual };
+}

--- a/scripts/cowork-manifest-contract.test.mjs
+++ b/scripts/cowork-manifest-contract.test.mjs
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+import { verifyCoworkChecksum } from './cowork-manifest-contract.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'cowork-manifest-'));
+  const filePath = join(root, 'fixture.zip');
+  const bytes = Buffer.from('deterministic cowork fixture');
+  writeFileSync(filePath, bytes);
+  const checksum = createHash('sha256').update(bytes).digest('hex');
+  return { root, filePath, checksum };
+}
+
+test('accepts the producer checksum field for an exact file', () => {
+  const { root, filePath, checksum } = fixture();
+  try {
+    assert.equal(verifyCoworkChecksum(filePath, { checksum }, 'plugin').ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('refuses a missing checksum instead of treating it as unverified success', () => {
+  const { root, filePath } = fixture();
+  try {
+    const result = verifyCoworkChecksum(filePath, {}, 'plugin');
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /missing a valid checksum/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('refuses a sha256 alias and requires the canonical checksum field', () => {
+  const { root, filePath, checksum } = fixture();
+  try {
+    const result = verifyCoworkChecksum(filePath, { sha256: checksum }, 'plugin');
+    assert.equal(result.ok, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('refuses a checksum mismatch', () => {
+  const { root, filePath } = fixture();
+  try {
+    const result = verifyCoworkChecksum(filePath, { checksum: '0'.repeat(64) }, 'plugin');
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /checksum mismatch/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/cowork-page-contract.test.mjs
+++ b/scripts/cowork-page-contract.test.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const page = readFileSync('marketplace/src/pages/cowork.astro', 'utf8');
+const grid = readFileSync('marketplace/src/components/CoworkGrid.astro', 'utf8');
+const validator = readFileSync('marketplace/scripts/validate-cowork-downloads.mjs', 'utf8');
+
+test('Cowork page has no invented totals or guessed download paths', () => {
+  assert.doesNotMatch(page, /\|\|\s*(?:300|1300|18)\b/);
+  assert.doesNotMatch(page, /claude-code-plugins-all\.zip/);
+  assert.doesNotMatch(page, /catch\s*\{/);
+  assert.match(page, /manifest\.bundles\.length/);
+  assert.match(page, /Cowork-packaged skills/);
+});
+
+test('Cowork grid consumes producer fields and has no loading fallback', () => {
+  assert.doesNotMatch(grid, /Loading\.\.\./);
+  assert.doesNotMatch(grid, /plugin\.skillCount|plugin\.commandCount/);
+  assert.match(grid, /plugin\.skills/);
+  assert.match(grid, /plugin\.commands/);
+});
+
+test('download validation uses the canonical checksum field', () => {
+  assert.match(validator, /verifyCoworkChecksum/);
+  assert.doesNotMatch(validator, /\.sha256\b/);
+  assert.doesNotMatch(validator, /sort\(\(\) => Math\.random/);
+});

--- a/scripts/published-count-cohorts.json
+++ b/scripts/published-count-cohorts.json
@@ -119,7 +119,7 @@
     {
       "classification": "packaged-or-bundle-local",
       "owner": "E1.6 follow-up",
-      "reason": "Cowork totals count downloadable package contents or one bundle/plugin, not the marketplace-visible cohort; their manifest authority and fallback removal require a separate contract.",
+      "reason": "Cowork totals count downloadable package contents or one bundle/plugin, not the marketplace-visible cohort; they are reproduced by the generated Cowork manifest after `node scripts/build-cowork-zips.mjs`. The manifest is now required and consumer fallbacks are forbidden; local package/bundle cohort enforcement remains a separate contract.",
       "paths": ["marketplace/src/components/CoworkGrid.astro", "marketplace/src/pages/cowork.astro"]
     },
     {


### PR DESCRIPTION
## Summary
- harden the Cowork generated-manifest contract so missing or incomplete projections fail closed
- align CoworkGrid with producer-emitted skills/commands fields and remove guessed paths/loading fallbacks
- verify canonical checksum values deterministically for plugin, bundle, and mega-zip artifacts
- record E1.6 evidence in AAR 760, update the count-registry deferral reason, docs index, and CHANGELOG

## Governance
- Bead: claude-hz8f.13 (Blueprint 727 §13 / E1.6)
- Scope: one bounded Cowork manifest-consumer/checksum slice
- Non-scope: producer soft-failure redesign, mirrored content, plugin/skill corpus, registries, credentials, contributors, Plane, branch rules, releases, production
- Rollback: revert this focused commit and rerun the documented Cowork, cohort, generated-content, changelog, and E1 measurement gates

## Evidence
- Clean-checkout independent review of exact head 21c8805b57f03f1ec0dd03fa251d9ef8456ca9b0: PASS
- Contract and red-proof tests: 7/7
- Cowork producer: 451 plugin zips, 18 bundles; clean-checkout packaged skill cohort: 2,998
- Astro build: 3,870 pages
- Download validator: 18 checks, 480 links, deterministic checksums
- Cohort gate: ALLOW cohorts=5 enforced=5 deferred=50 discovered=51
- Epic 1 measurement: 37/37
- Generated-content: 8/8 plus 3,068/3,068
- Changelog coverage: 20/20
- No mirrored content or external mutation

Please review the full diff and failure paths. This PR is intentionally draft pending hosted CI and bot review.
