### PR TITLE
fix(marketplace-site): govern learning hub count contracts

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -60,3 +60,4 @@
 !763-AA-AACR-epic-1-entity-local-count-contracts.md
 !764-AA-AACR-epic-1-cowork-count-contracts.md
 !765-AA-AACR-epic-1-vendor-pack-count-contracts.md
+!766-AA-AACR-epic-1-learning-hub-count-contracts.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (205 files). Local-only working
+Covers the **tracked** documentation estate (206 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -187,6 +187,7 @@ index and `000-docs/.gitignore`.
 - [763-AA-AACR-epic-1-entity-local-count-contracts.md](763-AA-AACR-epic-1-entity-local-count-contracts.md)
 - [764-AA-AACR-epic-1-cowork-count-contracts.md](764-AA-AACR-epic-1-cowork-count-contracts.md)
 - [765-AA-AACR-epic-1-vendor-pack-count-contracts.md](765-AA-AACR-epic-1-vendor-pack-count-contracts.md)
+- [766-AA-AACR-epic-1-learning-hub-count-contracts.md](766-AA-AACR-epic-1-learning-hub-count-contracts.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1195,6 +1195,12 @@ The registry carries 60 exact claims (two per page), and the live checker report
 learning-hub aggregate, stale live copy, research snapshots, README, and mirrored content remain
 separate deferred populations.
 
+**E1.6 learning-hub continuation (2026-08-18).** The learning-hub landing page now separates
+two aggregate vendor-pack totals from two per-pack card/tier counts. Four exact claims are
+registered, and the checker reports `ALLOW cohorts=5 enforced=6 deferred=91 discovered=20`.
+The values remain unchanged; research, stale/live-copy, README, and mirrored populations remain
+deferred.
+
 **Dependencies / entry criteria.** None for the measurement harness, the catalog work, and the asset sniff. The dead-domain sweep **must wait for Epic 2's freeze** — the frozen set is an input, not an afterthought.
 
 **Proposed beads (15).**

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23074
+        "tracked_files": 23075
       }
     },
     "2": {
@@ -1931,10 +1931,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 205,
+        "index_entries": 206,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 205,
+        "tracked_documents": 206,
         "untracked_index_entries": []
       }
     },
@@ -1958,9 +1958,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15551,
+        "invisible_files": 15552,
         "target_invisible_files": 0,
-        "tracked_files": 23074
+        "tracked_files": 23075
       }
     },
     "47": {

--- a/000-docs/766-AA-AACR-epic-1-learning-hub-count-contracts.md
+++ b/000-docs/766-AA-AACR-epic-1-learning-hub-count-contracts.md
@@ -1,0 +1,40 @@
+# Learning-Hub Count Contracts — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Scope:** `marketplace/src/pages/learn/index.astro`
+- **Status:** implementation slice; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The learning hub now distinguishes its aggregate vendor-pack totals from the
+per-pack counts shown in its tier and vendor cards. Four exact claims are
+registered on the page: two `learning-hub-aggregate` claims and two
+`vendor-pack-local` claims. Unscoped metadata and range wording were removed;
+numeric source values were not changed.
+
+## Evidence
+
+| Gate                          | Result                                                              |
+| ----------------------------- | ------------------------------------------------------------------- |
+| Published-count fixture suite | PASS — 35/35, including hub claim coverage                          |
+| Live registry                 | PASS — `ALLOW cohorts=5 enforced=6 deferred=91 discovered=20`       |
+| Claims                        | Four exact claims on the learning hub                               |
+| Numeric values                | Unchanged; only population labels and copy wording changed          |
+| Mirrored content              | No `.source.json` or mirrored skill content changed                 |
+| External systems              | No registry, credential, contributor, Plane, or production mutation |
+
+## Reproduction
+
+```bash
+node --test scripts/check-published-count-cohorts.test.mjs
+node scripts/check-published-count-cohorts.mjs --json
+```
+
+## Rollback and boundaries
+
+Revert the focused learning-hub, registry, test, changelog, index, scorecard,
+and AAR changes, then rerun the commands above. Research, stale/live-copy,
+README, mirrored-content, and external work remain separate E1.6 scope; this
+record does not close the Bead or authorize Epic 2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - **fix(learning):** label vendor pack and category counts as
   `vendor-pack-local`, remove unscoped metadata totals, and register all 60
   rendered claims with the fail-closed count contract.
+- **fix(learning):** separate learning-hub aggregate totals from per-pack
+  counts with four exact population-labeled contracts.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.

--- a/marketplace/src/pages/learn/index.astro
+++ b/marketplace/src/pages/learn/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import vendorPacks from '../../data/vendor-packs.json';
 
 const pageTitle = 'SaaS Skill Packs - Learn Hub';
-const pageDescription = 'Deep integration packs for your favorite SaaS platforms. Each pack contains 12-30 skills for complete coverage.';
+const pageDescription = 'Deep integration packs for your favorite SaaS platforms, with focused coverage for complete workflows.';
 
 const tierOrder = ['flagship+', 'flagship', 'pro', 'standard'];
 const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
@@ -166,17 +166,17 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
   <section class="learn-hero">
     <h1 class="learn-title">SaaS Skill Packs</h1>
     <p class="learn-subtitle">
-      Deep integration packs for your favorite platforms. Each pack contains 12-30 skills
+      Deep integration packs for your favorite platforms. Each pack contains focused skills
       covering authentication, operations, debugging, and production best practices.
     </p>
     <div class="hero-stats">
       <div class="hero-stat">
-        <span>{vendorPacks.vendors.length}</span>
-        Vendor Packs
+        <span data-count-provenance="learning-hub-aggregate">{vendorPacks.vendors.length}</span>
+        learning-hub-aggregate vendor packs
       </div>
       <div class="hero-stat">
-        <span>{vendorPacks.vendors.reduce((acc, v) => acc + v.skillCount, 0)}</span>
-        Total Skills
+        <span data-count-provenance="learning-hub-aggregate">{vendorPacks.vendors.reduce((acc, v) => acc + v.skillCount, 0)}</span>
+        learning-hub-aggregate skills across packs
       </div>
     </div>
   </section>
@@ -194,7 +194,7 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
               {tierInfo.badge}
             </span>
             <span class="tier-description">
-              {tierInfo.skillCount} skills per pack
+              <span data-count-provenance="vendor-pack-local">{tierInfo.skillCount} vendor-pack-local skills per pack</span>
             </span>
           </div>
 
@@ -206,7 +206,7 @@ const sortedVendors = [...vendorPacks.vendors].sort((a, b) => {
                 </div>
                 <p class="vendor-description">{vendor.description}</p>
                 <div class="vendor-meta">
-                  <span class="skill-count">{vendor.skillCount} skills</span>
+                  <span class="skill-count" data-count-provenance="vendor-pack-local">{vendor.skillCount} vendor-pack-local skills</span>
                   <span class="install-hint">View Pack</span>
                 </div>
               </a>

--- a/scripts/check-published-count-cohorts.test.mjs
+++ b/scripts/check-published-count-cohorts.test.mjs
@@ -1086,3 +1086,22 @@ test('live vendor-pack pages use explicit local claims for pack and category cou
   equal(report.deferred >= 60, true);
   equal(report.findings.length, 0);
 });
+
+test('learning hub separates aggregate and vendor-pack-local claims', () => {
+  const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, 'scripts/published-count-cohorts.json'), 'utf8'),
+  );
+  const group = registry.deferredGroups.find(
+    (candidate) => candidate.classification === 'learning-hub-aggregate',
+  );
+  equal(group.paths.length, 0);
+  equal(group.claims.length, 4);
+  equal(new Set(group.claims.map((claim) => claim.expression)).size, 4);
+  equal(
+    group.claims.filter((claim) => claim.classification === 'learning-hub-aggregate').length,
+    2,
+  );
+  equal(group.claims.filter((claim) => claim.classification === 'vendor-pack-local').length, 2);
+  equal(check(repositoryRoot).allow, true);
+});

--- a/scripts/published-count-cohorts.json
+++ b/scripts/published-count-cohorts.json
@@ -1220,7 +1220,65 @@
       "classification": "learning-hub-aggregate",
       "owner": "E1.6 follow-up",
       "reason": "The learning-hub landing page aggregates skills across vendor packs; it is neither a repository-wide corpus nor a single vendor-pack count, so it requires its own aggregate cohort contract.",
-      "paths": ["marketplace/src/pages/learn/index.astro"]
+      "paths": [],
+      "claims": [
+        {
+          "path": "marketplace/src/pages/learn/index.astro",
+          "expression": "vendorPacks.vendors.length",
+          "classification": "learning-hub-aggregate",
+          "owner": "E1.6 follow-up",
+          "reason": "The learning hub reports the number of vendor packs represented in its aggregate landing page.",
+          "label": "learning-hub-aggregate vendor packs",
+          "provenance": "data-count-provenance=\"learning-hub-aggregate\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"learning-hub-aggregate\">{vendorPacks.vendors.length}</span>\n        learning-hub-aggregate vendor packs",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/learn/index.astro",
+          "expression": "vendorPacks.vendors.reduce((acc, v) => acc + v.skillCount, 0)",
+          "classification": "learning-hub-aggregate",
+          "owner": "E1.6 follow-up",
+          "reason": "The learning hub reports the aggregate skills represented across all vendor packs.",
+          "label": "learning-hub-aggregate skills across packs",
+          "provenance": "data-count-provenance=\"learning-hub-aggregate\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"learning-hub-aggregate\">{vendorPacks.vendors.reduce((acc, v) => acc + v.skillCount, 0)}</span>\n        learning-hub-aggregate skills across packs",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/learn/index.astro",
+          "expression": "tierInfo.skillCount",
+          "classification": "vendor-pack-local",
+          "owner": "E1.6 follow-up",
+          "reason": "Each tier summary reports the skills per vendor-specific pack.",
+          "label": "vendor-pack-local skills per pack",
+          "provenance": "data-count-provenance=\"vendor-pack-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"vendor-pack-local\">{tierInfo.skillCount} vendor-pack-local skills per pack",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        },
+        {
+          "path": "marketplace/src/pages/learn/index.astro",
+          "expression": "vendor.skillCount",
+          "classification": "vendor-pack-local",
+          "owner": "E1.6 follow-up",
+          "reason": "Each vendor card reports the skills in one vendor-specific learning pack.",
+          "label": "vendor-pack-local skills",
+          "provenance": "data-count-provenance=\"vendor-pack-local\"",
+          "command": "node scripts/check-published-count-cohorts.mjs --json",
+          "contract": "data-count-provenance=\"vendor-pack-local\">{vendor.skillCount} vendor-pack-local skills",
+          "sink": "rendered",
+          "function": "Astro",
+          "call": "Astro"
+        }
+      ]
     },
     {
       "classification": "live-copy-or-quality-rule",


### PR DESCRIPTION
## Summary
- distinguish aggregate learning-hub totals from per-vendor-pack counts
- label four count surfaces with exact aggregate/local provenance
- remove unscoped metadata and range wording
- add live regression coverage plus AAR 766, blueprint/changelog/index/scorecard updates

Bead: `claude-hz8f.13`
Blueprint: 727 §13, E1.6

## Evidence
- `node --test scripts/check-published-count-cohorts.test.mjs` — 35/35 pass
- `node scripts/check-published-count-cohorts.mjs --json` — `ALLOW cohorts=5 enforced=6 deferred=91 discovered=20`
- `TMPDIR=/dev/shm node scripts/measure-epic-1.mjs --check` — `epic-1-measurement: OK`
- `pnpm --dir marketplace run build` — 3,871 pages built
- Prettier, diff checks, and commit harness pass

## Scope and non-scope
One bounded E1.6 continuation. Numeric values are unchanged. No mirrored content, registry, credential, contributor, Plane, branch-protection, release, or production mutation occurred. Research, stale/live-copy, README, and other epics remain out of scope.

## Rollback
Revert this focused commit and rerun the checker, fixture suite, and measurement command.
