### PR TITLE
fix(docs-governance): close three contract holes in the canonical schema

### DIFF
--- a/schemas/canonical/v0/skill-contract.schema.json
+++ b/schemas/canonical/v0/skill-contract.schema.json
@@ -133,9 +133,8 @@
         "author": { "type": "string", "minLength": 1 },
         "license": { "type": "string", "minLength": 1 },
         "spdx": {
-          "type": "string",
-          "pattern": "^[A-Za-z0-9.+-]+( (WITH|AND|OR) [A-Za-z0-9.+-]+)*$",
-          "description": "SPDX expression only. \"SEE LICENSE IN LICENSE\" is invalid."
+          "$ref": "#/$defs/spdxExpression",
+          "description": "SPDX expression over the registered vocabulary only. \"SEE LICENSE IN LICENSE\" and invented token-shaped values are invalid; a genuinely custom license uses LicenseRef-<name>."
         },
         "source": { "type": ["string", "null"], "description": "Upstream repo URL when mirrored." },
         "source_commit": {
@@ -147,6 +146,18 @@
           "type": ["string", "null"],
           "description": "MUST equal .source.json when mirrored (cross-file check, not expressible here)."
         }
+      },
+      "if": {
+        "properties": { "source": { "type": "string" } },
+        "required": ["source"]
+      },
+      "then": {
+        "$comment": "A mirrored contract (non-null source) MUST pin the resolved commit and record the upstream license — mutable upstream provenance is exactly what the lockfile threat model forbids.",
+        "properties": {
+          "source_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+          "upstream_license": { "type": "string", "minLength": 1 }
+        },
+        "required": ["source_commit", "upstream_license"]
       }
     },
     "adapters": {
@@ -161,20 +172,62 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["capability", "adapter", "reason", "degradation"],
+        "required": ["capability", "adapter", "reason"],
         "properties": {
           "capability": { "type": "string" },
           "adapter": { "type": "string" },
           "reason": { "type": "string", "minLength": 1 },
           "degradation": {
             "enum": ["fail-closed", "skip", "prompt-in-band"],
-            "default": "fail-closed"
+            "default": "fail-closed",
+            "$comment": "Optional so the documented fail-closed default can actually apply: an omitted degradation MEANS fail-closed (consumers compile with useDefaults or treat absence as fail-closed). Requiring it made the default unreachable."
           }
         }
       }
     }
   },
   "$defs": {
+    "spdxId": {
+      "$comment": "The v0 registered license vocabulary — the ids present in this corpus plus the SPDX LicenseRef- extension shape for genuinely custom licenses. An invented token-shaped value (e.g. MadeUpLicense) is rejected; growing this list is a schema change, reviewed like one.",
+      "anyOf": [
+        {
+          "enum": [
+            "MIT",
+            "Apache-2.0",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "ISC",
+            "GPL-2.0-only",
+            "GPL-2.0-or-later",
+            "GPL-3.0-only",
+            "GPL-3.0-or-later",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only",
+            "AGPL-3.0-only",
+            "AGPL-3.0-or-later",
+            "MPL-2.0",
+            "Unlicense",
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            "0BSD",
+            "Zlib"
+          ]
+        },
+        { "type": "string", "pattern": "^LicenseRef-[A-Za-z0-9.-]+$" }
+      ]
+    },
+    "spdxExpression": {
+      "$comment": "A single id, or a binary expression over ids. Nested parenthesized expressions are out of v0 scope — use LicenseRef- for exotic terms.",
+      "anyOf": [
+        { "$ref": "#/$defs/spdxId" },
+        {
+          "type": "string",
+          "pattern": "^\\S+( (WITH|AND|OR) \\S+)+$",
+          "$comment": "Expression shape; each operand is checked by the gate layer against the same vocabulary (JSON Schema cannot split-and-check operands)."
+        }
+      ]
+    },
     "ioPort": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/check-canonical-schema.test.mjs
+++ b/scripts/check-canonical-schema.test.mjs
@@ -89,9 +89,41 @@ test('red run — a harness with no registered adapter artifact is rejected', ()
 test('red run — a branch name is not a mirror pin', () => {
   const p = withPatch({});
   p.provenance.source = 'https://github.com/x/y';
+  p.provenance.upstream_license = 'MIT';
   p.provenance.source_commit = 'main';
   assert.equal(validate(p), false);
   p.provenance.source_commit = 'a'.repeat(40);
+  assert.ok(validate(p), JSON.stringify(validate.errors));
+});
+
+test('red run — a mirrored contract cannot omit its pin or upstream license', () => {
+  const p = withPatch({});
+  p.provenance.source = 'https://github.com/x/y';
+  p.provenance.source_commit = null;
+  p.provenance.upstream_license = 'MIT';
+  assert.equal(validate(p), false, 'null source_commit with non-null source must fail');
+  p.provenance.source_commit = 'a'.repeat(40);
+  p.provenance.upstream_license = null;
+  assert.equal(validate(p), false, 'null upstream_license with non-null source must fail');
+  // and a non-mirrored contract (null source) keeps nulls legal
+  p.provenance.source = null;
+  p.provenance.source_commit = null;
+  assert.ok(validate(p), JSON.stringify(validate.errors));
+});
+
+test('red run — an invented token-shaped SPDX id is rejected', () => {
+  const p = withPatch({});
+  p.provenance.spdx = 'MadeUpLicense';
+  assert.equal(validate(p), false);
+  p.provenance.spdx = 'LicenseRef-IntentSolutions-Proprietary';
+  assert.ok(validate(p), JSON.stringify(validate.errors));
+  p.provenance.spdx = 'Apache-2.0 WITH LLVM-exception';
+  assert.ok(validate(p), JSON.stringify(validate.errors));
+});
+
+test('an omitted degradation is legal and means fail-closed', () => {
+  const p = withPatch({});
+  p.unsupported = [{ capability: 'user.prompt', adapter: 'codex', reason: 'no primitive' }];
   assert.ok(validate(p), JSON.stringify(validate.errors));
 });
 
@@ -101,7 +133,7 @@ test('red run — harness tool spellings are not capabilities', () => {
   }
 });
 
-test('red run — unsupported entries require reason and degradation', () => {
+test('red run — unsupported entries require a reason', () => {
   const p = withPatch({});
   p.unsupported = [{ capability: 'user.prompt', adapter: 'codex' }];
   assert.equal(validate(p), false);


### PR DESCRIPTION
## What
Fixes all three Greptile P1s on merged PR #1266 (the E3.2 canonical skill contract): a conditional mirror-pin requirement (non-null `source` ⇒ 40-hex `source_commit` + non-null `upstream_license`), a registered SPDX vocabulary (v0 enum + `LicenseRef-*`; invented token-shaped ids rejected), and an actually-usable fail-closed default (`degradation` optional; absence means fail-closed).

## Why one-line
All three were validate-but-shouldn't holes in a contract whose whole purpose is that claims are machine-checkable; chose a closed license enum over the full SPDX list so vocabulary growth is a reviewed schema change.

## Verification
`validate:canonical-schema` 11/11 including three new red runs (null pin with non-null source; `MadeUpLicense` rejected while `LicenseRef-…` and `Apache-2.0 WITH LLVM-exception` accepted; omitted degradation legal) · hosted CI final.

Refs: PR #1266 review threads, blueprint 000-docs/727 § 5.2, bead claude-t9s9.2.