### PR TITLE
docs(docs-governance): file the Epic 2 closure AAR and disposition the warden audit

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -71,3 +71,4 @@
 !774-AA-AACR-epic-1-closure.md
 !775-AA-AACR-epic-2-doc-fact-assertions.md
 !776-AA-AACR-epic-2-readme-landing-contract.md
+!777-AA-AACR-epic-2-closure.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (216 files). Local-only working
+Covers the **tracked** documentation estate (217 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -198,6 +198,7 @@ index and `000-docs/.gitignore`.
 - [774-AA-AACR-epic-1-closure.md](774-AA-AACR-epic-1-closure.md)
 - [775-AA-AACR-epic-2-doc-fact-assertions.md](775-AA-AACR-epic-2-doc-fact-assertions.md)
 - [776-AA-AACR-epic-2-readme-landing-contract.md](776-AA-AACR-epic-2-readme-landing-contract.md)
+- [777-AA-AACR-epic-2-closure.md](777-AA-AACR-epic-2-closure.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1243,7 +1243,13 @@ demanded. (7) **Skill-count cohorts**: the `3,179 SKILL.md` figure used across �
 are incorrect. (8) **Plugin totals**: "~470"/"470-plugin" reads resolve to the catalog-entry
 cohort, 468 at this correction. Bead 2.6's own target text (§ 13 row 2.6) predates these
 landings; its operative targets are the assertions in beads 2.7/2.8 plus the cohort-label
-discipline of E1.6.
+discipline of E1.6. (9) **Epic 2's exit criterion "8→3 self-declarations, all linked"**
+(§ 13, and exit-scorecard row 43's "8/1 → 3/3") is reconciled against the live graph: the
+effective authority-claimant count is **2** (this blueprint and 6767-b), both linked — the
+freeze retired more claimants than the criterion anticipated, so the target is EXCEEDED, not
+missed. The pinned assertion is `check-doc-authority.test.mjs` (two claimants, twelve
+canonical-table links); "2 ≤ 3, all linked" is the satisfied reading, recorded here so no
+audit needs to re-derive it.
 
 **Dependencies / entry criteria.** None for the measurement harness, the catalog work, and the asset sniff. The dead-domain sweep **must wait for Epic 2's freeze** — the frozen set is an input, not an afterthought.
 

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23109
+        "tracked_files": 23110
       }
     },
     "2": {
@@ -1945,10 +1945,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 216,
+        "index_entries": 217,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 216,
+        "tracked_documents": 217,
         "untracked_index_entries": []
       }
     },
@@ -1972,9 +1972,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15570,
+        "invisible_files": 15571,
         "target_invisible_files": 0,
-        "tracked_files": 23109
+        "tracked_files": 23110
       }
     },
     "47": {

--- a/000-docs/777-AA-AACR-epic-2-closure.md
+++ b/000-docs/777-AA-AACR-epic-2-closure.md
@@ -1,0 +1,83 @@
+<!-- doc-class: record -->
+
+# Epic 2 Closure — Documentation Authority and Source-of-Truth Consolidation — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 2 (§ 13), 13 blueprint beads E2.1–E2.13
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Epic bead:** `claude-hedb` (11 children, all closed)
+- **Status:** Closure record; the parent bead closes after this filing merges, per the program's filing-then-close transaction
+
+## Verdict
+
+Epic 2 is complete. All 13 blueprint beads are implemented, merged, and closed with PR +
+merge-SHA evidence across 11 children (two coupled pairs: E2.1+E2.2 landed together at
+ratification, E2.7+E2.8 shared one assertion checker). The eight-months-standing pathology the
+epic existed to end — eight documents self-declaring AUTHORITATIVE with one linked, and
+governing files restating facts that then rotted — is now mechanically unrepeatable: authority
+requires a `STANDARDS.md` link (gate), every tracked document carries a machine-readable
+lifecycle class (gate), frozen bodies are byte-pinned (gate), the index is generated (gate), the
+two most rot-prone facts are asserted equal to the code (gate), and the README is a governed
+landing contract with byte budgets (gates).
+
+## Bead-to-evidence map
+
+| Blueprint                                      | Child            | Evidence (implementation → AAR)                                                  |
+| ---------------------------------------------- | ---------------- | -------------------------------------------------------------------------------- |
+| E2.1 standards freeze (+E2.2 blueprint filing) | `claude-hedb.1`  | PR #1197 → AAR 737; E2.2 satisfied by ratification PR #1186 → record 730         |
+| E2.3 authority-pointer gate                    | `claude-hedb.2`  | PR #1200 → AAR 738                                                               |
+| E2.4 generated docs index                      | `claude-hedb.3`  | PR #1202 → AAR 739                                                               |
+| E2.5 document lifecycle classes                | `claude-hedb.7`  | PR #1253 → AAR 770                                                               |
+| E2.6 documented-number corrections             | `claude-hedb.8`  | PR #1259 → the appended E2.6 correction blocks in 727/694/728/729 are the record |
+| E2.7 + E2.8 fact assertions (coupled)          | `claude-hedb.9`  | PR #1260 → AAR 775                                                               |
+| E2.9 frozen prose-anchor gate                  | `claude-hedb.4`  | PR #1204 → AAR 740                                                               |
+| E2.10 authority-map pointers                   | `claude-hedb.10` | PR #1261                                                                         |
+| E2.11 cross-system authority                   | `claude-hedb.6`  | PR #1222 → AAR 751                                                               |
+| E2.12 supersession record shape                | `claude-hedb.5`  | PR #1214 → AAR 747                                                               |
+| E2.13 README landing contract                  | `claude-hedb.11` | PR #1262 (+ review-findings follow-up #1263) → AAR 776                           |
+
+## Blueprint exit criteria
+
+- **"8→3 self-declarations, all linked":** the live tree has exactly **2** effective authority
+  claimants (727 and 6767-b), both `STANDARDS.md`-linked — beyond the ≤3 target — verified by
+  `check-doc-authority.mjs` (12 canonical-table links, pinned by test). The criterion itself is
+  reconciled in 727's E2.6 correction block, item 9 (flagged by the pre-closure warden audit:
+  "2" must be read against the criterion on record, never silently).
+- **Named gates all green and wired in `doc-governance`:** authority-pointer, doc-class,
+  index-drift, schema-version + ci-count (`validate:doc-fact-assertions`), prose-anchor, and the
+  README landing contract (R1/R2 at emit inside the single writer; R4/R5/R6/R8/R9 via
+  `validate:readme-contract`) — each with fixture red runs.
+- **Exit scorecard rows:** row 42 (schema) asserted equal at 4.0.0; row 44 (index) generated and
+  drift-gated at parity; row 43 (self-declarations) exceeded; the ci-count prose is asserted
+  equal to the workflow both directions.
+
+## Owner reshapings and dispositions
+
+E2.6's blueprint target text predated Epic 1's landings; its operative form (documented in 727's
+appended **E2.6 documentation-number correction** block) dispositioned eight spent baselines
+rather than "correcting" already-fixed rows. Ratified/locked records received dated correction
+appendices, never rewritten rows. E2.13 disclosed three § 6A.2 deviations (spotlight retained,
+NPM-STATS retained, badges as single-writer projections) in AAR 776.
+
+## Residual transfers
+
+- Epic 3 replaces E2.13's interim R5 harness-name refusal with the generated `adapters[]`
+  registry cross-check and renders the adapter matrix (E3.12).
+- Epic 10's `certification-report.json` flips the README CERTIFICATION block to the live split
+  automatically; a malformed report fails the generator loudly (hardened in PR #1263).
+
+## Warden audit disposition
+
+The `beads-warden` pre-closure audit raised four blockers and three correcting notes; all are
+dispositioned in the closure PR: (1) E2.13's bead closed with full PR #1262 + AAR 776 +
+follow-up #1263 evidence after the audit snapshot; (2) every child state was re-read directly
+via `bd show` against the live Dolt-backed store (11/11 CLOSED — no rapid-write drop); (3) the
+"8→3" criterion is reconciled in 727's E2.6 correction block item 9; (4) CHANGELOG entries for
+E2.6, E2.7+E2.8, E2.10, and E2.13 were added under 2026-08-18. Correcting notes were appended to
+`claude-hedb.10` (deliberately thin record — pointerization-only slice), `claude-hedb.6`
+(title-vs-scope precision), and the parent's progressive-activation narrative.
+
+## Verification of this record
+
+Every PR number and SHA is resolvable; the warden audit plus the `bd show` read-back precede the
+parent close. This AAR passes the same doc-governance gates it documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2026-08-18
 
+- **docs(governance):** correct every live documented number that disagreed
+  with the code (E2.6): the merge gate is three required contexts, the
+  aggregate needs twenty-one jobs, and ratified records received dated
+  correction appendices instead of rewritten baselines.
+- **feat(governance):** pin the documented `ci-required` contract and schema
+  version to the code with fail-loud prose-anchor assertions (E2.7+E2.8).
+- **docs(governance):** point STANDARDS, CLAUDE, and AGENTS at the blueprint's
+  one-owner-per-fact-class authority map instead of restating ownership
+  (E2.10).
+- **feat(governance):** rebuild the root README as a governed landing contract
+  — category-only TOC, byte budgets, cohort-labeled scale block, certification
+  honesty block, frozen install slug pinned by red-run tests (E2.13).
 - **fix(marketplace):** label search-result and entity-local skill counts with
   their local population and provenance instead of presenting them as global
   marketplace totals.


### PR DESCRIPTION
## What
Files `000-docs/777` — the Epic 2 closure record (all 13 blueprint beads closed across 11 children with PR+SHA evidence; six named gates live) — and dispositions all four blockers plus three correcting notes from the beads-warden pre-closure audit: E2.13 evidence completed post-snapshot, 11/11 bd-show read-back, the '8→3 self-declarations' criterion reconciled in 727's E2.6 correction block (live count 2, both linked — exceeded, recorded), and the missing CHANGELOG entries added. Parent bead `claude-hedb` closes when this merges.

## Why
Blueprint 727 § 13 requires the epic-closure AAR + evidence before the parent bead may close; the warden audit is the independent pre-closure review.

Refs: blueprint 000-docs/727 § 13 Epic 2, bead claude-hedb, AARs 736–776, PRs #1197–#1263.