### PR TITLE
fix(marketplace): govern entity-local count contracts

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -57,3 +57,4 @@
 !760-AA-AACR-epic-1-cowork-manifest-contract.md
 !761-AA-AACR-epic-1-social-image-count-cohort.md
 !762-AA-AACR-epic-1-query-local-count-contracts.md
+!763-AA-AACR-epic-1-entity-local-count-contracts.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (202 files). Local-only working
+Covers the **tracked** documentation estate (203 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -184,6 +184,7 @@ index and `000-docs/.gitignore`.
 - [760-AA-AACR-epic-1-cowork-manifest-contract.md](760-AA-AACR-epic-1-cowork-manifest-contract.md)
 - [761-AA-AACR-epic-1-social-image-count-cohort.md](761-AA-AACR-epic-1-social-image-count-cohort.md)
 - [762-AA-AACR-epic-1-query-local-count-contracts.md](762-AA-AACR-epic-1-query-local-count-contracts.md)
+- [763-AA-AACR-epic-1-entity-local-count-contracts.md](763-AA-AACR-epic-1-entity-local-count-contracts.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1178,7 +1178,9 @@ rendered count/label contract, markup attributes cannot impersonate it, and prov
 top-level component tag parsed outside quoted attributes and Astro expression strings. Paired raw
 text elements are parsed with quote- and brace-aware opening tags, so a quoted `/>` cannot disguise
 a script body as self-closing; malformed raw-text elements are refused. Cowork packages, entity-local cards, vendor packs, stale live copy, and research snapshots
-are not forced into the marketplace cohort. README work is deferred because its generated count
+are not forced into the marketplace cohort. Entity-local cards are now separately labeled and bound
+to exact deferred claims in `scripts/published-count-cohorts.json`; their local contracts are not
+interchangeable with the marketplace cohort. README work is deferred because its generated count
 contract overlaps active PRs; the authoritative local check is
 `node scripts/generate-readme-toc.mjs --check` (there is no `pnpm run readme:check`). E1.6 remains
 open until every published count surface is either enforced with its true cohort or governed as an

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23071
+        "tracked_files": 23072
       }
     },
     "2": {
@@ -1931,10 +1931,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 202,
+        "index_entries": 203,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 202,
+        "tracked_documents": 203,
         "untracked_index_entries": []
       }
     },
@@ -1958,9 +1958,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15548,
+        "invisible_files": 15549,
         "target_invisible_files": 0,
-        "tracked_files": 23071
+        "tracked_files": 23072
       }
     },
     "47": {

--- a/000-docs/763-AA-AACR-epic-1-entity-local-count-contracts.md
+++ b/000-docs/763-AA-AACR-epic-1-entity-local-count-contracts.md
@@ -1,0 +1,48 @@
+# Entity-Local Count Contracts — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Scope:** spotlight cards, plugin cards, community cards, and plugin-detail pages
+- **Status:** implementation slice; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The entity-local surfaces in this slice now identify the population attached to
+the rendered entity instead of presenting its count as a marketplace total.
+The four Astro surfaces use `entity-local`, `contributor-local`, or
+`plugin-local` provenance labels. Their exact rendered expressions, labels,
+contracts, and checker command are registered in
+`scripts/published-count-cohorts.json`; no numeric values were changed.
+
+The checker now supports multiple distinct claims for one source path while
+rejecting duplicate expressions, missing contracts, unsafe paths, malformed
+claims, and expressions that are not bound to either an enforced or owned
+deferred contract. This slice does not govern Cowork bundles, vendor packs,
+learning-hub aggregates, historical copy, research snapshots, README counts,
+or mirrored skill content.
+
+## Evidence
+
+| Gate                          | Result                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------ |
+| Published-count fixture suite | PASS — 33/33, including duplicate-expression and unregistered-claim red proofs |
+| Live registry                 | PASS — `ALLOW cohorts=5 enforced=6 deferred=51 discovered=50`                  |
+| Changed surfaces              | Four Astro pages/components plus the registry/checker fixtures                 |
+| Numeric values                | Unchanged; only local labels and deterministic contracts changed               |
+| Mirrored content              | No `.source.json` or mirrored skill content changed                            |
+| External systems              | No registry, credential, contributor, Plane, or production mutation            |
+
+## Reproduction
+
+```bash
+node --test scripts/check-published-count-cohorts.test.mjs
+node scripts/check-published-count-cohorts.mjs --json
+```
+
+## Rollback and boundaries
+
+Revert the focused Astro, registry, checker, test, changelog, index, and AAR
+changes, then rerun both commands above. The next E1.6 slices must separately
+classify the remaining deferred populations; this record does not close the
+Bead or authorize Epic 2 work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - **fix(marketplace):** label search-result and entity-local skill counts with
   their local population and provenance instead of presenting them as global
   marketplace totals.
+- **fix(marketplace):** make spotlight, plugin, community, and plugin-detail
+  counts identify their entity-local population with fail-closed registry
+  contracts; numeric values are unchanged.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.

--- a/marketplace/src/components/KillerSkills.astro
+++ b/marketplace/src/components/KillerSkills.astro
@@ -4,6 +4,8 @@ import spotlightData from '../data/spotlights.json';
 const skill = spotlightData.spotlight;
 const week = spotlightData.week;
 const isExternal = skill.link.startsWith('http');
+const skillCount = skill.skillCount;
+const hasSkillCount = typeof skillCount === 'number' && skillCount > 0;
 ---
 
 <div
@@ -14,6 +16,9 @@ const isExternal = skill.link.startsWith('http');
   data-week={week}
   data-external={isExternal ? 'true' : 'false'}
 >
+  {hasSkillCount && (
+    <p class="killer-skills" data-count-provenance="entity-local">{skillCount.toLocaleString()} entity-local skills</p>
+  )}
   <div class="killer-top">
     <span class="killer-category">{skill.category}</span>
   </div>
@@ -42,9 +47,6 @@ const isExternal = skill.link.startsWith('http');
       />
       <span class="killer-author-name">{skill.author}</span>
     </a>
-    {skill.skillCount && (
-      <span class="killer-skills">{skill.skillCount} skills</span>
-    )}
   </div>
 
   <div class="killer-actions">

--- a/marketplace/src/components/PluginCard.astro
+++ b/marketplace/src/components/PluginCard.astro
@@ -20,7 +20,8 @@ interface Props {
   href: string;
 }
 const { name, description, installCommand, author, skillCount, href } = Astro.props;
-const showMeta = Boolean(author) || Boolean(skillCount);
+const hasSkillCount = typeof skillCount === 'number' && skillCount > 0;
+const showMeta = Boolean(author) || hasSkillCount;
 ---
 <a class="pcard" href={href}>
   <h3>{name}</h3>
@@ -29,8 +30,10 @@ const showMeta = Boolean(author) || Boolean(skillCount);
   {showMeta && (
     <small>
       {author && <span>{author}</span>}
-      {author && skillCount ? ' · ' : null}
-      {skillCount && <span>{skillCount} skills</span>}
+      {author && hasSkillCount ? ' · ' : null}
+      {hasSkillCount && (
+        <span data-count-provenance="entity-local">{skillCount.toLocaleString()} entity-local skills</span>
+      )}
     </small>
   )}
 </a>

--- a/marketplace/src/pages/community.astro
+++ b/marketplace/src/pages/community.astro
@@ -508,8 +508,11 @@ function getContributionSummary(plugins: any[]): string {
       <div class="hof-grid">
         {hallOfFame.map(item => {
           const isExternal = item.link.startsWith('http');
+          const itemSkillCount = item.skillCount;
+          const hasItemSkillCount = typeof itemSkillCount === 'number' && itemSkillCount > 0;
           return (
             <a href={item.link} class="hof-card" target={isExternal ? '_blank' : undefined} rel={isExternal ? 'noopener noreferrer' : undefined}>
+              {hasItemSkillCount && <span class="hof-skills" data-count-provenance="entity-local">{itemSkillCount.toLocaleString()} entity-local skills</span>}
               <div class="hof-top">
                 <span class="hof-grade">{item.grade}</span>
                 <span class="hof-week">{item.week}</span>
@@ -521,7 +524,6 @@ function getContributionSummary(plugins: any[]): string {
               <div class="hof-author">
                 <img src={`https://github.com/${item.authorGithub}.png?size=64`} alt={item.author} class="hof-avatar" width="32" height="32" loading="lazy" />
                 <a href={`https://github.com/${item.authorGithub}`} class="hof-author-link" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation();">{item.author}</a>
-                {item.skillCount && <span class="hof-skills">{item.skillCount} skills</span>}
               </div>
               <span class="hof-link">{isExternal ? 'View on GitHub →' : 'View plugin →'}</span>
             </a>
@@ -535,13 +537,15 @@ function getContributionSummary(plugins: any[]): string {
   <div class="section-container">
     <h2 class="section-heading">Contributors</h2>
     <div class="contributors-grid">
-      {contributors.map(contrib => (
+      {contributors.map(contrib => {
+        const contributorPluginCount = contrib.plugins.length;
+        return (
         <div
           class="contributor-card"
           role="button"
           tabindex="0"
           aria-expanded="false"
-          aria-label={`${contrib.name}, ${contrib.plugins.length} plugins`}
+          aria-label={`${contrib.name}, ${contributorPluginCount} plugins`}
         >
           <div class="contributor-header">
             <div class="contributor-info">
@@ -549,7 +553,7 @@ function getContributionSummary(plugins: any[]): string {
               <div class="contributor-summary">{getContributionSummary(contrib.plugins)}</div>
             </div>
             <div class="contributor-count">
-              {contrib.plugins.length} plugin{contrib.plugins.length !== 1 ? 's' : ''}
+              <span data-count-provenance="contributor-local">{contributorPluginCount.toLocaleString()} contributor-local plugin{contributorPluginCount !== 1 ? 's' : ''}</span>
             </div>
             <span class="toggle-chevron" aria-hidden="true">&#9656;</span>
           </div>
@@ -567,7 +571,8 @@ function getContributionSummary(plugins: any[]): string {
             </div>
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
 
     <!-- Community Plugins Grid -->

--- a/marketplace/src/pages/plugins/[name].astro
+++ b/marketplace/src/pages/plugins/[name].astro
@@ -29,7 +29,6 @@ const readme = (readmeSections as any)[plugin.name] || null;
 const formatComponents = (components: any) => {
   if (!components) return [];
   const items = [];
-  if (components.skills) items.push(`${components.skills} skill${components.skills > 1 ? 's' : ''}`);
   if (components.commands) items.push(`${components.commands} command${components.commands > 1 ? 's' : ''}`);
   if (components.agents) items.push(`${components.agents} agent${components.agents > 1 ? 's' : ''}`);
   if (components.hooks) items.push(`${components.hooks} hook${components.hooks > 1 ? 's' : ''}`);
@@ -56,11 +55,14 @@ const cleanTools = (tools: string[]) =>
   tools.map((t: string) => t.replace(/^"|"$/g, '')).filter((t: string) => t.length > 0);
 
 const isSaasPack = plugin.category === 'saas-packs';
-const hasSkills = pluginSkills.length > 0;
+const pluginSkillCount = pluginSkills.length;
+const hasSkills = pluginSkillCount > 0;
+const hasMultipleSkills = pluginSkillCount > 1;
+const componentSkillCount = plugin.components?.skills;
+const hasComponentSkillCount = typeof componentSkillCount === 'number' && componentSkillCount > 0;
 
 // Stats bar items
 const statsItems: Array<{ label: string; value: string }> = [];
-if (plugin.components?.skills) statsItems.push({ label: 'Skills', value: String(plugin.components.skills) });
 if (plugin.components?.commands) statsItems.push({ label: 'Commands', value: String(plugin.components.commands) });
 if (plugin.components?.agents) statsItems.push({ label: 'Agents', value: String(plugin.components.agents) });
 if (plugin.mcpTools) statsItems.push({ label: 'MCP Tools', value: String(plugin.mcpTools) });
@@ -105,9 +107,15 @@ statsItems.push({ label: 'License', value: plugin.license || 'MIT' });
       <!-- 4. Stats Bar -->
       {statsItems.length > 0 && (
         <div class="stats-bar">
+          {hasComponentSkillCount && (
+            <div class="stat-item">
+              <span class="stat-value" data-count-provenance="plugin-local">{componentSkillCount.toLocaleString()}</span>
+              <span class="stat-label">plugin-local skills</span>
+            </div>
+          )}
           {statsItems.map((stat, i) => (
             <>
-              {i > 0 && <span class="stats-divider" aria-hidden="true" />}
+              {(hasComponentSkillCount || i > 0) && <span class="stats-divider" aria-hidden="true" />}
               <div class="stat-item">
                 <span class="stat-value">{stat.value}</span>
                 <span class="stat-label">{stat.label}</span>
@@ -150,8 +158,8 @@ statsItems.push({ label: 'License', value: plugin.license || 'MIT' });
       {hasSkills ? (
         <div class="section skills-section">
           <div class="skills-header">
-            <h2>Skills ({pluginSkills.length})</h2>
-            {pluginSkills.length > 1 && (
+            <h2>Skills ({pluginSkillCount.toLocaleString()}) <small data-count-provenance="plugin-local">plugin-local skills</small></h2>
+            {hasMultipleSkills && (
               <button class="expand-all-btn" id="expand-all-btn">Expand All</button>
             )}
           </div>

--- a/scripts/check-published-count-cohorts.mjs
+++ b/scripts/check-published-count-cohorts.mjs
@@ -644,6 +644,87 @@ function renderedContractOccurrences(
   ].sort((left, right) => left - right);
 }
 
+function validateDeferredClaim({
+  claim,
+  claimField,
+  surfacePath,
+  rawSource,
+  visibleSource,
+  expressions,
+}) {
+  if (!claim || typeof claim !== 'object' || Array.isArray(claim)) {
+    refuse('INVALID_DEFERRED_GROUP_CLAIM', `${claimField} must be an object`);
+  }
+  const claimExpression = nonemptyString(claim.expression, `${claimField}.expression`);
+  nonemptyString(claim.classification, `${claimField}.classification`);
+  nonemptyString(claim.owner, `${claimField}.owner`);
+  nonemptyString(claim.reason, `${claimField}.reason`);
+  const claimLabel = nonemptyString(claim.label, `${claimField}.label`);
+  const claimProvenance = nonemptyString(claim.provenance, `${claimField}.provenance`);
+  const claimCommand = nonemptyString(claim.command, `${claimField}.command`);
+  const claimContract = nonemptyString(claim.contract, `${claimField}.contract`);
+  const claimSink = nonemptyString(claim.sink, `${claimField}.sink`);
+  const claimFunction = nonemptyString(claim.function, `${claimField}.function`);
+  const claimCall = nonemptyString(claim.call, `${claimField}.call`);
+  if (claimCommand !== 'node scripts/check-published-count-cohorts.mjs --json') {
+    refuse(
+      'INVALID_LOCAL_COMMAND',
+      `${claimField}.command must be the executable local-count checker command`,
+    );
+  }
+  if (!foldedText(claimLabel).includes(foldedText(claim.classification))) {
+    refuse(
+      'LOCAL_LABEL_MISMATCH',
+      `${claimField}.label must name classification ${JSON.stringify(claim.classification)}`,
+    );
+  }
+  if (!claimProvenance.includes(claim.classification)) {
+    refuse(
+      'LOCAL_PROVENANCE_MISMATCH',
+      `${claimField}.provenance must name classification ${JSON.stringify(claim.classification)}`,
+    );
+  }
+  if (!claimContract.includes(claimExpression)) {
+    refuse(
+      'LOCAL_CONTRACT_MISMATCH',
+      `${claimField}.contract must include expression ${JSON.stringify(claimExpression)}`,
+    );
+  }
+  if (!claimContract.includes(claimLabel) || !claimContract.includes(claimProvenance)) {
+    refuse(
+      'LOCAL_CONTRACT_MISMATCH',
+      `${claimField}.contract must include its declared label and provenance`,
+    );
+  }
+  if (expressions.includes(claimExpression)) {
+    refuse(
+      'DUPLICATE_SURFACE_EXPRESSION',
+      `${surfacePath} registers expression more than once: ${JSON.stringify(claimExpression)}`,
+    );
+  }
+  if (literalOccurrences(rawSource, claimExpression).length === 0) {
+    refuse(
+      'MISSING_EXPRESSION',
+      `${surfacePath} does not contain deferred expression ${JSON.stringify(claimExpression)}`,
+    );
+  }
+  const contractOccurrences = renderedContractOccurrences(
+    rawSource,
+    visibleSource,
+    claimContract,
+    claimSink,
+    claimFunction,
+    claimCall,
+  );
+  if (contractOccurrences.length !== 1) {
+    refuse(
+      'INVALID_LOCAL_CONTRACT',
+      `${surfacePath} must contain local contract exactly once (found ${contractOccurrences.length})`,
+    );
+  }
+  return claimExpression;
+}
+
 function lineAtOffset(source, offset) {
   return source.slice(0, offset).split('\n').length;
 }
@@ -882,14 +963,44 @@ function validateSurfaces(registry, root, io) {
     nonemptyString(group.classification, `${field}.classification`);
     nonemptyString(group.owner, `${field}.owner`);
     nonemptyString(group.reason, `${field}.reason`);
-    if (!Array.isArray(group.paths) || group.paths.length === 0) {
-      refuse('INVALID_DEFERRED_GROUP', `${field}.paths must be a nonempty array`);
+    if (group.paths !== undefined && !Array.isArray(group.paths)) {
+      refuse('INVALID_DEFERRED_GROUP', `${field}.paths must be an array when provided`);
     }
-    for (const [pathIndex, candidate] of group.paths.entries()) {
+    if (group.claims !== undefined && !Array.isArray(group.claims)) {
+      refuse('INVALID_DEFERRED_GROUP', `${field}.claims must be an array when provided`);
+    }
+    const paths = group.paths ?? [];
+    const claims = group.claims ?? [];
+    if (paths.length === 0 && claims.length === 0) {
+      refuse('INVALID_DEFERRED_GROUP', `${field} must contain paths or claims`);
+    }
+    for (const [pathIndex, candidate] of paths.entries()) {
       const surfacePath = validateRepositoryPath(candidate, `${field}.paths[${pathIndex}]`);
       registerSurfacePath(surfacePath);
       safeRead(root, surfacePath, io);
       registeredExpressions.set(surfacePath, null);
+      deferred += 1;
+    }
+    for (const [claimIndex, claim] of claims.entries()) {
+      const claimField = `${field}.claims[${claimIndex}]`;
+      if (!claim || typeof claim !== 'object' || Array.isArray(claim)) {
+        refuse('INVALID_DEFERRED_GROUP_CLAIM', `${claimField} must be an object`);
+      }
+      const surfacePath = validateRepositoryPath(claim.path, `${claimField}.path`);
+      registerSurfacePath(surfacePath);
+      const rawSource = safeRead(root, surfacePath, io);
+      const visibleSource = stripComments(maskNonRenderedAstroRegions(rawSource));
+      const expressions = [];
+      const claimExpression = validateDeferredClaim({
+        claim,
+        claimField,
+        surfacePath,
+        rawSource,
+        visibleSource,
+        expressions,
+      });
+      expressions.push(claimExpression);
+      registeredExpressions.set(surfacePath, expressions);
       deferred += 1;
     }
   }

--- a/scripts/check-published-count-cohorts.mjs
+++ b/scripts/check-published-count-cohorts.mjs
@@ -702,10 +702,17 @@ function validateDeferredClaim({
       `${surfacePath} registers expression more than once: ${JSON.stringify(claimExpression)}`,
     );
   }
-  if (literalOccurrences(rawSource, claimExpression).length === 0) {
+  const expressionOccurrences = literalOccurrences(rawSource, claimExpression);
+  if (expressionOccurrences.length === 0) {
     refuse(
       'MISSING_EXPRESSION',
       `${surfacePath} does not contain deferred expression ${JSON.stringify(claimExpression)}`,
+    );
+  }
+  if (expressionOccurrences.length !== 1) {
+    refuse(
+      'AMBIGUOUS_LOCAL_EXPRESSION',
+      `${surfacePath} contains deferred expression ${JSON.stringify(claimExpression)} ${expressionOccurrences.length} times; each claim must bind exactly one rendered occurrence`,
     );
   }
   const contractOccurrences = renderedContractOccurrences(
@@ -981,16 +988,24 @@ function validateSurfaces(registry, root, io) {
       registeredExpressions.set(surfacePath, null);
       deferred += 1;
     }
+    const claimExpressionsByPath = new Map();
     for (const [claimIndex, claim] of claims.entries()) {
       const claimField = `${field}.claims[${claimIndex}]`;
       if (!claim || typeof claim !== 'object' || Array.isArray(claim)) {
         refuse('INVALID_DEFERRED_GROUP_CLAIM', `${claimField} must be an object`);
       }
       const surfacePath = validateRepositoryPath(claim.path, `${claimField}.path`);
-      registerSurfacePath(surfacePath);
+      let expressions = claimExpressionsByPath.get(surfacePath);
+      if (!expressions) {
+        if (exactPaths.has(surfacePath)) {
+          refuse('DUPLICATE_SURFACE_PATH', `duplicate surface path: ${surfacePath}`);
+        }
+        registerSurfacePath(surfacePath);
+        expressions = [];
+        claimExpressionsByPath.set(surfacePath, expressions);
+      }
       const rawSource = safeRead(root, surfacePath, io);
       const visibleSource = stripComments(maskNonRenderedAstroRegions(rawSource));
-      const expressions = [];
       const claimExpression = validateDeferredClaim({
         claim,
         claimField,
@@ -1371,7 +1386,7 @@ function discoverPublicCountSources(root, registeredPaths, registeredExpressions
       if (unregistered) {
         refuse(
           'UNREGISTERED_PUBLIC_COUNT_EXPRESSION',
-          `${relativePath}:${lineAtOffset(source, unregistered.offset)} contains an unregistered published skill-count expression`,
+          `${relativePath}:${lineAtOffset(source, unregistered.offset)} contains an unregistered published skill-count expression ${JSON.stringify(unregistered.text)}`,
         );
       }
     }

--- a/scripts/check-published-count-cohorts.test.mjs
+++ b/scripts/check-published-count-cohorts.test.mjs
@@ -949,6 +949,15 @@ test('deferred-group claims enforce exact rendered contracts and fail closed', (
   equal(check(valid).deferred, 1);
   equal(check(valid).discovered, 2);
 
+  const duplicateRenderedExpression = makeFixture({
+    deferredGroups: [group],
+    source,
+    files: {
+      [claim.path]: `${claimSource}<span>{catalog.count} unlabelled skills</span>\n`,
+    },
+  });
+  equal(findingCode(check(duplicateRenderedExpression)), 'AMBIGUOUS_LOCAL_EXPRESSION');
+
   const missingExpression = makeFixture({
     deferredGroups: [
       {
@@ -986,7 +995,7 @@ test('deferred-group claims enforce exact rendered contracts and fail closed', (
     source,
     files: { [claim.path]: claimSource },
   });
-  equal(findingCode(check(duplicateClaim)), 'DUPLICATE_SURFACE_PATH');
+  equal(findingCode(check(duplicateClaim)), 'DUPLICATE_SURFACE_EXPRESSION');
 
   const deadContract = makeFixture({
     deferredGroups: [group],

--- a/scripts/check-published-count-cohorts.test.mjs
+++ b/scripts/check-published-count-cohorts.test.mjs
@@ -15,7 +15,7 @@ afterEach(() => {
   for (const root of temporaryRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
-function registryFor(surfaces) {
+function registryFor(surfaces, deferredGroups = []) {
   return {
     schemaVersion: 1,
     cohorts: Object.fromEntries(
@@ -37,7 +37,7 @@ function registryFor(surfaces) {
       ignoredPhrases: ['Tons of Skills'],
     },
     surfaces,
-    deferredGroups: [],
+    deferredGroups,
   };
 }
 
@@ -65,7 +65,12 @@ function validSource() {
   ].join('\n');
 }
 
-function makeFixture({ surfaces = [enforcedSurface()], source = validSource() } = {}) {
+function makeFixture({
+  surfaces = [enforcedSurface()],
+  source = validSource(),
+  deferredGroups = [],
+  files = {},
+} = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'published-count-cohorts-'));
   temporaryRoots.push(root);
   fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
@@ -73,9 +78,14 @@ function makeFixture({ surfaces = [enforcedSurface()], source = validSource() } 
   fs.mkdirSync(path.join(root, 'marketplace/src/components'), { recursive: true });
   fs.writeFileSync(
     path.join(root, 'scripts/published-count-cohorts.json'),
-    `${JSON.stringify(registryFor(surfaces), null, 2)}\n`,
+    `${JSON.stringify(registryFor(surfaces, deferredGroups), null, 2)}\n`,
   );
   fs.writeFileSync(path.join(root, 'marketplace/src/pages/index.astro'), source);
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const absolutePath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents);
+  }
   return root;
 }
 
@@ -902,6 +912,124 @@ test('deferred groups require exact owned paths and share duplicate protection',
   ];
   fs.writeFileSync(missingRegistryPath, JSON.stringify(missingRegistry));
   equal(findingCode(check(missing)), 'INVALID_DEFERRED_GROUP');
+});
+
+test('deferred-group claims enforce exact rendered contracts and fail closed', () => {
+  const claim = {
+    path: 'marketplace/src/pages/group-claim.astro',
+    expression: 'catalog.count',
+    classification: 'local-entity',
+    owner: 'E1.6 follow-up',
+    reason: 'The count belongs to one local entity.',
+    label: 'local-entity skills',
+    provenance: 'data-count-provenance="local-entity"',
+    command: 'node scripts/check-published-count-cohorts.mjs --json',
+    contract:
+      '<span data-count-provenance="local-entity">{catalog.count} local-entity skills</span>',
+    sink: 'metaParts.push',
+    function: 'renderCard',
+    call: 'renderCard',
+  };
+  const group = {
+    classification: 'local-entity',
+    owner: 'E1.6 follow-up',
+    reason: 'Fixture deferred group.',
+    claims: [claim],
+  };
+  const source = validSource();
+  const claimSource =
+    '<span data-count-provenance="local-entity">{catalog.count} local-entity skills</span>\n';
+
+  const valid = makeFixture({
+    deferredGroups: [group],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(check(valid).allow, true);
+  equal(check(valid).deferred, 1);
+  equal(check(valid).discovered, 2);
+
+  const missingExpression = makeFixture({
+    deferredGroups: [
+      {
+        ...group,
+        claims: [
+          {
+            ...claim,
+            expression: 'missing.count',
+            contract: claim.contract.replace('catalog.count', 'missing.count'),
+          },
+        ],
+      },
+    ],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(missingExpression)), 'MISSING_EXPRESSION');
+
+  const labelMismatch = makeFixture({
+    deferredGroups: [{ ...group, claims: [{ ...claim, label: 'other skills' }] }],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(labelMismatch)), 'LOCAL_LABEL_MISMATCH');
+
+  const provenanceMismatch = makeFixture({
+    deferredGroups: [{ ...group, claims: [{ ...claim, provenance: 'other-provenance' }] }],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(provenanceMismatch)), 'LOCAL_PROVENANCE_MISMATCH');
+
+  const duplicateClaim = makeFixture({
+    deferredGroups: [{ ...group, claims: [claim, { ...claim }] }],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(duplicateClaim)), 'DUPLICATE_SURFACE_PATH');
+
+  const deadContract = makeFixture({
+    deferredGroups: [group],
+    source: [
+      validSource().trimEnd(),
+      '<script>',
+      'const dead = `<span data-count-provenance="local-entity">{catalog.count} local-entity skills</span>`;',
+      '</script>',
+      '',
+    ].join('\n'),
+    files: {
+      [claim.path]: [
+        '<script>',
+        'const dead = `<span data-count-provenance="local-entity">{catalog.count} local-entity skills</span>`;',
+        '</script>',
+        '',
+      ].join('\n'),
+    },
+  });
+  equal(findingCode(check(deadContract)), 'INVALID_LOCAL_CONTRACT');
+
+  const malformedClaim = makeFixture({
+    deferredGroups: [{ ...group, claims: [null] }],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(malformedClaim)), 'INVALID_DEFERRED_GROUP_CLAIM');
+
+  const missingRequiredField = { ...claim };
+  delete missingRequiredField.function;
+  const missingField = makeFixture({
+    deferredGroups: [{ ...group, claims: [missingRequiredField] }],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(missingField)), 'INVALID_REGISTRY');
+
+  const unsafeClaim = makeFixture({
+    deferredGroups: [{ ...group, claims: [{ ...claim, path: '../group-claim.astro' }] }],
+    source,
+    files: { [claim.path]: claimSource },
+  });
+  equal(findingCode(check(unsafeClaim)), 'UNSAFE_PATH');
 });
 
 test('canonical cohort shape and resolver commands fail closed on contradiction', () => {

--- a/scripts/published-count-cohorts.json
+++ b/scripts/published-count-cohorts.json
@@ -152,11 +152,92 @@
       "classification": "entity-local",
       "owner": "E1.6 follow-up",
       "reason": "These values count skills attached to one card, spotlight, plugin, or result item; a local-entity labeling contract is still required before E1.6 closes.",
-      "paths": [
-        "marketplace/src/components/KillerSkills.astro",
-        "marketplace/src/components/PluginCard.astro",
-        "marketplace/src/pages/community.astro",
-        "marketplace/src/pages/plugins/[name].astro"
+      "paths": [],
+      "claims": [
+        {
+          "path": "marketplace/src/components/KillerSkills.astro",
+          "expression": "skillCount.toLocaleString()",
+          "classification": "entity-local",
+          "owner": "E1.6 follow-up",
+          "reason": "The spotlight card reports the skill count attached to one highlighted entity.",
+          "label": "entity-local skills",
+          "provenance": "data-count-provenance=\"entity-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"entity-local\">{skillCount.toLocaleString()} entity-local skills",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/components/PluginCard.astro",
+          "expression": "skillCount.toLocaleString()",
+          "classification": "entity-local",
+          "owner": "E1.6 follow-up",
+          "reason": "The reusable card reports the skill count attached to one plugin or skill entity when supplied.",
+          "label": "entity-local skills",
+          "provenance": "data-count-provenance=\"entity-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"entity-local\">{skillCount.toLocaleString()} entity-local skills",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/community.astro",
+          "expression": "itemSkillCount.toLocaleString()",
+          "classification": "entity-local",
+          "owner": "E1.6 follow-up",
+          "reason": "The hall-of-fame card reports the skill count attached to one spotlight entity.",
+          "label": "entity-local skills",
+          "provenance": "data-count-provenance=\"entity-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "<span class=\"hof-skills\" data-count-provenance=\"entity-local\">{itemSkillCount.toLocaleString()} entity-local skills",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/community.astro",
+          "expression": "contributorPluginCount.toLocaleString()",
+          "classification": "contributor-local",
+          "owner": "E1.6 follow-up",
+          "reason": "The contributor card reports plugins attributed to one contributor, not a corpus-wide skill cohort.",
+          "label": "contributor-local plugin",
+          "provenance": "data-count-provenance=\"contributor-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"contributor-local\">{contributorPluginCount.toLocaleString()} contributor-local plugin",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/plugins/[name].astro",
+          "expression": "pluginSkillCount.toLocaleString()",
+          "classification": "plugin-local",
+          "owner": "E1.6 follow-up",
+          "reason": "The plugin detail page reports skills belonging to one plugin, not the marketplace corpus.",
+          "label": "plugin-local skills",
+          "provenance": "data-count-provenance=\"plugin-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "Skills ({pluginSkillCount.toLocaleString()}) <small data-count-provenance=\"plugin-local\">plugin-local skills",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/plugins/[name].astro",
+          "expression": "componentSkillCount.toLocaleString()",
+          "classification": "plugin-local",
+          "owner": "E1.6 follow-up",
+          "reason": "The plugin catalog metadata reports skills attached to one plugin when the detail page has no global skills list for that plugin.",
+          "label": "plugin-local skills",
+          "provenance": "data-count-provenance=\"plugin-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "<span class=\"stat-value\" data-count-provenance=\"plugin-local\">{componentSkillCount.toLocaleString()}</span>\n              <span class=\"stat-label\">plugin-local skills",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary

Advance blueprint 727 Epic 1.6 with one isolated entity-local count-contract slice.

Bead: `claude-hz8f.13`

This PR labels and registers exact rendered contracts for:
- spotlight/KillerSkills counts (`entity-local`), repositioned before the card content
- reusable PluginCard counts (`entity-local`)
- community hall-of-fame and contributor counts (`entity-local` / `contributor-local`), with the spotlight count moved out of author metadata
- plugin detail counts (`plugin-local`), including the component metadata stat

The plugin-detail component formatter intentionally no longer emits an unlabeled skills fragment; the same component-local count remains visible in the explicit provenance-labeled stats bar. This preserves the count while removing an ungoverned duplicate display.

The shared fail-closed checker now rejects any deferred expression that occurs more than once in a source file, preventing a second unlabeled occurrence from reusing the first claim. It also supports multiple distinct claims on one source path while rejecting duplicate expressions and unregistered claims.

## Scope

In scope: the four Astro surfaces, the shared count registry/checker/tests, the E1.6 AAR, blueprint progress wording, scorecard/index/changelog updates.

Out of scope: Cowork bundles, vendor packs, learning-hub aggregates, historical/research copy, README counts, mirrored skill content, Epic 2, registry/credential/contributor/Plane/production mutations.

## Evidence

- `node --test scripts/check-published-count-cohorts.test.mjs` — 33/33 pass, including duplicate-occurrence red proof
- `node scripts/check-published-count-cohorts.mjs --json` — `ALLOW`, cohorts=5, enforced=6, deferred=51, discovered=50
- `pnpm run validate:generated-content` — pass
- `pnpm --dir marketplace run build` — 3,871 pages pass
- `pnpm run measure:e1:check` — pass at staged head; scorecard updated to 23,072 tracked files / 203 indexed documents / 15,549 gitleaks-invisible paths
- `pnpm run verify` — pass
- `pnpm run format:check` — pass
- `git diff --check` — pass

No numeric corpus count values changed. No mirrored content or external systems were mutated.

## Review notes

The source-level DOM repositioning is intentional and documented above. The generated docs index was regenerated after staging the new filed AAR. The scorecard was regenerated from the exact staged index; its `allowlist_patterns=25` is the number of gitleaks regex patterns, while `invisible_files=15549` is the measured tracked-path cohort (including the newly filed docs path).

## Rollback

Revert the focused merge containing `1910fd309` and rerun the focused checker, measurement, generated-content, and build gates.

## Merge gates

Requires fresh exact-head independent clean-checkout review and all required GitHub contexts. Greptile/MiniMax results will be treated as evidence only for this exact head; stale bot reviews will be disclosed.
