### PR TITLE
feat(docs-governance): ship the canonical skill contract as a JSON Schema draft

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1595,6 +1595,14 @@ jobs:
       - name: Check the README landing contract
         run: pnpm run validate:readme-contract
 
+      # The canonical harness-free skill contract (blueprint 727 § 5.2, Epic 3
+      # E3.2): schemas/canonical/v0 must compile under Ajv 2020 strict and hold
+      # its red runs (closed schema, no vendor-literal model class, registry-
+      # enum adapters, resolved-SHA mirror pins). DRAFT + UPSTREAM-PENDING —
+      # the kernel proposal is E3.13's deliverable.
+      - name: Check the canonical skill-contract schema
+        run: pnpm run validate:canonical-schema
+
       # 6767-h is a frozen historical standard that remains cited by schemas.
       # Pin its section map and prove every cited heading still resolves.
       - name: Check frozen prose anchors remain valid

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -74,3 +74,4 @@
 !777-AA-AACR-epic-2-closure.md
 !778-RA-DATA-model-agnostic-migration-surface.md
 !778-RA-DATA-model-agnostic-migration-surface.json
+!779-AA-AACR-epic-3-canonical-skill-contract.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (219 files). Local-only working
+Covers the **tracked** documentation estate (220 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -201,6 +201,7 @@ index and `000-docs/.gitignore`.
 - [777-AA-AACR-epic-2-closure.md](777-AA-AACR-epic-2-closure.md)
 - [778-RA-DATA-model-agnostic-migration-surface.json](778-RA-DATA-model-agnostic-migration-surface.json)
 - [778-RA-DATA-model-agnostic-migration-surface.md](778-RA-DATA-model-agnostic-migration-surface.md)
+- [779-AA-AACR-epic-3-canonical-skill-contract.md](779-AA-AACR-epic-3-canonical-skill-contract.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23114
+        "tracked_files": 23118
       }
     },
     "2": {
@@ -1949,10 +1949,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 219,
+        "index_entries": 220,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 219,
+        "tracked_documents": 220,
         "untracked_index_entries": []
       }
     },
@@ -1976,9 +1976,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15573,
+        "invisible_files": 15576,
         "target_invisible_files": 0,
-        "tracked_files": 23114
+        "tracked_files": 23118
       }
     },
     "47": {

--- a/000-docs/779-AA-AACR-epic-3-canonical-skill-contract.md
+++ b/000-docs/779-AA-AACR-epic-3-canonical-skill-contract.md
@@ -1,0 +1,60 @@
+<!-- doc-class: record -->
+
+# Epic 3 Canonical Skill Contract — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 3 bead 3.2 (§ 5)
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-t9s9.2`
+- **Implementation PR:** [#1266](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1266)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E3.2 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The canonical harness-free skill contract exists as a versioned JSON Schema draft:
+`schemas/canonical/v0/skill-contract.schema.json` (Ajv 2020 strict-compiling,
+`additionalProperties: false` at every level) with its prose companion
+`schemas/canonical/v0/README.md`. It validates `skill-card.yaml` — home **B** of the § 5.1
+four-home split — and encodes the § 5.2 shape exactly: abstract capabilities (bare or scoped,
+never harness tool spellings), fail-closed constraints, declared side effects,
+`requires.services`, `model_class` tiers (`reasoning-high | balanced | fast`, never a vendor
+literal), lifecycle/supersession, SPDX-only provenance with resolved-40-hex mirror pins,
+`adapters[]` as a registry enum (only `claude-code` registered at v0), `unsupported[]` with
+`fail-closed` default degradation, and `compatibility` rejected as an unknown key because it is
+a generated projection, never hand-authored.
+
+**`ALWAYS_REQUIRED` is untouched.** Home A (frontmatter) keeps the IS 8 exactly as the
+SCHEMA_CHANGELOG NON-NEGOTIABLES govern them; this contract is additive by construction and the
+prose companion states the five-one rule.
+
+## Upstream posture
+
+`Status: DRAFT` + `UPSTREAM-PENDING` in the schema's `$comment` and the companion: this
+repository must never become its own schema authority. The kernel proposal to
+`@intentsolutions/core` (schemas `skill-contract`, `capability`, `eval-spec`) is E3.13's
+deliverable, gated on the E3.3/E3.4 drafts existing; the issue number is recorded there when
+filed.
+
+## Verification
+
+- `pnpm run validate:canonical-schema` — 8/8 tests: the blueprint § 5.2 example validates; a
+  minimal seven-required-field contract validates; red runs for the five failure classes —
+  unknown top-level key (closed schema; includes hand-authored `compatibility`), vendor-literal
+  model class (`claude-sonnet-4`, `claude-fable-5`, `gpt-5`, `sonnet` all rejected),
+  unregistered adapter (`codex`, `openclaw`, empty list), branch-name mirror pin (`main`
+  rejected, 40-hex accepted), and harness tool spellings as capabilities (`Bash(jq:*)`,
+  `mcp__plane__query`, `Read` all rejected).
+- Wired as a `doc-governance` step (blocks via `ci-required`); hosted CI is the final gate.
+
+## Scope discipline
+
+No SKILL.md, frontmatter rule, validator behavior, catalog entry, or mirror file changed. The
+schema is a new artifact with tests; nothing consumes it yet — E3.4 extends it against the
+corpus, E3.5/E3.10 build the gates, E3.11 backfills declarations.
+
+## Follow-up
+
+- E3.3: `capability-map.json` — the committed vocabulary covering every tool token in the
+  corpus under one parser (next activation; owns Epic 4's gate input).
+- E3.13: the kernel proposal naming this directory as the draft.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "validate:mcp-plaintext-creds": "node --test scripts/check-mcp-plaintext-creds.test.mjs && node scripts/check-mcp-plaintext-creds.mjs",
     "validate:doc-fact-assertions": "node --test scripts/check-doc-fact-assertions.test.mjs && node scripts/check-doc-fact-assertions.mjs",
     "validate:readme-contract": "node --test scripts/check-readme-contract.test.mjs && node scripts/check-readme-contract.mjs",
+    "validate:canonical-schema": "node --test scripts/check-canonical-schema.test.mjs",
     "verify": "node scripts/run-verification-pipeline.mjs",
     "lint:root": "eslint .",
     "lint:design": "node scripts/lint-design-tells.mjs",

--- a/schemas/canonical/v0/README.md
+++ b/schemas/canonical/v0/README.md
@@ -1,0 +1,66 @@
+# Canonical harness-free skill contract — v0 (DRAFT)
+
+**Status: DRAFT · UPSTREAM-PENDING.** This repository must never become its own schema
+authority: the contract here is the draft to be proposed to `@intentsolutions/core` as the
+`skill-contract` authoring schema (blueprint 727, Epic 3 bead 3.13 — the kernel issue number is
+recorded there when filed). Until the kernel adopts it, this directory is the single draft
+source and every consumer cites it as DRAFT.
+
+## What this is
+
+`skill-contract.schema.json` validates **`skill-card.yaml`** — home **B** of the four-home
+split defined by blueprint 727 § 5.1:
+
+| Home  | File                   | Writer                        | Read by                                                                  |
+| ----- | ---------------------- | ----------------------------- | ------------------------------------------------------------------------ |
+| A     | `SKILL.md` frontmatter | skill author                  | the model, at catalog load                                               |
+| **B** | **`skill-card.yaml`**  | **skill author / maintainer** | **validators, adapter generators, marketplace filters, security review** |
+| C     | catalog entry          | catalog maintainer            | catalog builds, the site                                                 |
+| D     | evidence store (Dolt)  | CI / eval lab only            | badges, gates, history                                                   |
+
+**Home A is untouched.** The frontmatter keeps the IS 8 required fields (`ALWAYS_REQUIRED`)
+exactly as governed by `000-docs/SCHEMA_CHANGELOG.md` § NON-NEGOTIABLES — this contract is
+additive. Any governance field the model does not need in order to decide whether to fire lives
+here, not in frontmatter.
+
+## The load-bearing rules the schema encodes
+
+1. **Capabilities are abstract.** `filesystem.read`, `shell.exec: { commands: [jq] }`,
+   `network.http: { hosts: [...] }` — never a harness tool spelling. `Bash(jq:*)` is a Claude
+   Code _expression_ of `shell.exec`; the adapter map owns that translation, and the frontmatter
+   `allowed-tools` is derived-checked against it (E3.4/E3.5).
+2. **`model_class`, never a vendor literal.** `reasoning-high | balanced | fast`. Adapters
+   resolve the tier to a concrete model; an adapter with no matching model **errors** — silent
+   substitution is a schema violation (§ 5.4 rule 4).
+3. **`adapters[]` is a registry enum, not a wish list.** `claude-code` is the only registered
+   adapter at v0. A harness may be listed only when a generated adapter artifact exists; the
+   enum grows in lockstep with the registry (E3.11's ratchet). `compatibility` is a GENERATED
+   projection of `adapters[]` + `requires` + `unsupported[]` and is rejected here as an unknown
+   key — it must never be hand-authored into the contract.
+4. **`unsupported[]` fails closed.** Declaring what a harness cannot do (with a reason and a
+   `degradation` that defaults to `fail-closed`) is a stronger honest claim than an untested
+   portability sentence.
+5. **Provenance pins are real.** SPDX-only license expressions; a mirrored skill records the
+   upstream URL and a **resolved 40-hex commit** — a branch name is not a pin.
+6. **Closed everywhere.** `additionalProperties: false` at every level: an unknown key is a
+   contract violation, not an extension point. Extensions go through a schema version bump and,
+   eventually, the kernel.
+
+## Validation
+
+```bash
+node --test scripts/check-canonical-schema.test.mjs
+```
+
+The test suite validates the blueprint § 5.2 example, a minimal contract, and red runs for the
+five failure classes the rules above name (unknown keys, vendor-literal model class,
+unregistered adapter, branch-name pin, harness tool spelling as capability).
+
+## Companions
+
+- `capability-map.json` (E3.3) — the committed vocabulary mapping every corpus tool token to an
+  abstract capability, one parser, one vocabulary.
+- `000-docs/778-RA-DATA-model-agnostic-migration-surface.md` — the measured surface every
+  Epic 3 bead consumes.
+- Blueprint 727 § 5 — the contract's authority; § 5.3 is the field-disposition table for
+  today's frontmatter/agent fields.

--- a/schemas/canonical/v0/skill-contract.schema.json
+++ b/schemas/canonical/v0/skill-contract.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tonsofskills.com/schemas/canonical/v0/skill-contract.schema.json",
+  "title": "Canonical harness-free skill contract (skill-card.yaml)",
+  "$comment": "Status: DRAFT (v0). UPSTREAM-PENDING: this repository must never become its own schema authority — the contract is to be proposed to @intentsolutions/core as the `skill-contract` authoring schema (blueprint 727 Epic 3 bead 3.13; the kernel issue number is recorded in that bead and in 000-docs when filed). Home B of the four-home split (blueprint 727 § 5.1): written by the skill author per behavior change, read by validators, adapter generators, marketplace filters, and security review. The SKILL.md frontmatter (home A) is NOT this contract and keeps the IS 8 unchanged — this file is additive and never touches ALWAYS_REQUIRED.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "version",
+    "intent",
+    "capabilities",
+    "model_class",
+    "lifecycle",
+    "provenance",
+    "adapters"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{0,63}$",
+      "description": "Stable identity; NEVER renamed — install slugs are API."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
+      "description": "The ONE version; display surfaces project from it."
+    },
+    "intent": {
+      "type": "string",
+      "minLength": 10,
+      "description": "What the skill is for. No trigger syntax, no harness verbs."
+    },
+    "inputs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ioPort" }
+    },
+    "outputs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ioPort" }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/capability" },
+      "description": "ABSTRACT capabilities from the committed vocabulary (capability-map.json). Never a harness tool name — `Bash(jq:*)` is a Claude Code expression of `shell.exec`, not a capability."
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "forbid": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$" },
+          "description": "Capabilities this skill must never exercise, portable intent behind disallowed-tools."
+        },
+        "bounded": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max_steps": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "risk_tier": { "enum": ["low", "medium", "high"] }
+      }
+    },
+    "side_effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "writes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path"],
+            "properties": {
+              "path": { "type": "string" },
+              "approx_mb_max": { "type": "number", "exclusiveMinimum": 0 }
+            }
+          }
+        },
+        "network": { "type": "array", "items": { "type": "string" } },
+        "env": { "type": "array", "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" } }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "name"],
+            "properties": {
+              "kind": { "enum": ["mcp", "cli", "api"] },
+              "name": { "type": "string" },
+              "env": {
+                "type": "array",
+                "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "model_class": {
+      "enum": ["reasoning-high", "balanced", "fast"],
+      "description": "NEVER a vendor literal. Adapters resolve the tier to a concrete model; an adapter with no matching model MUST error (fail closed) — silent substitution is a schema violation."
+    },
+    "evaluation": {
+      "type": "string",
+      "description": "Path to the harness-neutral eval-spec.yaml. REQUIRED at certification tier T3+ (enforced by the tier gate, not by this schema)."
+    },
+    "not_for": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Sibling skill ids that should win instead; anti-trigger routing."
+    },
+    "lifecycle": { "enum": ["active", "deprecated", "sunset"] },
+    "superseded_by": { "type": ["string", "null"] },
+    "sunset_on": {
+      "type": ["string", "null"],
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["author", "license", "spdx"],
+      "properties": {
+        "author": { "type": "string", "minLength": 1 },
+        "license": { "type": "string", "minLength": 1 },
+        "spdx": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9.+-]+( (WITH|AND|OR) [A-Za-z0-9.+-]+)*$",
+          "description": "SPDX expression only. \"SEE LICENSE IN LICENSE\" is invalid."
+        },
+        "source": { "type": ["string", "null"], "description": "Upstream repo URL when mirrored." },
+        "source_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "RESOLVED SHA when mirrored — a branch name is not a pin."
+        },
+        "upstream_license": {
+          "type": ["string", "null"],
+          "description": "MUST equal .source.json when mirrored (cross-file check, not expressible here)."
+        }
+      }
+    },
+    "adapters": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["claude-code"] },
+      "description": "Enum from the committed adapter registry — grows ONLY when a generated adapter artifact exists (listing a harness with no artifact fails CI, blueprint E3.11). claude-code is the sole registered adapter at v0."
+    },
+    "unsupported": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["capability", "adapter", "reason", "degradation"],
+        "properties": {
+          "capability": { "type": "string" },
+          "adapter": { "type": "string" },
+          "reason": { "type": "string", "minLength": 1 },
+          "degradation": {
+            "enum": ["fail-closed", "skip", "prompt-in-band"],
+            "default": "fail-closed"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "ioPort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-z][a-z0-9_-]*$" },
+        "type": { "type": "string" },
+        "required": { "type": "boolean" },
+        "schema": { "type": "string" }
+      }
+    },
+    "capability": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_.]*$",
+          "$comment": "Bare capability token, e.g. filesystem.read, user.prompt."
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "maxProperties": 1,
+          "propertyNames": { "pattern": "^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_.]*$" },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "paths": { "type": "array", "items": { "type": "string" } },
+              "commands": { "type": "array", "items": { "type": "string" } },
+              "hosts": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "$comment": "Scoped capability, e.g. shell.exec: { commands: [jq, date] }."
+        }
+      ]
+    }
+  }
+}

--- a/scripts/check-canonical-schema.test.mjs
+++ b/scripts/check-canonical-schema.test.mjs
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const schema = JSON.parse(
+  readFileSync(
+    new URL('../schemas/canonical/v0/skill-contract.schema.json', import.meta.url),
+    'utf-8',
+  ),
+);
+const ajv = new Ajv2020.default({ strict: true, allErrors: true });
+const validate = ajv.compile(schema);
+
+// The blueprint § 5.2 example, expressed as the JSON the YAML parses to.
+const EXAMPLE = {
+  id: 'plane',
+  version: '0.3.0',
+  intent: 'Synthesize project-tracker data into observations about team behavior.',
+  inputs: [{ name: 'project', type: 'string', required: true }],
+  outputs: [{ name: 'report', type: 'markdown', schema: './schemas/report.json' }],
+  capabilities: [
+    'filesystem.read',
+    { 'filesystem.write': { paths: ['./out/**'] } },
+    { 'shell.exec': { commands: ['jq', 'date'] } },
+    { 'network.http': { hosts: ['api.plane.so'] } },
+    'user.prompt',
+  ],
+  constraints: {
+    forbid: ['filesystem.write.dotenv', 'shell.exec.rm', 'network.exfil'],
+    bounded: { max_steps: 40 },
+    risk_tier: 'medium',
+  },
+  side_effects: {
+    writes: [{ path: './out/**', approx_mb_max: 5 }],
+    network: ['api.plane.so'],
+    env: ['PLANE_API_KEY'],
+  },
+  requires: { services: [{ kind: 'mcp', name: 'plane', env: ['PLANE_API_KEY'] }] },
+  model_class: 'balanced',
+  evaluation: './eval-spec.yaml',
+  not_for: ['plane-admin-migration'],
+  lifecycle: 'active',
+  superseded_by: null,
+  sunset_on: null,
+  provenance: {
+    author: 'Name <email>',
+    license: 'MIT',
+    spdx: 'MIT',
+    source: null,
+    source_commit: null,
+    upstream_license: null,
+  },
+  adapters: ['claude-code'],
+  unsupported: [
+    {
+      capability: 'user.prompt',
+      adapter: 'codex',
+      reason: 'no interactive-confirmation primitive',
+      degradation: 'fail-closed',
+    },
+  ],
+};
+
+const withPatch = (patch) => JSON.parse(JSON.stringify({ ...EXAMPLE, ...patch }));
+
+test('the blueprint § 5.2 example validates', () => {
+  const ok = validate(EXAMPLE);
+  assert.ok(ok, JSON.stringify(validate.errors, null, 2));
+});
+
+test('red run — an unknown top-level key is rejected (closed schema)', () => {
+  assert.equal(validate(withPatch({ compatibility: 'Claude Code only' })), false);
+  assert.equal(validate(withPatch({ metadata: {} })), false);
+});
+
+test('red run — a vendor literal cannot be a model class', () => {
+  for (const literal of ['claude-sonnet-4', 'claude-fable-5', 'gpt-5', 'sonnet']) {
+    assert.equal(validate(withPatch({ model_class: literal })), false, literal);
+  }
+});
+
+test('red run — a harness with no registered adapter artifact is rejected', () => {
+  for (const bogus of [['codex'], ['claude-code', 'openclaw'], []]) {
+    assert.equal(validate(withPatch({ adapters: bogus })), false, JSON.stringify(bogus));
+  }
+});
+
+test('red run — a branch name is not a mirror pin', () => {
+  const p = withPatch({});
+  p.provenance.source = 'https://github.com/x/y';
+  p.provenance.source_commit = 'main';
+  assert.equal(validate(p), false);
+  p.provenance.source_commit = 'a'.repeat(40);
+  assert.ok(validate(p), JSON.stringify(validate.errors));
+});
+
+test('red run — harness tool spellings are not capabilities', () => {
+  for (const notACapability of ['Bash(jq:*)', 'mcp__plane__query', 'Read']) {
+    assert.equal(validate(withPatch({ capabilities: [notACapability] })), false, notACapability);
+  }
+});
+
+test('red run — unsupported entries require reason and degradation', () => {
+  const p = withPatch({});
+  p.unsupported = [{ capability: 'user.prompt', adapter: 'codex' }];
+  assert.equal(validate(p), false);
+});
+
+test('minimal contract: only the required seven fields', () => {
+  const minimal = {
+    id: 'tiny',
+    version: '1.0.0',
+    intent: 'Do one small portable thing.',
+    capabilities: ['filesystem.read'],
+    model_class: 'fast',
+    lifecycle: 'active',
+    provenance: { author: 'A <a@b.c>', license: 'MIT', spdx: 'MIT' },
+    adapters: ['claude-code'],
+  };
+  assert.ok(validate(minimal), JSON.stringify(validate.errors, null, 2));
+});


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 3 bead E3.2** (bead `claude-t9s9.2`, § 5.2): `schemas/canonical/v0/skill-contract.schema.json` — the harness-free `skill-card.yaml` machine contract (home B of the § 5.1 four-home split) — plus its prose companion and an 8-test suite wired as `validate:canonical-schema` in `doc-governance`.

## Why + decision rationale
Portability claims must be facts, not sentences: the contract encodes abstract capabilities (never harness tool spellings), `model_class` tiers (never vendor literals — resolution failure errors, § 5.4 rule 4), registry-enum `adapters[]` (`claude-code` only at v0 — listing an artifact-less harness is a schema violation TODAY, not a ratchet exception later), `unsupported[]` with fail-closed default, SPDX-only provenance with resolved-40-hex mirror pins, and `compatibility` rejected as an unknown key (generated projection, never hand-authored). **`ALWAYS_REQUIRED` untouched** — home A keeps the IS 8; this is additive.

## Upstream posture
DRAFT + UPSTREAM-PENDING in the schema `$comment` and companion: the kernel proposal to `@intentsolutions/core` is E3.13's deliverable — this repo never becomes its own schema authority.

## Verification (evidence)
`pnpm run validate:canonical-schema` — **8/8**: the § 5.2 example + a minimal contract validate; red runs for five failure classes (unknown key incl. hand-authored compatibility; vendor-literal model class incl. `claude-fable-5`/`gpt-5`; unregistered adapter; branch-name pin vs 40-hex; `Bash(jq:*)`/`mcp__*` as capability). Ajv 2020 strict compile. `check-doc-classes` allow=true · docs index 220 · `measure-epic-1 --check` OK · hosted CI final.

## Risk / rollback
New artifact + gate, nothing consumes it yet (E3.4/E3.5/E3.10/E3.11 build on it); focused revert.

## Follow-up & deferred
E3.3 capability vocabulary (next activation) · E3.13 kernel proposal.

Refs: blueprint 000-docs/727 § 5 + § 13 E3.2, bead claude-t9s9.2, AAR 000-docs/779.