### PR TITLE
docs: mark live-copy and quality-rule boundaries

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -62,3 +62,4 @@
 !765-AA-AACR-epic-1-vendor-pack-count-contracts.md
 !766-AA-AACR-epic-1-learning-hub-count-contracts.md
 !767-AA-AACR-epic-1-research-snapshot-boundary.md
+!768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (207 files). Local-only working
+Covers the **tracked** documentation estate (208 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -189,6 +189,7 @@ index and `000-docs/.gitignore`.
 - [765-AA-AACR-epic-1-vendor-pack-count-contracts.md](765-AA-AACR-epic-1-vendor-pack-count-contracts.md)
 - [766-AA-AACR-epic-1-learning-hub-count-contracts.md](766-AA-AACR-epic-1-learning-hub-count-contracts.md)
 - [767-AA-AACR-epic-1-research-snapshot-boundary.md](767-AA-AACR-epic-1-research-snapshot-boundary.md)
+- [768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md](768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1206,6 +1206,12 @@ research analyses now display a shared 2026-03-04 snapshot boundary tied to repo
 `256db0b3eabc0669ffe75bc16f19053820c3e91c`. Their historical values remain deferred and are not
 presented as current marketplace totals.
 
+**E1.6 live-copy/quality-rule continuation (2026-08-18).** The documentation CTA now identifies
+its retained 418-plugin and 2,834-skill wording as `historical-copy` and explicitly says it is not
+a live total. The grading page now identifies its numeric bands as `quality-rule` policy rather
+than a corpus count. Both paths remain path-level deferred in the checker because neither is a
+current canonical cohort.
+
 **Dependencies / entry criteria.** None for the measurement harness, the catalog work, and the asset sniff. The dead-domain sweep **must wait for Epic 2's freeze** — the frozen set is an input, not an afterthought.
 
 **Proposed beads (15).**

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23076
+        "tracked_files": 23077
       }
     },
     "2": {
@@ -1931,10 +1931,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 207,
+        "index_entries": 208,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 207,
+        "tracked_documents": 208,
         "untracked_index_entries": []
       }
     },
@@ -1958,9 +1958,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15553,
+        "invisible_files": 15554,
         "target_invisible_files": 0,
-        "tracked_files": 23076
+        "tracked_files": 23077
       }
     },
     "47": {

--- a/000-docs/768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md
+++ b/000-docs/768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md
@@ -1,0 +1,49 @@
+# Live Copy and Quality-Rule Boundary — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Scope:** `marketplace/src/pages/docs/index.astro` and `marketplace/src/pages/grading.astro`
+- **Status:** implementation slice; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The documentation CTA retains its existing `418 plugins` and `2,834 skills`
+wording, but now marks both values as `historical-copy` and explicitly says
+they are not live totals. The grading page marks its numeric bands and
+thresholds as `quality-rule` policy, not a marketplace corpus count. No
+numeric values were changed.
+
+The registry keeps both paths in the `live-copy-or-quality-rule` path-level
+deferred population. This is deliberate: the docs values need a separate
+source/copy disposition, while grading thresholds are policy facts rather than
+canonical corpus measurements. The checker therefore does not substitute
+either surface into the five canonical cohorts.
+
+## Evidence
+
+| Gate                    | Result                                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| Published-count checker | PASS — `ALLOW`; canonical cohorts remain unchanged and both paths remain explicitly deferred             |
+| Docs CTA                | PASS — both retained values carry `data-count-provenance="historical-copy"` and a not-live-total warning |
+| Grading page            | PASS — policy values carry `data-count-provenance="quality-rule"`                                        |
+| Numeric values          | PASS — `418`, `2,834`, and grading thresholds unchanged                                                  |
+| Mirrored content        | No `.source.json` or mirrored skill content changed                                                      |
+| External systems        | No registry, credential, contributor, Plane, or production mutation                                      |
+
+## Reproduction
+
+```bash
+node scripts/check-published-count-cohorts.mjs --json
+pnpm --dir marketplace run build
+```
+
+The checker result before filing this record was `ALLOW` with
+`cohorts=5`, `enforced=6`, `deferred=91`, `discovered=20`, and no findings.
+
+## Rollback and boundaries
+
+Revert the focused page, registry, blueprint, changelog, index, and AAR
+changes, then rerun the commands above. Replacing the legacy docs numbers with
+current canonical totals, changing grading policy, editing README, touching
+mirrored content, or starting another epic remains out of scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   dated historical snapshot with an exact source-commit evidence boundary.
 - **docs(research):** distinguish the original index analysis claim from the
   source commit's separately documented evidence-corpus size.
+- **docs(counts):** mark the documentation CTA's retained totals as historical
+  copy and distinguish grading thresholds from corpus counts.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.

--- a/marketplace/src/pages/docs/index.astro
+++ b/marketplace/src/pages/docs/index.astro
@@ -85,7 +85,10 @@ const jsonLd = {
     <!-- Explore CTA -->
     <section class="hub-footer-cta">
       <div class="hub-container">
-        <p>Ready to explore? <a href="/explore">Browse 418 plugins</a> or <a href="/skills">search 2,834 skills</a>.</p>
+        <p class="hub-count-note">
+          <span data-count-provenance="historical-copy"><a href="/explore">Browse 418 plugins</a> — historical-copy plugins; legacy wording, not a live total.</span>
+          <span data-count-provenance="historical-copy"><a href="/skills">Search 2,834 skills</a> — historical-copy skills; legacy wording, not a live total.</span>
+        </p>
       </div>
     </section>
   </div>
@@ -246,6 +249,10 @@ const jsonLd = {
     .hub-footer-cta p {
       font-size: 1rem;
       color: var(--text-2);
+    }
+
+    .hub-count-note span {
+      display: block;
     }
 
     .hub-footer-cta a {

--- a/marketplace/src/pages/grading.astro
+++ b/marketplace/src/pages/grading.astro
@@ -243,6 +243,10 @@ const GRADE_BANDS = [
           informational-only grace window is in effect during the prescreen rollout; afterwards the
           <code>prescreen-grade</code> check is required at branch-protection.
         </p>
+        <p class="grading__note" data-count-provenance="quality-rule">
+          Quality-rule boundary: the numeric values on this page are grading thresholds and policy bands, not
+          marketplace-visible skill totals.
+        </p>
       </section>
 
       <section class="grading__section">

--- a/scripts/published-count-cohorts.json
+++ b/scripts/published-count-cohorts.json
@@ -1283,7 +1283,7 @@
     {
       "classification": "live-copy-or-quality-rule",
       "owner": "E1.6 follow-up",
-      "reason": "These active pages contain a stale global literal or a skill-quality threshold that the conservative discovery pass cannot safely classify as a canonical corpus cohort without a focused copy decision.",
+      "reason": "These active pages now identify their distinct surfaces: the docs CTA marks legacy historical-copy wording and the grading page marks quality-rule thresholds. Both remain path-level deferred because neither is a current canonical corpus cohort.",
       "paths": ["marketplace/src/pages/docs/index.astro", "marketplace/src/pages/grading.astro"]
     },
     {


### PR DESCRIPTION
## Scope

- Bead: `claude-hz8f.13`
- Blueprint: 727 §13, Epic 1 / E1.6
- Marks the docs CTA's retained totals as `historical-copy` and explicitly not live totals.
- Marks grading numeric bands as `quality-rule` policy, not marketplace corpus counts.
- Updates the deferred-population registry, scorecard, blueprint progress note, index, changelog, and AAR.

## Before / after evidence

- Published-count checker: `ALLOW`; `cohorts=5`, `enforced=6`, `deferred=91`, `discovered=20`, no findings.
- Epic 1 measurement check: `OK`.
- Docs values `418` and `2,834` are unchanged; only their interpretation is made explicit.
- Grading thresholds are unchanged.
- The two surfaces remain path-level deferred; an attempted claims conversion exposed a non-rendered section icon false positive, so this slice does not promote that expression into a public count claim.

## Validation

- `node --test scripts/check-published-count-cohorts.test.mjs` (35 passed)
- `TMPDIR=/dev/shm pnpm run measure:e1:check` (37 passed; scorecard OK)
- `pnpm --dir marketplace run build` (3,871 pages built)
- `node scripts/generate-docs-index.mjs --check`
- Prettier check and staged diff check passed.

## Non-scope

No numeric baseline changes, README work, mirrored content, registry/credential/contributor/Plane/production mutations, or other epic work.

## Security / licensing

No secrets, registry calls, package publication, or mirrored skill-content edits. No licensing surface changed.

## Rollback

Revert commit `f4212539d` and rerun the checker, measurement check, docs-index check, and marketplace build.
