### PR TITLE
docs: record E1.6 count-cohort closure

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -63,3 +63,4 @@
 !766-AA-AACR-epic-1-learning-hub-count-contracts.md
 !767-AA-AACR-epic-1-research-snapshot-boundary.md
 !768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md
+!769-AA-AACR-epic-1-count-cohort-closure.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (208 files). Local-only working
+Covers the **tracked** documentation estate (209 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -190,6 +190,7 @@ index and `000-docs/.gitignore`.
 - [766-AA-AACR-epic-1-learning-hub-count-contracts.md](766-AA-AACR-epic-1-learning-hub-count-contracts.md)
 - [767-AA-AACR-epic-1-research-snapshot-boundary.md](767-AA-AACR-epic-1-research-snapshot-boundary.md)
 - [768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md](768-AA-AACR-epic-1-live-copy-quality-rule-boundary.md)
+- [769-AA-AACR-epic-1-count-cohort-closure.md](769-AA-AACR-epic-1-count-cohort-closure.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1212,6 +1212,11 @@ a live total. The grading page now identifies its numeric bands as `quality-rule
 than a corpus count. Both paths remain path-level deferred in the checker because neither is a
 current canonical cohort.
 
+**E1.6 closure candidate (2026-08-18).** The completed count-contract slices now classify every
+discovered numeric surface as one of the five canonical cohorts or an explicit local/historical
+deferred class. Closure evidence is filed in AAR 769; Beads/Dolt remains the authority for the
+final bead state.
+
 **Dependencies / entry criteria.** None for the measurement harness, the catalog work, and the asset sniff. The dead-domain sweep **must wait for Epic 2's freeze** — the frozen set is an input, not an afterthought.
 
 **Proposed beads (15).**

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3179,
-        "tracked_files": 23077
+        "tracked_files": 23078
       }
     },
     "2": {
@@ -1931,10 +1931,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 208,
+        "index_entries": 209,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 208,
+        "tracked_documents": 209,
         "untracked_index_entries": []
       }
     },
@@ -1958,9 +1958,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15554,
+        "invisible_files": 15555,
         "target_invisible_files": 0,
-        "tracked_files": 23077
+        "tracked_files": 23078
       }
     },
     "47": {

--- a/000-docs/769-AA-AACR-epic-1-count-cohort-closure.md
+++ b/000-docs/769-AA-AACR-epic-1-count-cohort-closure.md
@@ -1,0 +1,52 @@
+# Epic 1 Count-Cohort Closure — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727 §13, Epic 1 bead 1.6
+- **Bead:** `claude-hz8f.13`
+- **Status:** closure candidate; actual merge and Beads/Dolt closure evidence are recorded after review
+
+## Outcome
+
+E1.6 now governs every discovered public numeric skill-count surface through
+`scripts/published-count-cohorts.json` and the fail-closed checker. The five
+canonical cohorts remain distinct: `marketplace-visible`, `graded`,
+`first-party`, `curated-mirror`, and `curriculum`. Local or historical values
+are explicitly classified rather than promoted into those corpus totals.
+
+The completed slices covered query-local and entity-local values, Cowork
+package-local values, vendor-pack and learning-hub values, the dated research
+snapshot, and the docs historical-copy/quality-rule pages. The retained
+numeric values were not rewritten to manufacture current-looking totals.
+
+## Final inventory and evidence
+
+| Gate                 | Result                                                                                                                                          |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Registry checker     | `ALLOW`; 5 cohorts, 6 enforced surfaces, 91 deferred claims, 20 discovered sources, no findings                                                 |
+| Canonical resolver   | Five named cohorts resolve from `scripts/corpus-resolver.mjs`                                                                                   |
+| Deferred populations | Six explicit classes: packaged/bundle-local, entity-local, vendor-pack-local, learning-hub-aggregate, live-copy/quality-rule, research-snapshot |
+| Fixture coverage     | Published-count suite 35/35; Epic 1 measurement suite 37/37                                                                                     |
+| Scorecard            | `TMPDIR=/dev/shm pnpm run measure:e1:check` → `epic-1-measurement: OK`                                                                          |
+| Rendered site        | `pnpm --dir marketplace run build` → 3,871 pages built                                                                                          |
+| Generated docs       | `node scripts/generate-docs-index.mjs --check` passed                                                                                           |
+| Numeric values       | No cohort baseline was changed by the count-contract slices                                                                                     |
+| Mirrored content     | No `.source.json` ancestor or mirrored skill content changed                                                                                    |
+| External systems     | No registry, credential, contributor, Plane, branch-rule, or production mutation                                                                |
+
+## Merge record
+
+The final implementation slice, PR #1251, merged as squash commit
+`7f8831daf9af58307bfb69f3f1174c18ecb14770` from independently reviewed head
+`f4212539d4e2d8744ef0722950b3fe8381d20c54`. The independent clean-checkout
+review returned PASS. Required checks and the link-check and Playwright gates
+passed. GitHub still reported `REVIEW_REQUIRED`; an administrator bypass was
+used and disclosed, with no self-approval.
+
+## Closure boundary and rollback
+
+This record closes the count-cohort classification work only. It does not
+close the Epic 1 parent or activate Epic 2/3. README landing-contract work,
+future canonical-cohort changes, and unrelated external or mirrored-content
+work remain governed by their own beads. Roll back by reverting the focused
+count-contract merges and rerunning the checker, measurement check, docs-index
+check, and marketplace build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   source commit's separately documented evidence-corpus size.
 - **docs(counts):** mark the documentation CTA's retained totals as historical
   copy and distinguish grading thresholds from corpus counts.
+- **docs(counts):** record the completed E1.6 count-cohort inventory and
+  closure evidence.
 - **fix(marketplace):** label generated social-card counts with the
   `marketplace-visible` cohort, canonical source, and reproducible resolver
   command; reject unreadable or malformed count inputs.


### PR DESCRIPTION
## Scope

- Bead: `claude-hz8f.13`
- Blueprint: 727 §13, Epic 1 bead 1.6
- Adds the final E1.6 count-cohort closure AAR and progress/changelog evidence.
- Records the complete canonical/deferred inventory and post-merge proof.

## Evidence

- `node --test scripts/check-published-count-cohorts.test.mjs` — 35/35 passed.
- `node scripts/check-published-count-cohorts.mjs --json` — `ALLOW`, 5 cohorts, 6 enforced, 91 deferred, 20 discovered, no findings.
- `TMPDIR=/dev/shm pnpm run measure:e1:check` — 37/37 passed; `epic-1-measurement: OK`.
- `node scripts/generate-docs-index.mjs --check` — passed.
- Prettier and `git diff --cached --check` — passed.

## Non-scope

No source-code behavior, numeric baseline, README, mirrored content, registry, credentials, contributors, Plane, branch rules, production, or other epic changes.

## Review and rollback

This is a documentation-only closure record. Review must confirm the registry inventory, exact merge evidence, no fabricated counts, and no unauthorized scope. Roll back by reverting this focused documentation commit and rerunning the listed checks.
