### PR TITLE
docs(docs-governance): point governing files at the section 11 authority map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,5 @@ Required branch-protection contexts on `main`: **`ci-required`**, **`gitleaks`**
 - `skill-conform` is a **separate** always-report workflow (`audit-harness conform --strict`). Never add it (or any path-scoped / provider-dependent job) to `ci-required`'s `needs:`.
 - Behavioral skill eval (`skill-eval-advisory.yml`) is **advisory only** until explicitly graduated.
 - Full gate architecture, validator SSoT rules, and non-negotiables: see `CLAUDE.md`.
+- Which document owns which fact class: blueprint `000-docs/727` § 11 (the authority map),
+  indexed publicly by `STANDARDS.md § Canonical documents`. Point at owners; don't restate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,12 @@ Beyond the 8 required fields, schema 3.5.0+ adds optional visibility-gating fiel
 
 ## Validation & the kernel SSoT — CI/CD posture
 
+> **Authority map:** which document owns which fact class is assigned in blueprint
+> `000-docs/727` § 11 (indexed by `STANDARDS.md § Canonical documents`). The sections below are
+> operational guidance that NAMES its authorities — where this file and an owner disagree, the
+> owner wins, and the doc-governance assertions (`validate:doc-fact-assertions`) pin the facts
+> most prone to drift.
+
 Two things grade frontmatter in this repo today, and the relationship between them is the load-bearing context to preserve.
 
 ### The two validators

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -98,6 +98,15 @@ linked from this table.** That rule is what the table exists for: it is the sing
 of which document owns which fact class, and it is the reason a document cannot grant itself
 authority by editing its own header.
 
+**The one-owner-per-fact-class authority map is
+[blueprint 727 § 11](000-docs/727-AT-ARCH-master-modernization-blueprint.md)** (with its § 11.1
+activation proof). This table is the public index that reaches every owner in ≤ 1 hop; § 11 is
+the per-fact-class assignment. A fact class gains an owner only by a row here plus a § 11 map
+row — never by a header edit, and never by restating the fact in another document. Governing
+files (`CLAUDE.md`, `AGENTS.md`, this file) point at owners rather than duplicating their
+content; where they do describe a fact operationally, the description names its authority and is
+pinned by the doc-governance assertions (`validate:doc-fact-assertions`).
+
 | Topic                                                                                                                            | Document                                                                                                                       |
 | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | **Platform master standard** (plugins, CI, release, docs governance, canonical contract, adapters, root README landing contract) | [000-docs/727-AT-ARCH-master-modernization-blueprint.md](000-docs/727-AT-ARCH-master-modernization-blueprint.md)               |


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 2 bead E2.10** (bead `claude-hedb.10`): STANDARDS.md, CLAUDE.md, and AGENTS.md now point at blueprint § 11 — the one-owner-per-fact-class authority map — instead of leaving ownership implied. STANDARDS.md § Canonical documents is named as the public one-hop index; § 11 as the assignment layer; CLAUDE.md's validation section explicitly subordinates its operational descriptions to the owners it names.

## Why one-line
The map existed (§ 11 + § 11.1 proof, STANDARDS-linked since ratification) but no governing file pointed at it — restatement, the exact failure mode § 11 exists to kill, had no stated alternative. Chose pointers + the E2.7/E2.8 assertions over stripping CLAUDE.md's operational text, because that text is working agent context and the assertions keep it true.

## Verification
`validate:doc-fact-assertions` OK · `check-doc-authority` OK (12 links) · its test suite 8/8 · hosted CI final. Docs-only; focused revert.

Refs: blueprint 000-docs/727 § 11/§ 11.1 + § 13 E2.10, bead claude-hedb.10.