### PR TITLE
feat(docs-governance): publish the model-agnostic migration-surface baseline

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -71,10 +71,6 @@
 !774-AA-AACR-epic-1-closure.md
 !775-AA-AACR-epic-2-doc-fact-assertions.md
 !776-AA-AACR-epic-2-readme-landing-contract.md
-<<<<<<< HEAD
+!777-AA-AACR-epic-2-closure.md
 !778-RA-DATA-model-agnostic-migration-surface.md
 !778-RA-DATA-model-agnostic-migration-surface.json
-||||||| 0dde800aa
-=======
-!777-AA-AACR-epic-2-closure.md
->>>>>>> origin/main

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -71,3 +71,5 @@
 !774-AA-AACR-epic-1-closure.md
 !775-AA-AACR-epic-2-doc-fact-assertions.md
 !776-AA-AACR-epic-2-readme-landing-contract.md
+!778-RA-DATA-model-agnostic-migration-surface.md
+!778-RA-DATA-model-agnostic-migration-surface.json

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,16 +5,9 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-<<<<<<< HEAD
-Covers the **tracked** documentation estate (218 files). Local-only working
-||||||| 0dde800aa
-Covers the **tracked** documentation estate (216 files). Local-only working
-=======
-Covers the **tracked** documentation estate (217 files). Local-only working
-
-> > > > > > > origin/main
-> > > > > > > documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
-> > > > > > > index and `000-docs/.gitignore`.
+Covers the **tracked** documentation estate (219 files). Local-only working
+documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
+index and `000-docs/.gitignore`.
 
 ## Files (global chronological order)
 
@@ -205,13 +198,9 @@ Covers the **tracked** documentation estate (217 files). Local-only working
 - [774-AA-AACR-epic-1-closure.md](774-AA-AACR-epic-1-closure.md)
 - [775-AA-AACR-epic-2-doc-fact-assertions.md](775-AA-AACR-epic-2-doc-fact-assertions.md)
 - [776-AA-AACR-epic-2-readme-landing-contract.md](776-AA-AACR-epic-2-readme-landing-contract.md)
-  <<<<<<< HEAD
+- [777-AA-AACR-epic-2-closure.md](777-AA-AACR-epic-2-closure.md)
 - [778-RA-DATA-model-agnostic-migration-surface.json](778-RA-DATA-model-agnostic-migration-surface.json)
 - [778-RA-DATA-model-agnostic-migration-surface.md](778-RA-DATA-model-agnostic-migration-surface.md)
-  ||||||| 0dde800aa
-  =======
-- [777-AA-AACR-epic-2-closure.md](777-AA-AACR-epic-2-closure.md)
-  > > > > > > > origin/main
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (216 files). Local-only working
+Covers the **tracked** documentation estate (218 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -198,6 +198,8 @@ index and `000-docs/.gitignore`.
 - [774-AA-AACR-epic-1-closure.md](774-AA-AACR-epic-1-closure.md)
 - [775-AA-AACR-epic-2-doc-fact-assertions.md](775-AA-AACR-epic-2-doc-fact-assertions.md)
 - [776-AA-AACR-epic-2-readme-landing-contract.md](776-AA-AACR-epic-2-readme-landing-contract.md)
+- [778-RA-DATA-model-agnostic-migration-surface.json](778-RA-DATA-model-agnostic-migration-surface.json)
+- [778-RA-DATA-model-agnostic-migration-surface.md](778-RA-DATA-model-agnostic-migration-surface.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23110
+        "tracked_files": 23114
       }
     },
     "2": {
@@ -539,8 +539,8 @@
       "cohort": "literal docs.anthropic.com occurrences in tracked text-like files",
       "dimension": "docs.anthropic.com occurrences",
       "measured_proxy": {
-        "files": 171,
-        "occurrences": 432,
+        "files": 173,
+        "occurrences": 435,
         "paths": [
           "000-docs/198-DR-SOPS-03-mcp-reliability.md",
           "000-docs/688-AA-AACR-2026-06-04-wiki-audit.md",
@@ -548,6 +548,7 @@
           "000-docs/719-RA-REPT-cleanup-candidate-register.md",
           "000-docs/725-RA-DATA-legacy-migration-inventory.md",
           "000-docs/727-AT-ARCH-master-modernization-blueprint.md",
+          "000-docs/778-RA-DATA-model-agnostic-migration-surface.md",
           "marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md",
           "marketplace/src/content/docs/concepts/agents.md",
           "marketplace/src/content/docs/concepts/commands-and-hooks.md",
@@ -654,6 +655,7 @@
           "plugins/security/severity1-marketplace/skills/prompt-improver/SKILL.md",
           "plugins/skill-enhancers/web-to-github-issue/README.md",
           "plugins/testing/kobiton-automate/README.md",
+          "scripts/measure-canonical-surface.mjs",
           "skills/.curated/agent-context-loader/SKILL.md",
           "skills/.curated/agent-safety-preflight/SKILL.md",
           "skills/.curated/anth-ci-integration/SKILL.md",
@@ -727,6 +729,7 @@
         "000-docs/719-RA-REPT-cleanup-candidate-register.md",
         "000-docs/725-RA-DATA-legacy-migration-inventory.md",
         "000-docs/727-AT-ARCH-master-modernization-blueprint.md",
+        "000-docs/778-RA-DATA-model-agnostic-migration-surface.md",
         "marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md",
         "marketplace/src/content/docs/concepts/agents.md",
         "marketplace/src/content/docs/concepts/commands-and-hooks.md",
@@ -833,6 +836,7 @@
         "plugins/security/severity1-marketplace/skills/prompt-improver/SKILL.md",
         "plugins/skill-enhancers/web-to-github-issue/README.md",
         "plugins/testing/kobiton-automate/README.md",
+        "scripts/measure-canonical-surface.mjs",
         "skills/.curated/agent-context-loader/SKILL.md",
         "skills/.curated/agent-safety-preflight/SKILL.md",
         "skills/.curated/anth-ci-integration/SKILL.md",
@@ -1945,10 +1949,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 217,
+        "index_entries": 219,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 217,
+        "tracked_documents": 219,
         "untracked_index_entries": []
       }
     },
@@ -1972,9 +1976,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15571,
+        "invisible_files": 15573,
         "target_invisible_files": 0,
-        "tracked_files": 23110
+        "tracked_files": 23114
       }
     },
     "47": {

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23109
+        "tracked_files": 23113
       }
     },
     "2": {
@@ -539,8 +539,8 @@
       "cohort": "literal docs.anthropic.com occurrences in tracked text-like files",
       "dimension": "docs.anthropic.com occurrences",
       "measured_proxy": {
-        "files": 171,
-        "occurrences": 432,
+        "files": 173,
+        "occurrences": 435,
         "paths": [
           "000-docs/198-DR-SOPS-03-mcp-reliability.md",
           "000-docs/688-AA-AACR-2026-06-04-wiki-audit.md",
@@ -548,6 +548,7 @@
           "000-docs/719-RA-REPT-cleanup-candidate-register.md",
           "000-docs/725-RA-DATA-legacy-migration-inventory.md",
           "000-docs/727-AT-ARCH-master-modernization-blueprint.md",
+          "000-docs/778-RA-DATA-model-agnostic-migration-surface.md",
           "marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md",
           "marketplace/src/content/docs/concepts/agents.md",
           "marketplace/src/content/docs/concepts/commands-and-hooks.md",
@@ -654,6 +655,7 @@
           "plugins/security/severity1-marketplace/skills/prompt-improver/SKILL.md",
           "plugins/skill-enhancers/web-to-github-issue/README.md",
           "plugins/testing/kobiton-automate/README.md",
+          "scripts/measure-canonical-surface.mjs",
           "skills/.curated/agent-context-loader/SKILL.md",
           "skills/.curated/agent-safety-preflight/SKILL.md",
           "skills/.curated/anth-ci-integration/SKILL.md",
@@ -727,6 +729,7 @@
         "000-docs/719-RA-REPT-cleanup-candidate-register.md",
         "000-docs/725-RA-DATA-legacy-migration-inventory.md",
         "000-docs/727-AT-ARCH-master-modernization-blueprint.md",
+        "000-docs/778-RA-DATA-model-agnostic-migration-surface.md",
         "marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md",
         "marketplace/src/content/docs/concepts/agents.md",
         "marketplace/src/content/docs/concepts/commands-and-hooks.md",
@@ -833,6 +836,7 @@
         "plugins/security/severity1-marketplace/skills/prompt-improver/SKILL.md",
         "plugins/skill-enhancers/web-to-github-issue/README.md",
         "plugins/testing/kobiton-automate/README.md",
+        "scripts/measure-canonical-surface.mjs",
         "skills/.curated/agent-context-loader/SKILL.md",
         "skills/.curated/agent-safety-preflight/SKILL.md",
         "skills/.curated/anth-ci-integration/SKILL.md",
@@ -1945,10 +1949,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 216,
+        "index_entries": 218,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 216,
+        "tracked_documents": 218,
         "untracked_index_entries": []
       }
     },
@@ -1972,9 +1976,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15570,
+        "invisible_files": 15572,
         "target_invisible_files": 0,
-        "tracked_files": 23109
+        "tracked_files": 23113
       }
     },
     "47": {

--- a/000-docs/778-RA-DATA-model-agnostic-migration-surface.json
+++ b/000-docs/778-RA-DATA-model-agnostic-migration-surface.json
@@ -1,0 +1,47 @@
+{
+  "measured_at_commit": "0dde800aa943724dd689122e67c35f0f595fd0f0",
+  "anthropic_docs_occurrences": {
+    "first-party": 257,
+    "mirror": 4,
+    "generated": 179
+  },
+  "anthropic_docs_files": {
+    "first-party": 115,
+    "mirror": 2,
+    "generated": 57
+  },
+  "claude_env_var_occurrences": {
+    "first-party": 1627,
+    "mirror": 104,
+    "generated": 1605
+  },
+  "claude_env_var_files": {
+    "first-party": 381,
+    "mirror": 41,
+    "generated": 299
+  },
+  "model_id_occurrences": {
+    "first-party": {
+      "functional": 398,
+      "prose": 485,
+      "bead-id": 7656
+    },
+    "mirror": {
+      "functional": 5,
+      "prose": 3,
+      "bead-id": 421
+    },
+    "generated": {
+      "functional": 531,
+      "prose": 387,
+      "bead-id": 382
+    }
+  },
+  "model_id_functional_files": {
+    "first-party": 184,
+    "mirror": 2,
+    "generated": 128
+  },
+  "mirror_roots": 64,
+  "tracked_files": 23109
+}

--- a/000-docs/778-RA-DATA-model-agnostic-migration-surface.md
+++ b/000-docs/778-RA-DATA-model-agnostic-migration-surface.md
@@ -1,0 +1,70 @@
+<!-- doc-class: record -->
+
+# Model-Agnostic Migration Surface — Committed Baseline
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 3 bead 3.1
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-t9s9.1`
+- **Generator:** `node scripts/measure-canonical-surface.mjs --write` (deterministic; commit
+  recorded inside the JSON) — data file:
+  [778-RA-DATA-model-agnostic-migration-surface.json](778-RA-DATA-model-agnostic-migration-surface.json)
+- **Status:** Point-in-time baseline. Every later Epic 3 bead consumes THIS surface; the
+  pre-regeneration numbers in blueprint § 3/§ 13 are superseded for planning purposes.
+
+## Why this measurement exists
+
+Epic 3's earlier surface estimates predated Epic 1's regeneration discipline: roughly half of
+the `docs.anthropic.com` occurrences sat inside generated artifacts, and bead handles shaped
+like `claude-4laa` could be mistaken for model identifiers by migration tooling. This baseline
+measures the tracked tree at a recorded commit, classified twice:
+
+- **Surface class** (by path): `first-party` (the actual migration surface) vs `mirror`
+  (below a `.source.json` root — upstream-owned, PROHIBITED to Epic 3) vs `generated`
+  (build projections — regenerated, never edited; they inherit whatever the canonical layer
+  emits).
+- **Model-identifier role** (per occurrence): `functional` (a `model:`/`"model"`/`--model`
+  assignment that configures behavior — the thing E3.8 replaces with `model_class` tiers) vs
+  `prose` (mentions in text — deliberately preserved) vs `bead-id` (beads issue handles —
+  protected; the classifier keeps a digit-led handle like `claude-4laa` in this class even on a
+  functional-looking line, with a regression test).
+
+## The true surface (first-party, the only migratable class)
+
+| Measure                                | Count | Files |
+| -------------------------------------- | ----: | ----: |
+| Functional model-id occurrences        |   398 |   184 |
+| Prose model-id occurrences (preserved) |   485 |     — |
+| Protected bead-id occurrences          | 7,656 |     — |
+| `docs.anthropic.com` occurrences       |   257 |   115 |
+| `CLAUDE_*` variable occurrences        | 1,627 |   381 |
+
+Mirror-class counts (5 functional model ids, 4 doc links, 104 env vars) are recorded in the
+JSON and are **out of scope by prohibition**, not by omission. Generated-class counts (531
+functional model ids across 128 files, 179 doc links, 1,605 env vars) are projections of the
+canonical layer: they converge to zero as the first-party surface migrates and regenerates, and
+must never be edited directly.
+
+The protected bead-id figure is dominated by the tracked beads export
+(`.beads/issues.jsonl`) and the AAR corpus quoting bead handles — large by design, and every one
+of them is a token migration tooling must refuse to touch (E3.7's exclusion contract).
+
+## How later beads consume this
+
+- **E3.2/E3.4** size the canonical contract against 184 functional files, not the stale ~131.
+- **E3.7** ships the reusable classifier + exclusion list; this script's `classifyModelToken`
+  (with its bead-id-on-functional-line regression test) is the draft semantics.
+- **E3.8** replaces the 398 functional occurrences with `model_class` tiers, fail-closed.
+- **E3.9** owns the 1,627 first-party `CLAUDE_*` occurrences (`${SKILL_DIR}` portability).
+- **E3.10**'s vendor-literal gate takes the post-migration zero as its baseline; this document
+  is the before.
+
+## Reproduce
+
+```bash
+node scripts/measure-canonical-surface.mjs          # print JSON to stdout
+node --test scripts/measure-canonical-surface.test.mjs
+```
+
+The JSON records the exact commit it measured; re-running at a later commit produces a NEW
+measurement, never an edit to this one.

--- a/scripts/measure-canonical-surface.mjs
+++ b/scripts/measure-canonical-surface.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * measure-canonical-surface.mjs — measure the true model-agnostic migration
+ * surface (blueprint 727, Epic 3 bead 3.1).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Epic 3 replaces vendor literals in the canonical layer with a harness-free
+ * contract. Its migration surface was first measured before Epic 1's
+ * regeneration discipline existed, and ~50% of `docs.anthropic.com`
+ * occurrences sat inside generated artifacts — an inflated surface. This
+ * script measures the surface from the tracked tree, classified three ways,
+ * so every later Epic 3 bead consumes ONE honest baseline.
+ *
+ * CLASSIFICATIONS
+ * ---------------
+ * Surface class (by path):
+ *   - mirror      any file below a directory that contains .source.json —
+ *                 upstream-owned, NEVER migrated (Epic 3 prohibited scope)
+ *   - generated   registered build projections (marketplace/src/data/**,
+ *                 skills/.curated/**, freshie exports, the generated docs
+ *                 index and scorecard) — regenerated, never edited
+ *   - first-party everything else: the actual migration surface
+ *
+ * Model-identifier role (per occurrence line):
+ *   - bead-id     a beads issue handle (claude-<hash>[.n]) that merely LOOKS
+ *                 like a model id. Protected: migration tooling must never
+ *                 rewrite these. Detected shape-first, before any model match.
+ *   - functional  the id configures behavior: a frontmatter/JSON/YAML
+ *                 `model:`/`"model"` assignment or a `--model` flag
+ *   - prose       a mention in text (comparisons, history, commentary) —
+ *                 deliberately preserved per the blueprint
+ *
+ * Usage:
+ *   node scripts/measure-canonical-surface.mjs            # print JSON
+ *   node scripts/measure-canonical-surface.mjs --write    # write 000-docs/778 json+md
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
+
+const GENERATED_PREFIXES = [
+  'marketplace/src/data/',
+  'skills/.curated/',
+  'freshie/grades.csv',
+  'freshie/grade-histogram.json',
+  '000-docs/000-INDEX.md',
+  '000-docs/742-RA-DATA-epic-1-scorecard.json',
+];
+
+// Model-family ids ONLY — the bead-id shape (claude-<4char-hash>) must not
+// match. Families: opus/sonnet/haiku/fable/instant plus numeric generations.
+const MODEL_ID =
+  /\bclaude-(?:opus|sonnet|haiku|fable|instant|[1-9](?:[-.][0-9])?)(?:-[a-z0-9.]+)*\b/gi;
+// A beads handle: claude-<3-5 alnum hash>(.child)* — and NOT a model family.
+const BEAD_ID = /^claude-[a-z0-9]{3,5}(?:\.[0-9]+)*$/;
+// The numeric arm requires a generation boundary ("claude-3", "claude-3-5…",
+// "claude-2.1") so a bead handle like "claude-4laa" — digit followed
+// immediately by letters — stays in the protected bead-id class instead of
+// prefix-matching a model family. That shape is exactly the case the
+// blueprint's bead-ID protection exists for.
+const MODEL_FAMILY = /^claude-(?:opus|sonnet|haiku|fable|instant|[1-9](?:[-.]|$))/;
+
+const FUNCTIONAL_LINE = /(?:^|[^a-z])(?:model|models|MODEL)["']?\s*[:=]|--model[= ]/;
+
+export function classifyPath(path, mirrorRoots) {
+  for (const root of mirrorRoots) {
+    if (path.startsWith(root + '/')) return 'mirror';
+  }
+  for (const g of GENERATED_PREFIXES) {
+    if (path === g || path.startsWith(g)) return 'generated';
+  }
+  return 'first-party';
+}
+
+export function classifyModelToken(token, line) {
+  if (BEAD_ID.test(token) && !MODEL_FAMILY.test(token)) return 'bead-id';
+  if (FUNCTIONAL_LINE.test(line)) return 'functional';
+  return 'prose';
+}
+
+function trackedFiles() {
+  return execFileSync('git', ['ls-files'], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 256 * 1024 * 1024,
+  })
+    .split('\n')
+    .filter(Boolean);
+}
+
+const TEXT_EXT = /\.(md|mjs|cjs|js|ts|tsx|astro|json|ya?ml|py|sh|txt|toml|css|html)$/i;
+
+export function measure() {
+  const files = trackedFiles();
+  const mirrorRoots = files
+    .filter((f) => f.endsWith('/.source.json'))
+    .map((f) => f.slice(0, -'/.source.json'.length));
+
+  const zero = () => ({ 'first-party': 0, mirror: 0, generated: 0 });
+  const result = {
+    anthropic_docs_occurrences: zero(),
+    anthropic_docs_files: zero(),
+    claude_env_var_occurrences: zero(),
+    claude_env_var_files: zero(),
+    model_id_occurrences: {
+      'first-party': { functional: 0, prose: 0, 'bead-id': 0 },
+      mirror: { functional: 0, prose: 0, 'bead-id': 0 },
+      generated: { functional: 0, prose: 0, 'bead-id': 0 },
+    },
+    model_id_functional_files: { 'first-party': 0, mirror: 0, generated: 0 },
+    mirror_roots: mirrorRoots.length,
+    tracked_files: files.length,
+  };
+
+  for (const file of files) {
+    if (!TEXT_EXT.test(file)) continue;
+    let text;
+    try {
+      text = readFileSync(join(ROOT, file), 'utf-8');
+    } catch {
+      continue;
+    }
+    const cls = classifyPath(file, mirrorRoots);
+
+    const docsHits = (text.match(/docs\.anthropic\.com/g) || []).length;
+    if (docsHits > 0) {
+      result.anthropic_docs_occurrences[cls] += docsHits;
+      result.anthropic_docs_files[cls] += 1;
+    }
+
+    const envHits = (text.match(/\$\{?CLAUDE_[A-Z_]+/g) || []).length;
+    if (envHits > 0) {
+      result.claude_env_var_occurrences[cls] += envHits;
+      result.claude_env_var_files[cls] += 1;
+    }
+
+    let functionalInFile = false;
+    for (const line of text.split('\n')) {
+      const tokens = line.match(MODEL_ID) || [];
+      for (const token of tokens) {
+        const role = classifyModelToken(token, line);
+        result.model_id_occurrences[cls][role] += 1;
+        if (role === 'functional') functionalInFile = true;
+      }
+      // bead ids that the model regex cannot match still need protection
+      // counting: claude-<hash> handles on this line
+      const beadTokens = line.match(/\bclaude-[a-z0-9]{3,5}(?:\.[0-9]+)*\b/g) || [];
+      for (const token of beadTokens) {
+        if (BEAD_ID.test(token) && !MODEL_FAMILY.test(token) && !tokens.includes(token)) {
+          result.model_id_occurrences[cls]['bead-id'] += 1;
+        }
+      }
+    }
+    if (functionalInFile) result.model_id_functional_files[cls] += 1;
+  }
+
+  return result;
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf-8' }).trim();
+  const data = { measured_at_commit: head, ...measure() };
+  const json = JSON.stringify(data, null, 2) + '\n';
+  if (process.argv.includes('--write')) {
+    writeFileSync(
+      join(ROOT, '000-docs', '778-RA-DATA-model-agnostic-migration-surface.json'),
+      json,
+    );
+    console.log('written: 000-docs/778-RA-DATA-model-agnostic-migration-surface.json');
+  } else {
+    process.stdout.write(json);
+  }
+}

--- a/scripts/measure-canonical-surface.test.mjs
+++ b/scripts/measure-canonical-surface.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyModelToken, classifyPath } from './measure-canonical-surface.mjs';
+
+test('bead handles are protected — never functional or prose', () => {
+  // the three shapes the blueprint names, plus live handles from this program
+  for (const handle of [
+    'claude-hz8f',
+    'claude-hedb.11',
+    'claude-t9s9.1',
+    'claude-4laa.1',
+    'claude-5awj.6',
+  ]) {
+    assert.equal(
+      classifyModelToken(handle, `model: ${handle}`),
+      'bead-id',
+      `${handle} must stay in the protected class even on a functional-looking line`,
+    );
+  }
+});
+
+test('real model ids classify functional on config lines, prose elsewhere', () => {
+  assert.equal(classifyModelToken('claude-sonnet-4', 'model: claude-sonnet-4'), 'functional');
+  assert.equal(classifyModelToken('claude-3-5-haiku', '"model": "claude-3-5-haiku"'), 'functional');
+  assert.equal(classifyModelToken('claude-opus-4-1', '--model claude-opus-4-1'), 'functional');
+  assert.equal(
+    classifyModelToken('claude-fable-5', 'Fable is faster than claude-fable-5 predecessors.'),
+    'prose',
+  );
+  assert.equal(classifyModelToken('claude-2.1', 'the claude-2.1 era'), 'prose');
+});
+
+test('surface class: mirror beats generated beats first-party', () => {
+  const mirrors = ['plugins/design/uizze'];
+  assert.equal(classifyPath('plugins/design/uizze/README.md', mirrors), 'mirror');
+  assert.equal(classifyPath('marketplace/src/data/skills-index.json', mirrors), 'generated');
+  assert.equal(classifyPath('skills/.curated/x/SKILL.md', mirrors), 'generated');
+  assert.equal(classifyPath('plugins/devops/foo/SKILL.md', mirrors), 'first-party');
+  assert.equal(classifyPath('000-docs/742-RA-DATA-epic-1-scorecard.json', mirrors), 'generated');
+});


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 3 bead E3.1** (bead `claude-t9s9.1`) — the first Epic 3 activation, blueprint-ordered before any contract or rewrite work: a deterministic measurement of the true migration surface, committed as `000-docs/778` (json + md) with the measuring commit recorded inside it.

## Why + decision rationale
Epic 3's earlier estimates predated Epic 1's regeneration discipline (~50% of doc-link occurrences sat in generated artifacts) and bead handles shaped like `claude-4laa` could be mistaken for model ids by migration tooling. Chose shape-first bead-id protection with a generation-boundary model-family regex so a digit-led bead handle can never classify as migratable even on a `model:` line — the exact hazard the blueprint's exclusion contract names — pinned by a regression test.

## The measured surface (first-party, the only migratable class)
**398 functional model-id occurrences / 184 files** (stale estimate: ~131 files) · 485 preserved prose mentions · 257 `docs.anthropic.com` occurrences / 115 files · 1,627 `CLAUDE_*` occurrences / 381 files. Mirror class is out of scope by prohibition; generated class converges to zero as the canonical layer migrates.

## Verification (evidence)
Classifier tests 3/3 (bead-id protection incl. `claude-4laa` on a functional line; functional-vs-prose; mirror>generated>first-party precedence) · baseline regenerates deterministically · `check-doc-classes` allow=true · docs index 218 · `measure-epic-1 --check` OK · hosted CI final.

## Risk / rollback
Additive measurement + record; focused revert. No corpus mutation of any kind.

## Follow-up & deferred
E3.2 (canonical skill-contract JSON Schema) consumes this surface next; E3.7 promotes the classifier semantics to the reusable exclusion contract.

Refs: blueprint 000-docs/727 § 13 E3.1, bead claude-t9s9.1.