### PR TITLE
docs: mark research snapshot evidence boundary

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -61,3 +61,4 @@
 !764-AA-AACR-epic-1-cowork-count-contracts.md
 !765-AA-AACR-epic-1-vendor-pack-count-contracts.md
 !766-AA-AACR-epic-1-learning-hub-count-contracts.md
+!767-AA-AACR-epic-1-research-snapshot-boundary.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (206 files). Local-only working
+Covers the **tracked** documentation estate (207 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -188,6 +188,7 @@ index and `000-docs/.gitignore`.
 - [764-AA-AACR-epic-1-cowork-count-contracts.md](764-AA-AACR-epic-1-cowork-count-contracts.md)
 - [765-AA-AACR-epic-1-vendor-pack-count-contracts.md](765-AA-AACR-epic-1-vendor-pack-count-contracts.md)
 - [766-AA-AACR-epic-1-learning-hub-count-contracts.md](766-AA-AACR-epic-1-learning-hub-count-contracts.md)
+- [767-AA-AACR-epic-1-research-snapshot-boundary.md](767-AA-AACR-epic-1-research-snapshot-boundary.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1201,6 +1201,11 @@ registered, and the checker reports `ALLOW cohorts=5 enforced=6 deferred=91 disc
 The values remain unchanged; research, stale/live-copy, README, and mirrored populations remain
 deferred.
 
+**E1.6 research-snapshot continuation (2026-08-18).** The research landing page and six published
+research analyses now display a shared 2026-03-04 snapshot boundary tied to repository commit
+`256db0b3eabc0669ffe75bc16f19053820c3e91c`. Their historical values remain deferred and are not
+presented as current marketplace totals.
+
 **Dependencies / entry criteria.** None for the measurement harness, the catalog work, and the asset sniff. The dead-domain sweep **must wait for Epic 2's freeze** — the frozen set is an input, not an afterthought.
 
 **Proposed beads (15).**

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23075
+        "tracked_files": 23076
       }
     },
     "2": {
@@ -1931,10 +1931,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 206,
+        "index_entries": 207,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 206,
+        "tracked_documents": 207,
         "untracked_index_entries": []
       }
     },
@@ -1958,9 +1958,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15552,
+        "invisible_files": 15553,
         "target_invisible_files": 0,
-        "tracked_files": 23075
+        "tracked_files": 23076
       }
     },
     "47": {

--- a/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
+++ b/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
@@ -29,8 +29,12 @@ population rather than being relabeled as current marketplace counts.
 
 ```bash
 node scripts/check-published-count-cohorts.mjs --json
+# Observed: ALLOW; cohorts=5, enforced=6, deferred=91, discovered=20.
 pnpm --dir marketplace run build
 ```
+
+The checker output was `ALLOW` with no findings; the four population counts
+above are the result observed on the reviewed source commit.
 
 ## Rollback and boundaries
 

--- a/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
+++ b/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
@@ -14,16 +14,20 @@ snapshot boundary: captured 2026-03-04 from repository commit
 that the figures are historical evidence, not live corpus totals. Existing
 research values remain unchanged and stay in the `research-snapshot` deferred
 population rather than being relabeled as current marketplace counts.
+The index separately labels its original `1,500+` figure as a historical
+analysis claim; it does not present that value as the `1,372`-skill evidence
+corpus documented by the source commit.
 
 ## Evidence
 
-| Gate                    | Result                                                              |
-| ----------------------- | ------------------------------------------------------------------- |
-| Published-count checker | PASS — existing research paths remain explicit deferrals            |
-| Snapshot boundary       | PASS — shared template plus research index                          |
-| Numeric values          | Unchanged; only boundary wording and presentation added             |
-| Mirrored content        | No `.source.json` or mirrored skill content changed                 |
-| External systems        | No registry, credential, contributor, Plane, or production mutation |
+| Gate                    | Result                                                                     |
+| ----------------------- | -------------------------------------------------------------------------- |
+| Published-count checker | PASS — existing research paths remain explicit deferrals                   |
+| Snapshot boundary       | PASS — shared template plus research index                                 |
+| Numeric values          | Unchanged; only boundary wording and presentation added                    |
+| Corpus distinction      | PASS — original `1,500+` claim is not conflated with source `1,372` corpus |
+| Mirrored content        | No `.source.json` or mirrored skill content changed                        |
+| External systems        | No registry, credential, contributor, Plane, or production mutation        |
 
 ## Reproduction
 

--- a/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
+++ b/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
@@ -24,7 +24,8 @@ corpus documented by the source commit.
 | ----------------------- | -------------------------------------------------------------------------- |
 | Published-count checker | PASS — existing research paths remain explicit deferrals                   |
 | Snapshot boundary       | PASS — shared template plus research index                                 |
-| Numeric values          | Unchanged; only boundary wording and presentation added                    |
+| Research numeric values | Unchanged; historical analysis values were not rewritten                   |
+| Estate counters         | PASS — generated index/scorecard counters increased for filed AAR 767      |
 | Corpus distinction      | PASS — original `1,500+` claim is not conflated with source `1,372` corpus |
 | Mirrored content        | No `.source.json` or mirrored skill content changed                        |
 | External systems        | No registry, credential, contributor, Plane, or production mutation        |

--- a/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
+++ b/000-docs/767-AA-AACR-epic-1-research-snapshot-boundary.md
@@ -1,0 +1,40 @@
+# Research Snapshot Boundary — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Scope:** research landing page and six published research documents
+- **Status:** implementation slice; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The research index and all six research document pages now display a common
+snapshot boundary: captured 2026-03-04 from repository commit
+`256db0b3eabc0669ffe75bc16f19053820c3e91c`. The boundary explicitly states
+that the figures are historical evidence, not live corpus totals. Existing
+research values remain unchanged and stay in the `research-snapshot` deferred
+population rather than being relabeled as current marketplace counts.
+
+## Evidence
+
+| Gate                    | Result                                                              |
+| ----------------------- | ------------------------------------------------------------------- |
+| Published-count checker | PASS — existing research paths remain explicit deferrals            |
+| Snapshot boundary       | PASS — shared template plus research index                          |
+| Numeric values          | Unchanged; only boundary wording and presentation added             |
+| Mirrored content        | No `.source.json` or mirrored skill content changed                 |
+| External systems        | No registry, credential, contributor, Plane, or production mutation |
+
+## Reproduction
+
+```bash
+node scripts/check-published-count-cohorts.mjs --json
+pnpm --dir marketplace run build
+```
+
+## Rollback and boundaries
+
+Revert the focused research-template, research-index, changelog, index,
+scorecard, and AAR changes, then rerun the commands above. The two live-copy /
+quality-rule pages, README, mirrored content, and external work remain separate
+E1.6 scope; this record does not close the Bead or authorize Epic 2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   counts with four exact population-labeled contracts.
 - **docs(research):** mark the research index and published analyses as a
   dated historical snapshot with an exact source-commit evidence boundary.
+- **docs(research):** distinguish the original index analysis claim from the
+  source commit's separately documented evidence-corpus size.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   rendered claims with the fail-closed count contract.
 - **fix(learning):** separate learning-hub aggregate totals from per-pack
   counts with four exact population-labeled contracts.
+- **docs(research):** mark the research index and published analyses as a
+  dated historical snapshot with an exact source-commit evidence boundary.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.

--- a/marketplace/src/components/ResearchTemplate.astro
+++ b/marketplace/src/components/ResearchTemplate.astro
@@ -97,6 +97,11 @@ const currentUrl = `https://tonsofskills.com${Astro.url.pathname}`;
 
           <!-- Research Content -->
           <article class="research-content">
+            <p class="snapshot-note">
+              <strong>Research snapshot:</strong> captured 2026-03-04 from repository commit
+              <code>256db0b3eabc0669ffe75bc16f19053820c3e91c</code>. Values are historical evidence,
+              not live corpus totals.
+            </p>
             <slot />
 
             <!-- Cite This Block -->
@@ -278,6 +283,14 @@ const currentUrl = `https://tonsofskills.com${Astro.url.pathname}`;
     /* Research Content */
     .research-content {
       max-width: 800px;
+    }
+
+    .snapshot-note {
+      padding: 0.75rem 1rem;
+      border-left: 3px solid var(--primary);
+      background: var(--panel);
+      color: var(--ink-2);
+      font-size: 0.875rem;
     }
 
     /* Typography within content */

--- a/marketplace/src/pages/research.astro
+++ b/marketplace/src/pages/research.astro
@@ -102,7 +102,7 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
             <div class="stat-divider"></div>
             <div class="stat-item">
               <div class="stat-number">1,500+</div>
-              <div class="stat-label">Skills Analyzed</div>
+              <div class="stat-label">Original Analysis Claim</div>
             </div>
           </div>
         </div>
@@ -110,9 +110,10 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
     </section>
 
     <p class="research-snapshot-note">
-      Research snapshot captured 2026-03-04 from repository commit
-      <code>256db0b3eabc0669ffe75bc16f19053820c3e91c</code>; figures on this index are historical
-      evidence, not live corpus totals.
+      Research page snapshot captured 2026-03-04 from repository commit
+      <code>256db0b3eabc0669ffe75bc16f19053820c3e91c</code>. The original 1,500+ analysis claim is
+      retained as historical evidence; it is not a live total or a claim about that commit's
+      separately documented 1,372-skill evidence corpus.
     </p>
 
     <!-- Domain Cards -->

--- a/marketplace/src/pages/research.astro
+++ b/marketplace/src/pages/research.astro
@@ -109,6 +109,12 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
       </div>
     </section>
 
+    <p class="research-snapshot-note">
+      Research snapshot captured 2026-03-04 from repository commit
+      <code>256db0b3eabc0669ffe75bc16f19053820c3e91c</code>; figures on this index are historical
+      evidence, not live corpus totals.
+    </p>
+
     <!-- Domain Cards -->
     <section class="domains-section">
       <div class="container">
@@ -157,6 +163,16 @@ const readyDocs = domains.reduce((sum, d) => sum + d.docs.filter(doc => doc.read
       min-height: 100vh;
       background: var(--brand-light);
       color: var(--brand-dark);
+    }
+
+    .research-snapshot-note {
+      max-width: 1200px;
+      margin: 1.5rem auto 0;
+      padding: 0.75rem 1rem;
+      border-left: 3px solid var(--brand-green);
+      background: var(--brand-light-gray);
+      color: var(--brand-dark);
+      font-size: 0.875rem;
     }
 
     .container {


### PR DESCRIPTION
## Summary
- add a dated source-commit boundary to the research index and six research analyses
- make clear that research figures are historical evidence, not live corpus totals
- file AAR 767 and update the blueprint, changelog, docs index, and scorecard

Bead: `claude-hz8f.13`
Blueprint: 727 §13, E1.6

## Evidence
- `node scripts/check-published-count-cohorts.mjs --json` — `ALLOW`, no findings
- `TMPDIR=/dev/shm pnpm run measure:e1:check` — 37/37 and `epic-1-measurement: OK`
- `pnpm --dir marketplace run build` — 3,871 pages built
- Prettier, diff checks, and commit harness pass

## Scope and non-scope
This is one bounded E1.6 research-snapshot continuation. Historical values are unchanged. No mirrored content, registry, credential, contributor, Plane, branch-protection, release, or production mutation occurred. Live-copy/quality-rule pages, README, and other epics remain out of scope.

## Rollback
Revert this focused commit and rerun the checker, build, and measurement commands.
