### PR TITLE
fix(marketplace): govern query-local skill counts

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -56,3 +56,4 @@
 !759-AA-AACR-unified-search-drift-gate.md
 !760-AA-AACR-epic-1-cowork-manifest-contract.md
 !761-AA-AACR-epic-1-social-image-count-cohort.md
+!762-AA-AACR-epic-1-query-local-count-contracts.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (201 files). Local-only working
+Covers the **tracked** documentation estate (202 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -183,6 +183,7 @@ index and `000-docs/.gitignore`.
 - [759-AA-AACR-unified-search-drift-gate.md](759-AA-AACR-unified-search-drift-gate.md)
 - [760-AA-AACR-epic-1-cowork-manifest-contract.md](760-AA-AACR-epic-1-cowork-manifest-contract.md)
 - [761-AA-AACR-epic-1-social-image-count-cohort.md](761-AA-AACR-epic-1-social-image-count-cohort.md)
+- [762-AA-AACR-epic-1-query-local-count-contracts.md](762-AA-AACR-epic-1-query-local-count-contracts.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23069
+        "tracked_files": 23070
       }
     },
     "2": {
@@ -1931,10 +1931,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 201,
+        "index_entries": 202,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 201,
+        "tracked_documents": 202,
         "untracked_index_entries": []
       }
     },
@@ -1958,9 +1958,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15547,
+        "invisible_files": 15548,
         "target_invisible_files": 0,
-        "tracked_files": 23069
+        "tracked_files": 23070
       }
     },
     "47": {

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23070
+        "tracked_files": 23071
       }
     },
     "2": {
@@ -1960,7 +1960,7 @@
         "invalid_patterns": 0,
         "invisible_files": 15548,
         "target_invisible_files": 0,
-        "tracked_files": 23070
+        "tracked_files": 23071
       }
     },
     "47": {

--- a/000-docs/762-AA-AACR-epic-1-query-local-count-contracts.md
+++ b/000-docs/762-AA-AACR-epic-1-query-local-count-contracts.md
@@ -1,0 +1,36 @@
+# Query-Local Count Contracts — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Scope:** query-result and entity-local counts in the search UI
+- **Status:** implementation slice; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The search UI now distinguishes counts attached to one result entity from the
+current filtered query result. These values retain their existing numbers and
+are labeled `entity-local` or `query-result-local`; they are not represented as
+the marketplace-wide cohort. Each deferred expression carries the executable
+checker command and one exact contract binding expression, label, provenance,
+runtime sink, rendering function, and observed call site in the machine-
+readable count registry. The checker does not claim to recompute arbitrary
+browser-query values; it refuses deferred entries with missing, contradictory,
+unbound, or unreachable local contracts.
+
+## Evidence
+
+| Gate                          | Result                                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Published-count fixture suite | PASS — 32/32, including missing local contract red proofs                                              |
+| Live registry                 | PASS — `ALLOW cohorts=5 enforced=6 deferred=49 discovered=51`                                          |
+| Mirrored content              | No `.source.json` or mirrored skill content changed                                                    |
+| Numeric values                | Unchanged; only labels and contract metadata changed                                                   |
+| Runtime bindings              | `renderCard`/`metaParts.push` and `updateResultsCount`/`el.innerHTML`, each with an observed call site |
+
+## Rollback and boundaries
+
+Revert the focused page, registry, checker, test, documentation, and changelog
+changes, then rerun the fixture suite and live registry check. Global
+marketplace totals, README work, vendor packs, research snapshots, package
+contents, and external systems are outside this slice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-08-18
 
+- **fix(marketplace):** label search-result and entity-local skill counts with
+  their local population and provenance instead of presenting them as global
+  marketplace totals.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.

--- a/marketplace/src/pages/explore.astro
+++ b/marketplace/src/pages/explore.astro
@@ -603,7 +603,7 @@ const pageDescription = `Search all ${_rawStats.totalPlugins} catalog plugins an
         metaParts.push(`<span>Docs · ${escHtml(item.category)}</span>`);
       }
       if (item.skillCount > 0) {
-        metaParts.push(`<span>${item.skillCount} skills</span>`);
+        metaParts.push(`<span data-count-provenance="entity-local">${item.skillCount} entity-local skills</span>`);
       }
       const metaHtml = metaParts.length
         ? `<small>${metaParts.join(' · ')}</small>`

--- a/marketplace/src/pages/skills/index.astro
+++ b/marketplace/src/pages/skills/index.astro
@@ -396,7 +396,9 @@ const allTools = _rawCatalog.allowedToolsUsed;
 
     function updateResultsCount(shown, total) {
       const el = document.getElementById('results-count');
-      if (el) el.textContent = `Showing ${shown} of ${total} skills`;
+      if (el) {
+        el.innerHTML = `<span data-count-provenance="query-result-local">Showing ${shown} of ${total} query-result-local skills</span>`;
+      }
     }
 
     // Event listeners

--- a/scripts/check-published-count-cohorts.mjs
+++ b/scripts/check-published-count-cohorts.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
 
 const REGISTRY_PATH = 'scripts/published-count-cohorts.json';
 const DISCOVERY_ROOTS = Object.freeze(['marketplace/src/pages', 'marketplace/src/components']);
@@ -522,6 +523,127 @@ function literalOccurrences(source, literal) {
   return occurrences;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function runtimeFunctionRanges(source, functionName) {
+  const sourceFile = ts.createSourceFile(
+    'published-count-runtime.js',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const ranges = [];
+  function visit(node) {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === functionName && node.body) {
+      ranges.push({ start: node.body.getStart(sourceFile), end: node.body.getEnd() });
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return ranges;
+}
+
+function runtimeDirectCallOffsets(source, functionName) {
+  const sourceFile = ts.createSourceFile(
+    'published-count-runtime.js',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const offsets = [];
+  function visit(node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === functionName
+    ) {
+      offsets.push(node.expression.getStart(sourceFile));
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return offsets;
+}
+
+function runtimeTemplateLiteralOccurrences(source, literal, sink, functionName, callName) {
+  const occurrences = [];
+  for (const region of rawTextElementRegions(source).filter(
+    (entry) => entry.element === 'script',
+  )) {
+    const script = source.slice(region.start, region.end);
+    const bodyStart = script.indexOf('>') + 1;
+    const bodyEnd = script.lastIndexOf('</');
+    const body = bodyEnd > bodyStart ? script.slice(bodyStart, bodyEnd) : '';
+    const functionRanges = runtimeFunctionRanges(body, functionName).map((range) => ({
+      start: range.start + bodyStart,
+      end: range.end + bodyStart,
+    }));
+    const callOffsets = runtimeDirectCallOffsets(body, callName).map(
+      (offset) => offset + bodyStart,
+    );
+    const calledOutsideFunction = callOffsets.some(
+      (offset) => !functionRanges.some((range) => range.start <= offset && offset < range.end),
+    );
+    if (!calledOutsideFunction) continue;
+    let inTemplate = false;
+    let escaped = false;
+    for (let index = 0; index < script.length; index += 1) {
+      const character = script[index];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (character === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (character === '`') {
+        inTemplate = !inTemplate;
+        continue;
+      }
+      if (!inTemplate || !script.startsWith(literal, index)) continue;
+
+      const templateStart = script.lastIndexOf('`', index);
+      const statementStart = Math.max(
+        script.lastIndexOf(';', templateStart),
+        script.lastIndexOf('{', templateStart),
+        script.lastIndexOf('}', templateStart),
+        script.lastIndexOf('\n', templateStart),
+      );
+      const prefix = script.slice(statementStart + 1, templateStart);
+      const sinkPattern = sink.endsWith('.push')
+        ? new RegExp(`${escapeRegExp(sink)}\\(\\s*$`, 'u')
+        : new RegExp(`${escapeRegExp(sink)}\\s*=\\s*$`, 'u');
+      const functionRange = functionRanges.find(
+        (range) => range.start <= index && index < range.end,
+      );
+      if (functionRange && sinkPattern.test(prefix)) {
+        occurrences.push(region.start + index);
+      }
+      index += Math.max(literal.length - 1, 0);
+    }
+  }
+  return occurrences;
+}
+
+function renderedContractOccurrences(
+  rawSource,
+  visibleSource,
+  literal,
+  sink,
+  functionName,
+  callName,
+) {
+  return [
+    ...literalOccurrences(visibleSource, literal),
+    ...runtimeTemplateLiteralOccurrences(rawSource, literal, sink, functionName, callName),
+  ].sort((left, right) => left - right);
+}
+
 function lineAtOffset(source, offset) {
   return source.slice(0, offset).split('\n').length;
 }
@@ -642,6 +764,50 @@ function validateSurfaces(registry, root, io) {
         nonemptyString(claim.classification, `${claimField}.classification`);
         nonemptyString(claim.owner, `${claimField}.owner`);
         nonemptyString(claim.reason, `${claimField}.reason`);
+        const claimLabel = nonemptyString(claim.label, `${claimField}.label`);
+        const claimProvenance = nonemptyString(claim.provenance, `${claimField}.provenance`);
+        const claimCommand = nonemptyString(claim.command, `${claimField}.command`);
+        const claimContract = nonemptyString(claim.contract, `${claimField}.contract`);
+        const claimSink = nonemptyString(claim.sink, `${claimField}.sink`);
+        const claimFunction = nonemptyString(claim.function, `${claimField}.function`);
+        const claimCall = nonemptyString(claim.call, `${claimField}.call`);
+        if (
+          [claimExpression, claimLabel, claimProvenance, claimCommand, claimContract].some(
+            (value) => value.length === 0,
+          )
+        ) {
+          continue;
+        }
+        if (claimCommand !== 'node scripts/check-published-count-cohorts.mjs --json') {
+          refuse(
+            'INVALID_LOCAL_COMMAND',
+            `${claimField}.command must be the executable local-count checker command`,
+          );
+        }
+        if (!foldedText(claimLabel).includes(foldedText(claim.classification))) {
+          refuse(
+            'LOCAL_LABEL_MISMATCH',
+            `${claimField}.label must name classification ${JSON.stringify(claim.classification)}`,
+          );
+        }
+        if (!claimProvenance.includes(claim.classification)) {
+          refuse(
+            'LOCAL_PROVENANCE_MISMATCH',
+            `${claimField}.provenance must name classification ${JSON.stringify(claim.classification)}`,
+          );
+        }
+        if (!claimContract.includes(claimExpression)) {
+          refuse(
+            'LOCAL_CONTRACT_MISMATCH',
+            `${claimField}.contract must include expression ${JSON.stringify(claimExpression)}`,
+          );
+        }
+        if (!claimContract.includes(claimLabel) || !claimContract.includes(claimProvenance)) {
+          refuse(
+            'LOCAL_CONTRACT_MISMATCH',
+            `${claimField}.contract must include its declared label and provenance`,
+          );
+        }
         if (expressions.includes(claimExpression)) {
           refuse(
             'DUPLICATE_SURFACE_EXPRESSION',
@@ -652,6 +818,24 @@ function validateSurfaces(registry, root, io) {
           refuse(
             'MISSING_EXPRESSION',
             `${surfacePath} does not contain deferred expression ${JSON.stringify(claimExpression)}`,
+          );
+        }
+        // A contract only governs a published count when it is present in the
+        // rendered Astro surface or in a recognizable runtime HTML sink. Raw
+        // source also includes frontmatter and dead script constants, where a
+        // copy could otherwise satisfy the registry without affecting output.
+        const contractOccurrences = renderedContractOccurrences(
+          rawSource,
+          visibleSource,
+          claimContract,
+          claimSink,
+          claimFunction,
+          claimCall,
+        );
+        if (contractOccurrences.length !== 1) {
+          refuse(
+            'INVALID_LOCAL_CONTRACT',
+            `${surfacePath} must contain local contract exactly once (found ${contractOccurrences.length})`,
           );
         }
         expressions.push(claimExpression);

--- a/scripts/check-published-count-cohorts.test.mjs
+++ b/scripts/check-published-count-cohorts.test.mjs
@@ -216,19 +216,159 @@ test('registered pages may explicitly defer a second owned count expression', ()
     classification: 'entity-local',
     owner: 'fixture owner',
     reason: 'This fixture count is local to one entity.',
+    label: 'entity-local skills',
+    provenance: 'data-count-provenance="entity-local"',
+    command: 'node scripts/check-published-count-cohorts.mjs --json',
+    contract: 'data-count-provenance="entity-local">{catalog.count} entity-local skills',
+    sink: 'metaParts.push',
+    function: 'renderCard',
+    call: 'renderCard',
   };
   const root = makeFixture({
     surfaces: [enforcedSurface({ deferredExpressions: [deferredExpression] })],
-    source: `${validSource()}<div>{catalog.count} entity-local skills</div>\n`,
+    source: `${validSource()}<div data-count-provenance="entity-local">{catalog.count} entity-local skills</div>\n`,
   });
   equal(check(root).allow, true);
   equal(check(root).deferred, 1);
 
   const malformed = makeFixture({
     surfaces: [enforcedSurface({ deferredExpressions: [{ ...deferredExpression, owner: '' }] })],
-    source: `${validSource()}<div>{catalog.count} entity-local skills</div>\n`,
+    source: `${validSource()}<div data-count-provenance="entity-local">{catalog.count} entity-local skills</div>\n`,
   });
   equal(findingCode(check(malformed)), 'INVALID_REGISTRY');
+
+  const nonExecutableCommand = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [{ ...deferredExpression, command: 'browser resolver prose' }],
+      }),
+    ],
+    source: `${validSource()}<div data-count-provenance="entity-local">{catalog.count} entity-local skills</div>\n`,
+  });
+  equal(findingCode(check(nonExecutableCommand)), 'INVALID_LOCAL_COMMAND');
+
+  const unboundContract = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [{ ...deferredExpression, contract: 'not rendered here' }],
+      }),
+    ],
+    source: `${validSource()}<div data-count-provenance="entity-local">{catalog.count} entity-local skills</div>\n`,
+  });
+  equal(findingCode(check(unboundContract)), 'LOCAL_CONTRACT_MISMATCH');
+
+  const missingContract = { ...deferredExpression };
+  delete missingContract.contract;
+  const missingContractFixture = makeFixture({
+    surfaces: [enforcedSurface({ deferredExpressions: [missingContract] })],
+    source: `${validSource()}<div data-count-provenance="entity-local">{catalog.count} entity-local skills</div>\n`,
+  });
+  equal(findingCode(check(missingContractFixture)), 'INVALID_REGISTRY');
+
+  const unlabeledContract = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [
+          {
+            ...deferredExpression,
+            contract: '<span>{catalog.count} skills</span>',
+          },
+        ],
+      }),
+    ],
+    source: `${validSource()}<span>{catalog.count} skills</span>\n`,
+  });
+  equal(findingCode(check(unlabeledContract)), 'LOCAL_CONTRACT_MISMATCH');
+
+  const nonRenderedContract = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [
+          {
+            ...deferredExpression,
+            sink: 'el.innerHTML',
+            function: 'updateCount',
+            call: 'updateCount',
+          },
+        ],
+      }),
+    ],
+    source: [
+      '---',
+      'const deadContract = `data-count-provenance="entity-local">{catalog.count} entity-local skills`;',
+      '---',
+      '<div>{catalog.count} skills</div>',
+      '',
+    ].join('\n'),
+  });
+  equal(findingCode(check(nonRenderedContract)), 'INVALID_LOCAL_CONTRACT');
+
+  const runtimeContract = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [
+          {
+            ...deferredExpression,
+            sink: 'el.innerHTML',
+            function: 'updateCount',
+            call: 'updateCount',
+          },
+        ],
+      }),
+    ],
+    source: [
+      validSource().trimEnd(),
+      '<div>{catalog.count} skills</div>',
+      '<script>',
+      '  const el = document.querySelector("#count");',
+      '  function updateCount() {',
+      '    el.innerHTML = `<span data-count-provenance="entity-local">{catalog.count} entity-local skills</span>`;',
+      '  }',
+      '  updateCount();',
+      '</script>',
+      '',
+    ].join('\n'),
+  });
+  equal(check(runtimeContract).allow, true);
+
+  const discardedPush = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [deferredExpression],
+      }),
+    ],
+    source: [
+      validSource().trimEnd(),
+      '<script>',
+      '  const discarded = [];',
+      '  discarded.push(`<span data-count-provenance="entity-local">{catalog.count} entity-local skills</span>`);',
+      '</script>',
+      '',
+    ].join('\n'),
+  });
+  equal(findingCode(check(discardedPush)), 'INVALID_LOCAL_CONTRACT');
+
+  const deadExactSink = makeFixture({
+    surfaces: [
+      enforcedSurface({
+        deferredExpressions: [deferredExpression],
+      }),
+    ],
+    source: [
+      validSource().trimEnd(),
+      '<script>',
+      '  function renderCard() {',
+      '    metaParts.push(`<span data-count-provenance="entity-local">{catalog.count} entity-local skills</span>`);',
+      '  }',
+      '  // renderCard();',
+      '  const text = "renderCard()";',
+      '  notrenderCard();',
+      '  other.renderCard();',
+      '</script>',
+      '',
+    ].join('\n'),
+  });
+  equal(findingCode(check(deadExactSink)), 'INVALID_LOCAL_CONTRACT');
 });
 
 test('every expression in a combined shown-of-total skill count needs registration', () => {
@@ -241,11 +381,19 @@ test('every expression in a combined shown-of-total skill count needs registrati
             classification: 'query-result-local',
             owner: 'fixture owner',
             reason: 'The total belongs to the query-result cohort.',
+            label: 'query-result-local skills',
+            provenance: 'query-result-local',
+            command: 'node scripts/check-published-count-cohorts.mjs --json',
+            contract:
+              '<span data-count-provenance="query-result-local">Showing ${shown} of ${total} query-result-local skills</span>',
+            sink: 'el.innerHTML',
+            function: 'updateResultsCount',
+            call: 'updateResultsCount',
           },
         ],
       }),
     ],
-    source: `${validSource()}<p>Showing \${shown} of \${total} skills</p>\n`,
+    source: `${validSource()}<span data-count-provenance="query-result-local">Showing \${shown} of \${total} query-result-local skills</span><p>{shown} skills</p>\n`,
   });
   equal(findingCode(check(root)), 'UNREGISTERED_PUBLIC_COUNT_EXPRESSION');
 });

--- a/scripts/published-count-cohorts.json
+++ b/scripts/published-count-cohorts.json
@@ -62,7 +62,14 @@
           "expression": "item.skillCount",
           "classification": "entity-local",
           "owner": "E1.6 follow-up",
-          "reason": "This client-rendered value counts skills attached to one search result, not the marketplace-visible corpus; its local-entity label remains a separate contract."
+          "reason": "This client-rendered value counts skills attached to one search result, not the marketplace-visible corpus.",
+          "label": "entity-local skills",
+          "provenance": "data-count-provenance=\"entity-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"entity-local\">${item.skillCount} entity-local skills",
+          "sink": "metaParts.push",
+          "function": "renderCard",
+          "call": "renderCard"
         }
       ]
     },
@@ -97,13 +104,27 @@
           "expression": "${shown}",
           "classification": "query-result-local",
           "owner": "E1.6 follow-up",
-          "reason": "This client-rendered value is the current filtered result count, not a stable corpus cohort; its query-local label remains a separate contract."
+          "reason": "This client-rendered value is the current filtered result count, not a stable corpus cohort.",
+          "label": "query-result-local skills",
+          "provenance": "query-result-local",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "<span data-count-provenance=\"query-result-local\">Showing ${shown} of ${total} query-result-local skills</span>",
+          "sink": "el.innerHTML",
+          "function": "updateResultsCount",
+          "call": "updateResultsCount"
         },
         {
           "expression": "${total}",
           "classification": "query-result-local",
           "owner": "E1.6 follow-up",
-          "reason": "This client-rendered value is the current query total paired with the filtered result count, not an independently governed corpus cohort."
+          "reason": "This client-rendered value is the current query total paired with the filtered result count, not an independently governed corpus cohort.",
+          "label": "query-result-local skills",
+          "provenance": "query-result-local",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "<span data-count-provenance=\"query-result-local\">Showing ${shown} of ${total} query-result-local skills</span>",
+          "sink": "el.innerHTML",
+          "function": "updateResultsCount",
+          "call": "updateResultsCount"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- label the existing `item.skillCount` entity-local result-card count
- label `shown` and `total` as query-result-local counts
- require label, provenance, and reproduction command metadata for deferred count expressions
- add AAR 762, changelog, generated index, and refreshed Epic 1 scorecard

Bead: claude-hz8f.13
Blueprint: 727 §13 / Epic 1 bead 1.6

## Scope
This is one bounded continuation of E1.6. Numeric values are unchanged. Global marketplace-visible totals, README, vendor packs, research snapshots, mirrors, registry credentials, contributors, Plane, branch protection, and production are out of scope.

## Evidence
- `node --test scripts/check-published-count-cohorts.test.mjs` — 32/32
- `node scripts/check-published-count-cohorts.mjs --json` — ALLOW, 5 cohorts, 6 enforced, 49 deferred, 51 discovered
- `pnpm run measure:e1:check` — 37/37 and scorecard OK
- `pnpm --dir marketplace run build` — 3,870 pages built
- Prettier, ESLint, actionlint, docs index/ignore, and diff checks pass
- no `.source.json` or mirrored skill content changed
- no registry, credential, contributor, Plane, or production mutation

## Review and rollback
Independent clean-checkout review is required at the exact PR head. Revert this focused commit and rerun the checks above to roll back.