### PR TITLE
feat(governance): move the local MCP credential into SOPS and gate plaintext recurrence

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Assert sources.yaml and sources.lock.json key parity
         run: pnpm run validate:sources-lock-parity
 
+      # Credential pre-flight (blueprint 727 E1.14 / § 18.7): the root
+      # .mcp.json must never hold a live-shaped credential in plaintext env —
+      # values are SOPS-encrypted in the untracked machine-local .env.sops and
+      # injected at MCP launch by scripts/sops-env. CI checkouts have no root
+      # .mcp.json (untracked), so this passes trivially here; the same command
+      # is the local pre-flight, and the unit tests pin the classifier.
+      - name: Refuse plaintext credentials in the root MCP config
+        run: pnpm run validate:mcp-plaintext-creds
+
       # Supply-chain intake gate: sources.yaml include-anchoring ratchet.
       # An include starting with neither '/' nor '**' is silently auto-prefixed
       # '**/' by the sync engine's matcher and matches at ANY depth — the

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,7 @@ freshie/archives/*.sqlite
 
 # HF dataset build artifact (regenerate via freshie/scripts/build-hf-dataset.py)
 freshie/hf-dataset/skills.jsonl
+
+# SOPS-encrypted machine-local env (E1.14): ciphertext of live credentials
+# stays off the public remote; scripts/sops-env decrypts it in-process.
+.env.sops

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,20 @@
+# SOPS configuration. Encrypted secrets travel with the code.
+#
+# Recipients below can decrypt. To add an engineer:
+#   1. They run: age-keygen -o ~/.config/sops/age/keys.txt
+#   2. They share their public key (line starting "age1...")
+#   3. Add it under `age:` below (one per recipient block)
+#   4. Run: sops updatekeys .env.sops
+#   5. Commit. Old recipients stay valid until their line is removed + updatekeys re-run.
+#
+# CI uses SOPS_AGE_KEY env var (single GitHub Actions secret).
+
+creation_rules:
+  # Plaintext .env -> .env.sops:  sops -e .env > .env.sops
+  - path_regex: \.env$
+    age: >-
+      age1me3vkelljqe2u4zcagja9ru5fdpfpw72xmch39fwle2cr0yfr4cs8vr5d8
+  # secrets.<env>.yaml -> secrets.<env>.sops.yaml
+  - path_regex: secrets\.[a-z]+\.yaml$
+    age: >-
+      age1me3vkelljqe2u4zcagja9ru5fdpfpw72xmch39fwle2cr0yfr4cs8vr5d8

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -67,3 +67,4 @@
 !770-AA-AACR-epic-2-document-class-enforcement.md
 !771-AA-AACR-epic-1-stats-freshness-bound.md
 !772-AA-AACR-epic-1-sources-lock-parity.md
+!773-AA-AACR-epic-1-mcp-credential-sops.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (212 files). Local-only working
+Covers the **tracked** documentation estate (213 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -194,6 +194,7 @@ index and `000-docs/.gitignore`.
 - [770-AA-AACR-epic-2-document-class-enforcement.md](770-AA-AACR-epic-2-document-class-enforcement.md)
 - [771-AA-AACR-epic-1-stats-freshness-bound.md](771-AA-AACR-epic-1-stats-freshness-bound.md)
 - [772-AA-AACR-epic-1-sources-lock-parity.md](772-AA-AACR-epic-1-sources-lock-parity.md)
+- [773-AA-AACR-epic-1-mcp-credential-sops.md](773-AA-AACR-epic-1-mcp-credential-sops.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23096
+        "tracked_files": 23102
       }
     },
     "2": {
@@ -1941,10 +1941,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 212,
+        "index_entries": 213,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 212,
+        "tracked_documents": 213,
         "untracked_index_entries": []
       }
     },
@@ -1968,9 +1968,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15563,
+        "invisible_files": 15565,
         "target_invisible_files": 0,
-        "tracked_files": 23096
+        "tracked_files": 23102
       }
     },
     "47": {

--- a/000-docs/773-AA-AACR-epic-1-mcp-credential-sops.md
+++ b/000-docs/773-AA-AACR-epic-1-mcp-credential-sops.md
@@ -1,0 +1,72 @@
+<!-- doc-class: record -->
+
+# Epic 1 MCP Credential SOPS Migration — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 1 bead 1.14 (§ 18.7)
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-hz8f.16`
+- **Implementation PR:** [#1256](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1256)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E1.14 delegable controls implemented; rotation asked once, answer pending; merge fields are recorded in Beads/Dolt after review
+
+## Owner gate
+
+Blueprint § 18.7 marks this bead owner-gated: the SOPS move and pre-flight are delegable, the
+rotation is not. The owner authorized gated Epic 1–3 execution on 2026-08-18 ("act as owner in
+any gated calls u have permission"), under which the SOPS migration below was performed. Per the
+blueprint's **asked once, never assumed** rule, the rotation question was put to the owner once
+during this slice; no rotation is performed or assumed pending the answer.
+
+## Outcome
+
+The working-tree `/.mcp.json` no longer holds a live-shaped key in plaintext `env`. Before this
+slice it carried the Whop API key in plaintext for two MCP server entries (`whop`, `whop-docs`)
+— git-ignored and never in git history (verified in § 18.7), but unencrypted on a box where
+multiple agent sessions run with filesystem access.
+
+1. **Value moved to SOPS.** The key is age-encrypted in a machine-local `.env.sops`
+   (`sops -e --input-type dotenv`), staged only through `/dev/shm` (never plaintext on the SSD),
+   with a verified decrypt round-trip. Both MCP entries now launch through `scripts/sops-env`,
+   which decrypts to tmpfs, injects the env, and execs the server — the config carries no `env`
+   block at all.
+2. **`.env.sops` is deliberately UNTRACKED.** The estate SOPS standard commits encrypted files
+   to git, but that standard was written for private repos. This repository is public
+   (2,000+ stars); publishing ciphertext of a live credential to the public remote buys nothing
+   and advertises the target. Chose machine-local-untracked (with an explicit `.gitignore` entry
+   and rationale comment) over the committed-ciphertext standard for exactly this repo class.
+   What IS tracked: `.sops.yaml` (age recipient rules), `secrets.example.yaml`,
+   `scripts/sops-env` (the /dev/shm decrypt-exec wrapper), and the pre-flight gate.
+3. **Fail-closed pre-flight.** `scripts/check-mcp-plaintext-creds.mjs` scans the root
+   `.mcp.json`'s `env` values: known live prefixes (`apik_`, `sk-`, `ghp_`/`github_pat_`,
+   `xox*-`, `AKIA`, `glpat-`, `AGE-SECRET-KEY-`) fail, and any 20+ character opaque
+   non-placeholder value fails closed; `${VAR}` interpolations and placeholder shapes pass.
+   Scope is exactly the repo root — plugin directories ship example configs with placeholders by
+   design and are graded by the skill validator instead. Wired as
+   `validate:mcp-plaintext-creds` in the `validate` job (trivially green in CI, where the
+   untracked file never exists; the classifier is pinned by unit tests). Epic 4 bead 4.14 owns
+   the stronger refuse-to-start integration and the CI-enforced rotation record.
+
+## Verification
+
+- `node --test scripts/check-mcp-plaintext-creds.test.mjs` — 5/5 pass (prefix classes,
+  placeholder allowance, opaque-value fail-closed, server/key naming, env-free configs).
+- `node scripts/check-mcp-plaintext-creds.mjs` — OK against the migrated `.mcp.json`; the
+  pre-migration file fails the same check.
+- `scripts/sops-env node -e '…'` — decrypt round-trip OK (value length asserted, never printed).
+- A live server start could not be exercised inside the sandboxed session (network-restricted
+  `npx`); first natural launch is the next Claude Code session, and the wrapper's env injection
+  is proven by the round-trip.
+
+## Scope discipline
+
+No credential value appears in any log, commit, PR body, or this record. No rotation was
+performed. No plugin, catalog, package, or release surface changed. Tracked changes are limited
+to SOPS scaffolding, the pre-flight gate and tests, `package.json`/workflow wiring,
+`.gitignore`, and this AAR's governed projections.
+
+## Follow-up
+
+- **Owner (asked once, pending):** rotate the Whop key in the Whop dashboard; on a yes, the new
+  value is re-encrypted into `.env.sops` in one step.
+- Epic 4 bead 4.14: refuse-to-start pre-flight at MCP launch plus the rotation record.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "validate:changelog-coverage": "node --test scripts/check-changelog-coverage.test.mjs && node scripts/check-changelog-coverage.mjs",
     "validate:stats-freshness": "node --test scripts/check-stats-freshness.test.mjs && node scripts/check-stats-freshness.mjs --report",
     "validate:sources-lock-parity": "node --test scripts/check-sources-lock-parity.test.mjs && node scripts/check-sources-lock-parity.mjs",
+    "validate:mcp-plaintext-creds": "node --test scripts/check-mcp-plaintext-creds.test.mjs && node scripts/check-mcp-plaintext-creds.mjs",
     "verify": "node scripts/run-verification-pipeline.mjs",
     "lint:root": "eslint .",
     "lint:design": "node scripts/lint-design-tells.mjs",

--- a/scripts/check-mcp-plaintext-creds.mjs
+++ b/scripts/check-mcp-plaintext-creds.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * check-mcp-plaintext-creds.mjs — refuse a live-shaped credential in plaintext
+ * `env` in the repo-root MCP config (blueprint 727, Epic 1 bead 1.14).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The working-tree `/.mcp.json` (git-ignored, machine-local) carried a live
+ * Whop API key in plaintext `env` for months — never published, but sitting
+ * unencrypted on a box where multiple agent sessions run with filesystem
+ * access (blueprint § 18.7). The value now lives SOPS-encrypted in
+ * `.env.sops`, injected at server launch by `scripts/sops-env`. This
+ * pre-flight is the delegable recurrence guard: an MCP config whose `env`
+ * holds a live-shaped value fails loudly with the sanctioned fix.
+ *
+ * SCOPE
+ * -----
+ * Exactly the repo-root `.mcp.json`. Plugin directories ship example MCP
+ * configs with placeholder values by design; those are graded by the skill
+ * validator, not by this guard. A missing root config passes (CI checkouts
+ * never contain the untracked file). Epic 4 bead 4.14 owns the stronger
+ * refuse-to-start integration.
+ *
+ * WHAT COUNTS AS LIVE-SHAPED
+ * --------------------------
+ * Known provider prefixes (apik_, sk-, ghp_/gho_/ghs_, github_pat_, xoxb-/
+ * xoxp-, AKIA, glpat-, AGE-SECRET-KEY-) — plus a fallback: any env value 20+
+ * chars that is not a placeholder (${VAR} interpolation, YOUR_ prefixes,
+ * REPLACE, CHANGEME, EXAMPLE, PLACEHOLDER, angle-bracketed hints) is treated
+ * as a secret. Fail closed: when in doubt, it does not belong in plaintext.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+
+const LIVE_PREFIXES =
+  /^(apik_|sk-|ghp_|gho_|ghs_|github_pat_|xox[bpsoar]-|AKIA|glpat-|AGE-SECRET-KEY-)/;
+const PLACEHOLDER =
+  /^(\$\{[^}]*\}|<[^>]*>|(YOUR|MY|EXAMPLE|SAMPLE|TEST|DUMMY|FAKE)[-_].*|REPLACE.*|CHANGE ?ME.*|PLACEHOLDER.*|TODO.*|xxx+|\.\.\.)$/i;
+
+/** Classify one env value. Returns null when safe, else a reason string. */
+export function classifyEnvValue(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (PLACEHOLDER.test(value.trim())) return null;
+  if (LIVE_PREFIXES.test(value.trim())) return 'matches a known live credential prefix';
+  if (value.trim().length >= 20 && !/\s/.test(value.trim()))
+    return 'is a 20+ character opaque value that is not a recognized placeholder';
+  return null;
+}
+
+/** Scan a parsed MCP config object. Returns violation strings. */
+export function scanMcpConfig(config) {
+  const violations = [];
+  const servers = config?.mcpServers ?? {};
+  for (const [name, server] of Object.entries(servers)) {
+    for (const [key, value] of Object.entries(server?.env ?? {})) {
+      const reason = classifyEnvValue(value);
+      if (reason) {
+        violations.push(
+          `server "${name}" env ${key}: ${reason}. Move it to .env.sops and launch via ` +
+            `scripts/sops-env (see blueprint 727 § 18.7 / bead E1.14).`,
+        );
+      }
+    }
+  }
+  return violations;
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  const target = join(REPO_ROOT, '.mcp.json');
+  if (!existsSync(target)) {
+    console.log('mcp-plaintext-creds: OK (no root .mcp.json in this checkout)');
+    process.exit(0);
+  }
+  let config;
+  try {
+    config = JSON.parse(readFileSync(target, 'utf8'));
+  } catch (err) {
+    console.error(`mcp-plaintext-creds: STRUCTURAL — .mcp.json unparseable (${err.message})`);
+    process.exit(1);
+  }
+  const violations = scanMcpConfig(config);
+  for (const v of violations) console.error(`mcp-plaintext-creds: VIOLATION — ${v}`);
+  if (violations.length > 0) {
+    console.error(`mcp-plaintext-creds: FAIL — ${violations.length} plaintext credential(s).`);
+    process.exit(1);
+  }
+  console.log('mcp-plaintext-creds: OK (root .mcp.json holds no live-shaped plaintext env)');
+}

--- a/scripts/check-mcp-plaintext-creds.test.mjs
+++ b/scripts/check-mcp-plaintext-creds.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyEnvValue, scanMcpConfig } from './check-mcp-plaintext-creds.mjs';
+
+test('known live prefixes are violations', () => {
+  for (const v of [
+    'apik_Maaaaaaaaaaaaaaaaaaaaaaaa',
+    'sk-proj-abcdefabcdef',
+    'ghp_16charsofstuffhere',
+    'github_pat_11ABC',
+    'xoxb-1234-5678',
+    'AKIAIOSFODNN7EXAMPLE7',
+    'glpat-xxxxxxxxxxxxxxxxxxxx1',
+  ]) {
+    assert.match(classifyEnvValue(v) ?? '', /prefix/, `${v.slice(0, 6)}… must be flagged`);
+  }
+});
+
+test('placeholders and interpolations pass', () => {
+  for (const v of [
+    '${WHOP_API_KEY}',
+    '<your-api-key-here>',
+    'YOUR_API_KEY_HERE',
+    'REPLACE_WITH_YOUR_KEY',
+    'CHANGEME',
+    'PLACEHOLDER_VALUE_123',
+    '',
+    'short',
+  ]) {
+    assert.equal(classifyEnvValue(v), null, `${v || '(empty)'} must pass`);
+  }
+});
+
+test('long opaque non-placeholder values fail closed', () => {
+  assert.match(classifyEnvValue('a1b2c3d4e5f6g7h8i9j0k1l2') ?? '', /opaque/);
+  // sentences with spaces are configuration, not secrets
+  assert.equal(classifyEnvValue('this is a long description value'), null);
+});
+
+test('scanMcpConfig names the server and key', () => {
+  const violations = scanMcpConfig({
+    mcpServers: {
+      good: { command: 'scripts/sops-env', args: ['npx', 'server'] },
+      bad: { command: 'npx', env: { API_KEY: 'apik_Mliveliveliveliveliveli' } },
+    },
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /server "bad" env API_KEY/);
+  assert.match(violations[0], /sops-env/);
+});
+
+test('empty or env-free configs pass', () => {
+  assert.deepEqual(scanMcpConfig({}), []);
+  assert.deepEqual(scanMcpConfig({ mcpServers: { a: { command: 'x' } } }), []);
+});

--- a/scripts/sops-env
+++ b/scripts/sops-env
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# sops-env — wrapper around SOPS for this repo's .env.sops file.
+# Decrypts to tmpfs, sources into env, executes the command, wipes tmpfs.
+# Plaintext never touches the SSD.
+#
+# Usage:
+#   scripts/sops-env <command>           # run command with secrets in env
+#   scripts/sops-env decrypt             # print decrypted env to stdout
+#   scripts/sops-env edit                # edit encrypted file in place
+#
+# Requires: ~/bin/sops; ~/.config/sops/age/keys.txt or SOPS_AGE_KEY env var.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${SOPS_ENV_FILE:-$REPO_ROOT/.env.sops}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "sops-env: no encrypted env file at $ENV_FILE" >&2
+  exit 2
+fi
+
+if [ -x "$HOME/bin/sops" ]; then
+  SOPS_BIN="$HOME/bin/sops"
+elif command -v sops >/dev/null 2>&1; then
+  SOPS_BIN="sops"
+else
+  echo "sops-env: sops binary not found (tried ~/bin/sops and PATH)" >&2
+  exit 3
+fi
+
+decrypt_to_stdout() {
+  exec "$SOPS_BIN" -d --input-type dotenv --output-type dotenv "$ENV_FILE"
+}
+
+edit_in_place() {
+  exec "$SOPS_BIN" --input-type dotenv --output-type dotenv "$ENV_FILE"
+}
+
+exec_with_env() {
+  if [ -d /dev/shm ] && [ -w /dev/shm ]; then
+    TMPFILE=$(mktemp -p /dev/shm sops-env-XXXXXX)
+  else
+    TMPFILE=$(mktemp sops-env-XXXXXX)
+  fi
+  chmod 600 "$TMPFILE"
+  trap 'shred -u "$TMPFILE" 2>/dev/null || rm -f "$TMPFILE"' EXIT
+
+  "$SOPS_BIN" -d --input-type dotenv --output-type dotenv "$ENV_FILE" > "$TMPFILE"
+
+  set -a
+  # shellcheck disable=SC1090
+  source "$TMPFILE"
+  set +a
+
+  shred -u "$TMPFILE" 2>/dev/null || rm -f "$TMPFILE"
+  trap - EXIT
+
+  if [ "$#" -eq 0 ]; then
+    env
+  elif [ "$#" -eq 1 ]; then
+    bash -c "$1"
+  else
+    "$@"
+  fi
+}
+
+case "${1:-help}" in
+  decrypt|cat|show) decrypt_to_stdout ;;
+  edit)             edit_in_place ;;
+  help|-h|--help)   sed -n 's/^# \?//p' "$0" | head -20 ;;
+  --)               shift; exec_with_env "$@" ;;
+  *)                exec_with_env "$@" ;;
+esac

--- a/secrets.example.yaml
+++ b/secrets.example.yaml
@@ -1,0 +1,20 @@
+# secrets.example.yaml — template for SOPS-encrypted secrets.
+#
+# Two patterns; pick whichever fits the repo:
+#
+# A) Single dotenv at repo root:
+#      cp secrets.example.yaml .env   # then fill values
+#      sops -e .env > .env.sops
+#      rm .env                         # never commit plaintext
+#      scripts/sops-env <command>     # run with secrets in env
+#
+# B) Per-environment YAML:
+#      cp secrets.example.yaml secrets.dev.yaml   # fill values
+#      sops -e secrets.dev.yaml > secrets.dev.sops.yaml
+#      rm secrets.dev.yaml
+#
+# Replace these placeholders with the actual keys this repo needs.
+
+# example_api_key:    "sk-..."
+# example_db_url:     "postgres://user:pass@host:5432/db"
+# log_level:          "INFO"


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 1 bead E1.14** (bead `claude-hz8f.16`, owner-gated per § 18.7; SOPS move authorized by the owner 2026-08-18): the working-tree `.mcp.json` no longer holds a live-shaped key in plaintext `env`. The Whop API key is age-encrypted in a machine-local `.env.sops` and injected at MCP launch by `scripts/sops-env`; a fail-closed pre-flight refuses plaintext credential shapes in the root MCP config.

## Why + decision rationale
A live credential sat unencrypted for months on a box where multiple agent sessions run with filesystem access (never in git — verified in § 18.7). Chose an **untracked** `.env.sops` over the estate's committed-ciphertext SOPS standard because this repo is public: publishing ciphertext of a live key to a 2,000-star remote advertises the target and buys nothing. Rotation is **asked once, never assumed** — the ask is on record with the owner; no rotation performed.

## Layers touched
- `scripts/check-mcp-plaintext-creds.mjs` (+5 tests) — classifier: known live prefixes fail; 20+ char opaque non-placeholder env values fail closed; ${VAR}/placeholders pass. Scope: repo-root `.mcp.json` only (plugin example configs are the skill validator's jurisdiction). Wired as `validate:mcp-plaintext-creds` in the `validate` job (blocks via `ci-required`; trivially green in CI where the untracked file never exists — the unit tests pin the classifier).
- SOPS scaffolding now tracked: `.sops.yaml`, `secrets.example.yaml`, `scripts/sops-env` (tmpfs decrypt-exec wrapper); `.gitignore` entry for `.env.sops` with rationale.
- `000-docs/773` AAR; docs index 213; scorecard 742 regenerated.

## How verified (evidence)
- `node --test scripts/check-mcp-plaintext-creds.test.mjs` 5/5 pass; checker OK on the migrated config and fails on the pre-migration shape (unit-pinned)
- SOPS decrypt round-trip OK (value length asserted, never printed; plaintext staged only via /dev/shm and wiped)
- `check-doc-classes` allow=true; `measure-epic-1 --check` OK; hosted CI on this PR is the final gate

## Risk / rollback
Machine-local config change + additive gate; rollback is a focused revert plus restoring the local env block. The Whop MCP servers' first real launch is the next Claude Code session — if the wrapper misbehaves, the failure is local-only and loud.

## Operational impact
No CI secrets, no deploy-order change. Local requirement: `~/bin/sops` + age key at `~/.config/sops/age/keys.txt` (both already present on this box).

## Follow-up & deferred
- Owner: Whop key rotation (asked once, pending answer)
- Epic 4 bead 4.14: refuse-to-start launch integration + rotation record

Refs: blueprint 000-docs/727 §13 E1.14 + §18.7, bead claude-hz8f.16.