### PR TITLE
fix(docs-governance): repair README category links, cohort command, and cert-report validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ ccpi install devops-automation-pack
 
 Every number below names the cohort it counts and the command that reproduces it — an unlabeled count is how a corpus ends up with five contradictory answers to "how many skills."
 
-| Count | Cohort                                 | Reproduce with                                                          |
-| ----: | -------------------------------------- | ----------------------------------------------------------------------- |
-|   468 | catalog plugins (catalog-entry cohort) | `node scripts/generate-readme-toc.mjs` over `marketplace.extended.json` |
-| 3,069 | marketplace-visible skills (distinct)  | `resolveCorpus('marketplace-visible')` via `pnpm run measure:e1`        |
-|   347 | agent definitions in plugins           | `git ls-files 'plugins/**' \| grep '/agents/.*\.md'`                    |
-|    19 | plugin categories                      | `ls -d plugins/*/`                                                      |
+| Count | Cohort                                 | Reproduce with                                                                                                          |
+| ----: | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+|   468 | catalog plugins (catalog-entry cohort) | `node scripts/generate-readme-toc.mjs` over `marketplace.extended.json`                                                 |
+| 3,069 | marketplace-visible skills (distinct)  | `node -e "import('./scripts/corpus-resolver.mjs').then(m=>console.log(m.resolveCorpus('marketplace-visible').length))"` |
+|   347 | agent definitions in plugins           | `git ls-files 'plugins/**' \| grep '/agents/.*\.md'`                                                                    |
+|    19 | plugin categories                      | `ls -d plugins/*/`                                                                                                      |
 
 <!-- SCALE:END -->
 
@@ -113,27 +113,27 @@ Five real questions, five doors — each resolves to a live, generated surface, 
 
 The 19 categories below link into the live marketplace. Plugin counts are the catalog-entry cohort — regenerated from `marketplace.extended.json` by this generator; the catalog itself lives on [tonsofskills.com](https://tonsofskills.com), never in this file (§ 6A of the platform blueprint).
 
-|     | Category                                                                     | Plugins |
-| --- | ---------------------------------------------------------------------------- | ------: |
-| 🤖  | [AI & Machine Learning](https://tonsofskills.com/plugins?category=ai-ml)     |      36 |
-| 🎭  | [AI Agents & Agency](https://tonsofskills.com/plugins?category=ai-agency)    |      10 |
-| 🔌  | [API Development](https://tonsofskills.com/plugins?category=api-development) |      26 |
-| 💼  | [Business Tools](https://tonsofskills.com/plugins?category=business-tools)   |      21 |
-| 👥  | [Community](https://tonsofskills.com/plugins?category=community)             |      24 |
-| ₿   | [Crypto & Web3](https://tonsofskills.com/plugins?category=crypto)            |      27 |
-| 💾  | [Database](https://tonsofskills.com/plugins?category=database)               |      26 |
-| 🎨  | [Design](https://tonsofskills.com/plugins?category=design)                   |       9 |
-| 🔧  | [DevOps & Infrastructure](https://tonsofskills.com/plugins?category=devops)  |      36 |
-| 📚  | [Examples & Templates](https://tonsofskills.com/plugins?category=examples)   |       5 |
-| 🧩  | [MCP Servers](https://tonsofskills.com/plugins?category=mcp)                 |      16 |
-| 📦  | [Packages](https://tonsofskills.com/plugins?category=packages)               |       5 |
-| ⚡  | [Performance](https://tonsofskills.com/plugins?category=performance)         |      25 |
-| ✅  | [Productivity](https://tonsofskills.com/plugins?category=productivity)       |      31 |
-| 🎁  | [SaaS Skill Packs](https://tonsofskills.com/plugins?category=saas-packs)     |     106 |
-| 🔐  | [Security](https://tonsofskills.com/plugins?category=security)               |      27 |
-| ✨  | [Skill Enhancers](https://tonsofskills.com/plugins?category=skill-enhancers) |       9 |
-| 🧪  | [Testing](https://tonsofskills.com/plugins?category=testing)                 |      28 |
-| 📁  | [Analytics](https://tonsofskills.com/plugins?category=analytics)             |       1 |
+|     | Category                                                            | Plugins |
+| --- | ------------------------------------------------------------------- | ------: |
+| 🤖  | [AI & Machine Learning](https://tonsofskills.com/plugins#ai-ml)     |      36 |
+| 🎭  | [AI Agents & Agency](https://tonsofskills.com/plugins#ai-agency)    |      10 |
+| 🔌  | [API Development](https://tonsofskills.com/plugins#api-development) |      26 |
+| 💼  | [Business Tools](https://tonsofskills.com/plugins#business-tools)   |      21 |
+| 👥  | [Community](https://tonsofskills.com/plugins#community)             |      24 |
+| ₿   | [Crypto & Web3](https://tonsofskills.com/plugins#crypto)            |      27 |
+| 💾  | [Database](https://tonsofskills.com/plugins#database)               |      26 |
+| 🎨  | [Design](https://tonsofskills.com/plugins#design)                   |       9 |
+| 🔧  | [DevOps & Infrastructure](https://tonsofskills.com/plugins#devops)  |      36 |
+| 📚  | [Examples & Templates](https://tonsofskills.com/plugins#examples)   |       5 |
+| 🧩  | [MCP Servers](https://tonsofskills.com/plugins#mcp)                 |      16 |
+| 📦  | [Packages](https://tonsofskills.com/plugins#packages)               |       5 |
+| ⚡  | [Performance](https://tonsofskills.com/plugins#performance)         |      25 |
+| ✅  | [Productivity](https://tonsofskills.com/plugins#productivity)       |      31 |
+| 🎁  | [SaaS Skill Packs](https://tonsofskills.com/plugins#saas-packs)     |     106 |
+| 🔐  | [Security](https://tonsofskills.com/plugins#security)               |      27 |
+| ✨  | [Skill Enhancers](https://tonsofskills.com/plugins#skill-enhancers) |       9 |
+| 🧪  | [Testing](https://tonsofskills.com/plugins#testing)                 |      28 |
+| 📁  | [Analytics](https://tonsofskills.com/plugins#analytics)             |       1 |
 
 <!-- AUTO-TOC:END -->
 

--- a/marketplace/src/pages/plugins/index.astro
+++ b/marketplace/src/pages/plugins/index.astro
@@ -31,7 +31,8 @@ const pageDescription = `Explore all ${catalog.plugins.length} plugins for Claud
 
     <div class="categories">
       {Object.entries(byCategory).map(([category, plugins]: [string, any]) => (
-        <div class="category-section">
+        <div class="category-section" id={category}>
+          {/* the id anchors the README's per-category deep links (blueprint § 6A R9) */}
           <h2>{category.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</h2>
           <div class="plugins-grid">
             {plugins.map((plugin: any) => (

--- a/scripts/generate-readme-toc.mjs
+++ b/scripts/generate-readme-toc.mjs
@@ -198,8 +198,12 @@ function buildBlock(catalog) {
   for (const slug of ordered) {
     const meta = metaFor(slug);
     const count = byCategory.get(slug).length;
+    // Deep link to the category's id anchor on /plugins — that page renders a
+    // section per category with id={category}. A query parameter was wrong
+    // here: /plugins never reads one, so every ?category= link showed the
+    // full unfiltered page (review finding on PR #1262).
     lines.push(
-      `| ${meta.emoji} | [${meta.label}](https://tonsofskills.com/plugins?category=${encodeURIComponent(slug)}) | ${count} |`,
+      `| ${meta.emoji} | [${meta.label}](https://tonsofskills.com/plugins#${encodeURIComponent(slug)}) | ${count} |`,
     );
   }
   lines.push('');
@@ -220,7 +224,7 @@ function buildScaleBlock({ plugins, skills, agents }, categoryCount) {
     '| Count | Cohort | Reproduce with |',
     '| ----: | ------ | -------------- |',
     `| ${grouped(plugins)} | catalog plugins (catalog-entry cohort) | \`node scripts/generate-readme-toc.mjs\` over \`marketplace.extended.json\` |`,
-    `| ${grouped(skills)} | marketplace-visible skills (distinct) | \`resolveCorpus('marketplace-visible')\` via \`pnpm run measure:e1\` |`,
+    `| ${grouped(skills)} | marketplace-visible skills (distinct) | \`node -e "import('./scripts/corpus-resolver.mjs').then(m=>console.log(m.resolveCorpus('marketplace-visible').length))"\` |`,
     `| ${grouped(agents)} | agent definitions in plugins | \`git ls-files 'plugins/**' \\| grep '/agents/.*\\.md'\` |`,
     `| ${categoryCount} | plugin categories | \`ls -d plugins/*/\` |`,
     '',
@@ -232,22 +236,39 @@ function buildScaleBlock({ plugins, skills, agents }, categoryCount) {
 // an absent report renders the honest zero state, never a blank.
 function buildCertBlock() {
   const reportPath = join(ROOT, 'certification-report.json');
-  let body;
+  // Only a genuinely ABSENT report renders the not-yet-certified state. A
+  // present-but-malformed report must fail the generator loudly — treating it
+  // as absent would hide a broken certification pipeline behind an honest-
+  // looking zero state (review finding on PR #1262).
+  let raw;
   try {
-    const report = JSON.parse(readFileSync(reportPath, 'utf-8'));
-    const certified = Number(report?.certified ?? 0);
-    const pending = Number(report?.pending ?? 0);
-    body =
-      `Certification status from \`certification-report.json\`: ` +
-      `**${certified} certified** · **${pending} pending**. A tier is a computed, expiring ` +
-      `claim with retained evidence — never a self-approved badge.`;
-  } catch {
-    body =
+    raw = readFileSync(reportPath, 'utf-8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    const body =
       '**Not yet certified.** The certification program (tiers T0–T4 with retained, ' +
       'hash-matched evidence) is a later epic of the platform blueprint; until its report ' +
       'exists, no artifact on this surface claims a tier. This line is rendered from the ' +
       'absence of `certification-report.json` — honestly, not cosmetically.';
+    return [CERT_START, '', body, '', CERT_END].join('\n');
   }
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`certification-report.json exists but is unparseable: ${err.message}`);
+  }
+  const { certified, pending } = report ?? {};
+  const validCount = (n) => Number.isInteger(n) && n >= 0;
+  if (!validCount(certified) || !validCount(pending)) {
+    throw new Error(
+      'certification-report.json exists but certified/pending are not non-negative integers — refusing to render a coerced number',
+    );
+  }
+  const body =
+    `Certification status from \`certification-report.json\`: ` +
+    `**${certified} certified** · **${pending} pending**. A tier is a computed, expiring ` +
+    `claim with retained evidence — never a self-approved badge.`;
   return [CERT_START, '', body, '', CERT_END].join('\n');
 }
 


### PR DESCRIPTION
## What
Fixes all three Greptile findings on merged PR #1262 (the E2.13 README landing contract): dead-end category links (`/plugins?category=` was never read — now real `id` anchors + `/plugins#<slug>` deep links), a reproduce-command that measured the wrong cohort (now the exact `resolveCorpus('marketplace-visible')` one-liner, prints 3069), and cert-report handling where a malformed report masqueraded as absent (only ENOENT renders not-yet-certified; malformed/coercible values now throw).

## Why one-line
All three are truth-of-the-surface defects in the just-landed § 6A contract — exactly the class the contract exists to prevent.

## Verification
Generator `--check` in sync (13.9 KB) · `validate:readme-contract` OK · cohort one-liner verified · marketplace build validates the Astro change in CI.

Refs: PR #1262 review threads, blueprint 000-docs/727 § 6A, bead claude-hedb.11.