### PR TITLE
feat(docs-governance): pin the documented ci-required contract and schema version to the code

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1579,6 +1579,14 @@ jobs:
       - name: Check external stats artifacts declare freshness bounds
         run: pnpm run validate:stats-freshness
 
+      # The two most rot-prone documented facts stay mechanically equal to the
+      # code (blueprint 727 E2.7 + E2.8): CLAUDE.md's enumerated ci-required
+      # gate list must equal the workflow's needs: block, CLAUDE.md and
+      # GOVERNANCE.md must name all three required contexts, and every live
+      # schema-version claim surface must equal the validator's SCHEMA_VERSION.
+      - name: Assert documented ci-required contract and schema version equal the code
+        run: pnpm run validate:doc-fact-assertions
+
       # 6767-h is a frozen historical standard that remains cited by schemas.
       # Pin its section map and prove every cited heading still resolves.
       - name: Check frozen prose anchors remain valid

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -69,3 +69,4 @@
 !772-AA-AACR-epic-1-sources-lock-parity.md
 !773-AA-AACR-epic-1-mcp-credential-sops.md
 !774-AA-AACR-epic-1-closure.md
+!775-AA-AACR-epic-2-doc-fact-assertions.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (214 files). Local-only working
+Covers the **tracked** documentation estate (215 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -196,6 +196,7 @@ index and `000-docs/.gitignore`.
 - [772-AA-AACR-epic-1-sources-lock-parity.md](772-AA-AACR-epic-1-sources-lock-parity.md)
 - [773-AA-AACR-epic-1-mcp-credential-sops.md](773-AA-AACR-epic-1-mcp-credential-sops.md)
 - [774-AA-AACR-epic-1-closure.md](774-AA-AACR-epic-1-closure.md)
+- [775-AA-AACR-epic-2-doc-fact-assertions.md](775-AA-AACR-epic-2-doc-fact-assertions.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23103
+        "tracked_files": 23106
       }
     },
     "2": {
@@ -1945,10 +1945,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 214,
+        "index_entries": 215,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 214,
+        "tracked_documents": 215,
         "untracked_index_entries": []
       }
     },
@@ -1972,9 +1972,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15566,
+        "invisible_files": 15568,
         "target_invisible_files": 0,
-        "tracked_files": 23103
+        "tracked_files": 23106
       }
     },
     "47": {

--- a/000-docs/775-AA-AACR-epic-2-doc-fact-assertions.md
+++ b/000-docs/775-AA-AACR-epic-2-doc-fact-assertions.md
@@ -1,0 +1,51 @@
+<!-- doc-class: record -->
+
+# Epic 2 Documented-Fact Assertions — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 2 beads 2.7 and 2.8
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-hedb.9` (coupled slice — both beads are thin assertions over the facts E2.6 corrected and share one checker)
+- **Implementation PR:** [#1260](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1260)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E2.7 + E2.8 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The two documented facts with the worst rot history are now mechanically pinned to the code by
+`scripts/check-doc-fact-assertions.mjs`, wired as `validate:doc-fact-assertions` inside the
+`doc-governance` job (blocking via `ci-required`):
+
+1. **E2.7 — the ci-required contract.** CLAUDE.md's enumerated gate-job list (the
+   "`` `needs:` `` all N gate jobs (…)" sentence) must equal the actual `needs:` block of the
+   `ci-required` job in `validate-plugins.yml` — same count, same names, both directions. In
+   addition, CLAUDE.md and GOVERNANCE.md must each name all three required branch-protection
+   contexts (`ci-required`, `gitleaks`, `skill-conform`) — the regression guard for the
+   two-contexts understatement E2.6 found in GOVERNANCE.md, and for the 19-vs-21 job count the
+   reviewer guide carried.
+2. **E2.8 — the schema version.** The validator's `SCHEMA_VERSION` literal is the authority;
+   CLAUDE.md's "(schema X.Y.Z" reference, 6767-b's "CURRENT SCHEMA" banner, and
+   `SCHEMA_CHANGELOG.md`'s newest entry must all equal it. A missing claim surface is reported
+   as a moved anchor, never silently passed.
+
+Historical version strings inside dated changelog entries and record-class docs are deliberately
+out of scope — assertions cover live claim surfaces only, matching E2.6's correction discipline.
+
+## Verification
+
+- `node --test scripts/check-doc-fact-assertions.test.mjs` — 6/6 pass (needs extraction,
+  prose-anchor parse + moved-anchor failure, count/set mismatch reporting in both directions,
+  required-context regression guard, schema authority + claim parsing, null-surface fail-closed).
+- Live run against the post-E2.6 tree: OK (21 == 21 jobs, name sets equal, three contexts named
+  in both files, three schema surfaces == 4.0.0).
+- Hosted CI on the implementation PR is the final gate.
+
+## Scope discipline
+
+No documentation content changed in this slice — E2.6 corrected the facts; this slice only pins
+them. No plugin, catalog, credential, or release surface touched.
+
+## Follow-up
+
+Epic 2 remaining after this slice: E2.10 (one-owner-per-fact-class authority map) and E2.13
+(governed README landing contract).

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "validate:stats-freshness": "node --test scripts/check-stats-freshness.test.mjs && node scripts/check-stats-freshness.mjs --report",
     "validate:sources-lock-parity": "node --test scripts/check-sources-lock-parity.test.mjs && node scripts/check-sources-lock-parity.mjs",
     "validate:mcp-plaintext-creds": "node --test scripts/check-mcp-plaintext-creds.test.mjs && node scripts/check-mcp-plaintext-creds.mjs",
+    "validate:doc-fact-assertions": "node --test scripts/check-doc-fact-assertions.test.mjs && node scripts/check-doc-fact-assertions.mjs",
     "verify": "node scripts/run-verification-pipeline.mjs",
     "lint:root": "eslint .",
     "lint:design": "node scripts/lint-design-tells.mjs",

--- a/scripts/check-doc-fact-assertions.mjs
+++ b/scripts/check-doc-fact-assertions.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * check-doc-fact-assertions.mjs — keep the two most rot-prone documented facts
+ * mechanically equal to the code (blueprint 727, Epic 2 beads 2.7 and 2.8).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * E2.6 corrected a governing-doc corpus in which GOVERNANCE.md stated the
+ * merge gate as two required contexts (actual: three), the reviewer guide
+ * told triagers 19 gate jobs (actual: 21), and three surfaces disagreed about
+ * the validator schema version. Corrections rot without assertions; these two
+ * facts have rotted before and are cheap to pin.
+ *
+ * ASSERTION 1 (E2.7) — the ci-required contract:
+ *   - CLAUDE.md's enumerated gate-job list ("needs: all N gate jobs (a, b,
+ *     ...)") must equal the actual `needs:` block of the ci-required job in
+ *     .github/workflows/validate-plugins.yml — same count, same names.
+ *   - CLAUDE.md and GOVERNANCE.md must each name all three required
+ *     branch-protection contexts (ci-required, gitleaks, skill-conform)
+ *     — the regression guard for the two-contexts understatement.
+ *
+ * ASSERTION 2 (E2.8) — the schema version:
+ *   - scripts/validate-skills-schema.py's SCHEMA_VERSION is the authority.
+ *   - CLAUDE.md's "(schema X.Y.Z" reference, 6767-b's "CURRENT SCHEMA: X.Y.Z"
+ *     banner, and SCHEMA_CHANGELOG.md's newest "## [X.Y.Z]" entry must all
+ *     equal it.
+ *
+ * Historical version strings inside dated changelog entries or record-class
+ * docs are deliberately NOT scanned — only the live claim surfaces above.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+
+const read = (p) => readFileSync(join(REPO_ROOT, p), 'utf8');
+
+/** The actual gate list: ci-required's needs in the workflow. */
+export function actualCiRequiredNeeds(workflowText) {
+  const wf = yaml.load(workflowText);
+  const needs = wf?.jobs?.['ci-required']?.needs;
+  if (!Array.isArray(needs) || needs.length === 0) {
+    throw new Error('validate-plugins.yml: ci-required job has no needs array');
+  }
+  return needs.map(String);
+}
+
+/** CLAUDE.md's enumerated claim: "`needs:` all N gate jobs (a, b, c...)". */
+export function documentedCiRequiredClaim(claudeText) {
+  const m = claudeText.match(/`needs:`\s+all\s+(\d+)\s+gate jobs\s*\(([^)]+)\)/);
+  if (!m) {
+    throw new Error(
+      'CLAUDE.md: could not find the "`needs:` all N gate jobs (…)" enumeration — the assertion anchor moved',
+    );
+  }
+  return {
+    count: Number(m[1]),
+    names: m[2]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  };
+}
+
+export function compareCiRequired(claim, actual) {
+  const problems = [];
+  if (claim.count !== actual.length) {
+    problems.push(`documented count ${claim.count} != actual needs length ${actual.length}`);
+  }
+  const claimSet = new Set(claim.names);
+  const actualSet = new Set(actual);
+  for (const n of actual) if (!claimSet.has(n)) problems.push(`missing from prose: ${n}`);
+  for (const n of claim.names)
+    if (!actualSet.has(n)) problems.push(`prose names unknown job: ${n}`);
+  return problems;
+}
+
+const REQUIRED_CONTEXTS = ['ci-required', 'gitleaks', 'skill-conform'];
+
+export function missingContexts(text) {
+  return REQUIRED_CONTEXTS.filter((c) => !text.includes(c));
+}
+
+/** The authority: SCHEMA_VERSION in the validator. */
+export function validatorSchemaVersion(pyText) {
+  const m = pyText.match(/^SCHEMA_VERSION\s*=\s*"(\d+\.\d+\.\d+)"/m);
+  if (!m) throw new Error('validate-skills-schema.py: SCHEMA_VERSION literal not found');
+  return m[1];
+}
+
+export function schemaClaims({ claudeText, specText, changelogText }) {
+  const claims = [];
+  const claude = claudeText.match(/\(schema (\d+\.\d+\.\d+)/);
+  if (claude) claims.push({ surface: 'CLAUDE.md "(schema …)"', version: claude[1] });
+  else claims.push({ surface: 'CLAUDE.md "(schema …)"', version: null });
+  const spec = specText.match(/CURRENT SCHEMA:\s*(\d+\.\d+\.\d+)/);
+  claims.push({ surface: '6767-b banner "CURRENT SCHEMA"', version: spec ? spec[1] : null });
+  const changelog = changelogText.match(/^## \[(\d+\.\d+\.\d+)\]/m);
+  claims.push({
+    surface: 'SCHEMA_CHANGELOG newest entry',
+    version: changelog ? changelog[1] : null,
+  });
+  return claims;
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  const violations = [];
+
+  // E2.7 — ci-required contract
+  try {
+    const actual = actualCiRequiredNeeds(read('.github/workflows/validate-plugins.yml'));
+    const claudeText = read('CLAUDE.md');
+    const claim = documentedCiRequiredClaim(claudeText);
+    for (const p of compareCiRequired(claim, actual)) violations.push(`ci-required prose: ${p}`);
+    for (const c of missingContexts(claudeText))
+      violations.push(`CLAUDE.md never names required context "${c}"`);
+    for (const c of missingContexts(read('GOVERNANCE.md')))
+      violations.push(`GOVERNANCE.md never names required context "${c}"`);
+  } catch (err) {
+    violations.push(err.message);
+  }
+
+  // E2.8 — schema version
+  try {
+    const authority = validatorSchemaVersion(read('scripts/validate-skills-schema.py'));
+    const claims = schemaClaims({
+      claudeText: read('CLAUDE.md'),
+      specText: read('000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md'),
+      changelogText: read('000-docs/SCHEMA_CHANGELOG.md'),
+    });
+    for (const { surface, version } of claims) {
+      if (version === null) violations.push(`${surface}: claim surface not found — anchor moved`);
+      else if (version !== authority)
+        violations.push(`${surface}: states ${version}, validator SCHEMA_VERSION is ${authority}`);
+    }
+  } catch (err) {
+    violations.push(err.message);
+  }
+
+  for (const v of violations) console.error(`doc-fact-assertions: VIOLATION — ${v}`);
+  if (violations.length > 0) {
+    console.error(`doc-fact-assertions: FAIL — ${violations.length} violation(s).`);
+    process.exit(1);
+  }
+  console.log(
+    'doc-fact-assertions: OK (ci-required prose == workflow; schema claims == SCHEMA_VERSION)',
+  );
+}

--- a/scripts/check-doc-fact-assertions.test.mjs
+++ b/scripts/check-doc-fact-assertions.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  actualCiRequiredNeeds,
+  compareCiRequired,
+  documentedCiRequiredClaim,
+  missingContexts,
+  schemaClaims,
+  validatorSchemaVersion,
+} from './check-doc-fact-assertions.mjs';
+
+const WF = `
+jobs:
+  ci-required:
+    needs:
+      - validate
+      - verify
+      - test
+`;
+
+test('workflow needs are extracted from the ci-required job', () => {
+  assert.deepEqual(actualCiRequiredNeeds(WF), ['validate', 'verify', 'test']);
+  assert.throws(() => actualCiRequiredNeeds('jobs: {}'), /no needs array/);
+});
+
+test('the prose enumeration parses count and names', () => {
+  const claim = documentedCiRequiredClaim('… `needs:` all 3 gate jobs (validate, verify, test).');
+  assert.equal(claim.count, 3);
+  assert.deepEqual(claim.names, ['validate', 'verify', 'test']);
+  assert.throws(() => documentedCiRequiredClaim('no anchor here'), /anchor moved/);
+});
+
+test('count and set mismatches are both reported', () => {
+  const actual = ['validate', 'verify', 'test'];
+  assert.deepEqual(compareCiRequired({ count: 3, names: actual }, actual), []);
+  const wrong = compareCiRequired({ count: 2, names: ['validate', 'stale-job'] }, actual);
+  assert.ok(wrong.some((p) => p.includes('count')));
+  assert.ok(wrong.some((p) => p.includes('missing from prose: verify')));
+  assert.ok(wrong.some((p) => p.includes('unknown job: stale-job')));
+});
+
+test('all three required contexts must be named', () => {
+  assert.deepEqual(missingContexts('ci-required gitleaks skill-conform'), []);
+  assert.deepEqual(missingContexts('ci-required + gitleaks are the two'), ['skill-conform']);
+});
+
+test('schema authority and claim surfaces parse', () => {
+  assert.equal(validatorSchemaVersion('x\nSCHEMA_VERSION = "4.0.0"\ny'), '4.0.0');
+  const claims = schemaClaims({
+    claudeText: 'Validator (schema 4.0.0 — see changelog)',
+    specText: 'CURRENT SCHEMA: 4.0.0',
+    changelogText: '# log\n\n## [4.0.0] — 2026-08-16\n\n## [3.16.1] — old',
+  });
+  assert.deepEqual(
+    claims.map((c) => c.version),
+    ['4.0.0', '4.0.0', '4.0.0'],
+  );
+});
+
+test('a missing claim surface is reported as null, never silently passed', () => {
+  const claims = schemaClaims({ claudeText: 'no anchor', specText: 'none', changelogText: 'none' });
+  assert.deepEqual(
+    claims.map((c) => c.version),
+    [null, null, null],
+  );
+});


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 2 beads E2.7 + E2.8** as one coupled slice (bead `claude-hedb.9`): a deterministic checker keeps the two most rot-prone documented facts equal to the code, wired as `validate:doc-fact-assertions` in the `doc-governance` job (blocks via `ci-required`).

## Why + decision rationale
E2.6 (#1259) corrected a corpus in which GOVERNANCE.md understated the merge gate (two contexts vs three), the reviewer guide said 19 gate jobs (actual 21), and three surfaces disagreed on the schema version. Corrections rot without assertions. Coupled the two beads into one PR because both are thin assertions over the same just-corrected facts — shipping them separately leaves a rot window. Chose prose-anchored assertions over bounded generated blocks because the sentences already exist and a moved anchor fails loudly rather than silently passing.

## How it works
- **E2.7**: CLAUDE.md's "`needs:` all N gate jobs (…)" enumeration must equal `validate-plugins.yml`'s actual `ci-required` needs — count and name-set, both directions; CLAUDE.md + GOVERNANCE.md must each name `ci-required`, `gitleaks`, `skill-conform`.
- **E2.8**: validator `SCHEMA_VERSION` is the authority; CLAUDE.md's "(schema X.Y.Z", 6767-b's "CURRENT SCHEMA" banner, and SCHEMA_CHANGELOG's newest entry must all equal it. Missing surface ⇒ moved-anchor violation, never a silent pass. Historical versions in dated entries are deliberately out of scope.

## Verification (evidence)
- `node --test scripts/check-doc-fact-assertions.test.mjs` — 6/6
- Live run: OK (21==21, three contexts named in both files, three schema surfaces == 4.0.0)
- `check-doc-classes` allow=true · docs index 215 · `measure-epic-1 --check` OK · hosted CI final

## Risk / rollback
Additive gate; focused revert. Editing the anchored sentences in CLAUDE.md/GOVERNANCE.md now requires keeping them true — that is the point.

## Follow-up & deferred
Epic 2 remainder: E2.10 (authority map), E2.13 (governed README).

Refs: blueprint 000-docs/727 §13 E2.7/E2.8, bead claude-hedb.9, AAR 000-docs/775.