### PR TITLE
feat(docs-governance): publish the capability vocabulary with total corpus coverage

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1603,6 +1603,13 @@ jobs:
       - name: Check the canonical skill-contract schema
         run: pnpm run validate:canonical-schema
 
+      # Capability-vocabulary coverage (blueprint 727 E3.3): every tool token
+      # in every tracked SKILL.md/agent allowlist must map to an abstract
+      # capability through the ONE shared parser, or carry an enumerated
+      # disposition. An unmapped token fails, naming file and token.
+      - name: Check capability-vocabulary coverage
+        run: pnpm run validate:capability-coverage
+
       # 6767-h is a frozen historical standard that remains cited by schemas.
       # Pin its section map and prove every cited heading still resolves.
       - name: Check frozen prose anchors remain valid

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -75,3 +75,4 @@
 !778-RA-DATA-model-agnostic-migration-surface.md
 !778-RA-DATA-model-agnostic-migration-surface.json
 !779-AA-AACR-epic-3-canonical-skill-contract.md
+!780-AA-AACR-epic-3-capability-vocabulary.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (220 files). Local-only working
+Covers the **tracked** documentation estate (221 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -202,6 +202,7 @@ index and `000-docs/.gitignore`.
 - [778-RA-DATA-model-agnostic-migration-surface.json](778-RA-DATA-model-agnostic-migration-surface.json)
 - [778-RA-DATA-model-agnostic-migration-surface.md](778-RA-DATA-model-agnostic-migration-surface.md)
 - [779-AA-AACR-epic-3-canonical-skill-contract.md](779-AA-AACR-epic-3-canonical-skill-contract.md)
+- [780-AA-AACR-epic-3-capability-vocabulary.md](780-AA-AACR-epic-3-capability-vocabulary.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23118
+        "tracked_files": 23123
       }
     },
     "2": {
@@ -1949,10 +1949,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 220,
+        "index_entries": 221,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 220,
+        "tracked_documents": 221,
         "untracked_index_entries": []
       }
     },
@@ -1976,9 +1976,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15576,
+        "invisible_files": 15578,
         "target_invisible_files": 0,
-        "tracked_files": 23118
+        "tracked_files": 23123
       }
     },
     "47": {

--- a/000-docs/780-AA-AACR-epic-3-capability-vocabulary.md
+++ b/000-docs/780-AA-AACR-epic-3-capability-vocabulary.md
@@ -1,0 +1,63 @@
+<!-- doc-class: record -->
+
+# Epic 3 Capability Vocabulary — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 3 bead 3.3
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-t9s9.3`
+- **Implementation PR:** [#1268](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1268)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E3.3 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The capability vocabulary exists, and coverage over the live corpus is **total and
+gate-enforced**: `scripts/check-capability-coverage.mjs` sweeps every tracked `SKILL.md` and
+agent definition, parses all four tool-list fields with a real YAML parser, tokenizes through
+the ONE shared parser, and reports **30,323 tokens across 5,904 allowlist-bearing files (of
+5,949 targets) all covered, zero unparseable frontmatter** — wired as
+`validate:capability-coverage` in `doc-governance` (blocks via `ci-required`).
+
+Deliverables:
+
+1. **`scripts/lib/tool-token-parser.mjs`** — THE parser ("one parser, one vocabulary"). Token
+   shapes: `builtin` (with `Bash(...)` scopes; scope-internal commas never split),
+   `mcp` (`mcp__server[__tool]`), `namespaced` (`ns:tool` custom platform names), `unknown`
+   (never silently accepted). Consumers named in the header: E3.4, E3.5, E3.10, E4.2.
+2. **`schemas/canonical/v0/capability-map.json`** — 15 abstract capabilities; 20 builtin
+   mappings (including `Monitor`/`TaskStop`/`TaskOutput` → `agent.control`, discovered by the
+   sweep); shape rules for `mcp` → `service.mcp` and `namespaced` → `service.custom`; and an
+   enumerated `dispositions.tolerated` set.
+3. **The unknown-token disposition.** All six tolerated tokens live in `.source.json` mirror
+   subtrees — `hermes-tweet`'s bare custom tool names and `claude-workflow-skills`'
+   space-separated legacy lists — where the never-clobber rule forbids local edits; repair flows
+   by upstreaming. An unknown token NOT enumerated fails the gate, naming file and token.
+
+## Jurisdiction boundary
+
+Frontmatter that YAML cannot parse is counted and skipped, not failed here: structural
+allowlist validity is the schema validator's jurisdiction (E1.11 made it an ERROR there).
+Double-reporting the same defect would create two owners for one fact — the sweep reported
+**zero** such files at filing.
+
+## Verification
+
+- `pnpm run validate:capability-coverage` — parser + coverage tests 7/7 (shape classification,
+  scope-comma safety, YAML-list flattening, red runs for unmapped builtin and undispositioned
+  unknown, disposition/shape coverage, all-four-fields sweep) and the live corpus sweep OK.
+- Hosted CI on the implementation PR is the final gate.
+
+## Scope discipline
+
+No SKILL.md, agent file, mirror file, or catalog entry changed — measurement and vocabulary
+only. The two upstream-shape repairs (hermes-tweet, claude-workflow-skills) are candidates for
+respectful upstreaming per the external-sync model, never local edits.
+
+## Follow-up
+
+- E3.4 extends the contract schema with the adapters/compatibility generator consuming this
+  vocabulary; E3.5/E3.10 build their gates on the same parser; Epic 4's E4.2 consumes the
+  vocabulary for the runtime-safety boundary.
+- The `service.custom` namespace class (`triage:*` etc.) carries Epic 4's per-pack
+  runtime-safety review as its disposition.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "validate:doc-fact-assertions": "node --test scripts/check-doc-fact-assertions.test.mjs && node scripts/check-doc-fact-assertions.mjs",
     "validate:readme-contract": "node --test scripts/check-readme-contract.test.mjs && node scripts/check-readme-contract.mjs",
     "validate:canonical-schema": "node --test scripts/check-canonical-schema.test.mjs",
+    "validate:capability-coverage": "node --test scripts/check-capability-coverage.test.mjs && node scripts/check-capability-coverage.mjs",
     "verify": "node scripts/run-verification-pipeline.mjs",
     "lint:root": "eslint .",
     "lint:design": "node scripts/lint-design-tells.mjs",

--- a/schemas/canonical/v0/capability-map.json
+++ b/schemas/canonical/v0/capability-map.json
@@ -1,0 +1,64 @@
+{
+  "$comment": "Capability vocabulary v0 (blueprint 727, Epic 3 bead 3.3). Maps every tool token shape in the corpus to an abstract capability from the canonical contract (skill-contract.schema.json). ONE parser owns tokenization: scripts/lib/tool-token-parser.mjs — a gate that parses tool tokens any other way is the anti-pattern this file ends. Coverage is enforced by scripts/check-capability-coverage.mjs: a token that neither maps here nor appears in dispositions fails CI. UPSTREAM-PENDING alongside the skill contract (kernel proposal is E3.13).",
+  "version": "0.1.0",
+  "capabilities": {
+    "filesystem.read": "Read file contents",
+    "filesystem.search": "Search file contents and names",
+    "filesystem.glob": "Enumerate files by pattern",
+    "filesystem.write": "Create or overwrite files",
+    "filesystem.edit": "Modify existing files in place",
+    "shell.exec": "Execute shell commands (scoped by command list)",
+    "network.http": "Fetch remote resources over HTTP(S)",
+    "network.search": "Query a web search service",
+    "user.prompt": "Ask the operating user a question and wait",
+    "agent.spawn": "Launch subagents or delegated tasks",
+    "task.plan": "Maintain a task/plan list",
+    "skill.invoke": "Invoke another packaged skill",
+    "service.mcp": "Call a named MCP server (scoped by server name)",
+    "service.custom": "Call a platform-specific named tool a pack declares (scoped by namespace)",
+    "agent.control": "Monitor, resume, or stop background tasks"
+  },
+  "builtins": {
+    "Read": "filesystem.read",
+    "Grep": "filesystem.search",
+    "Glob": "filesystem.glob",
+    "Write": "filesystem.write",
+    "Edit": "filesystem.edit",
+    "NotebookEdit": "filesystem.edit",
+    "Bash": "shell.exec",
+    "BashOutput": "shell.exec",
+    "KillBash": "shell.exec",
+    "WebFetch": "network.http",
+    "WebSearch": "network.search",
+    "AskUserQuestion": "user.prompt",
+    "Task": "agent.spawn",
+    "Agent": "agent.spawn",
+    "TodoWrite": "task.plan",
+    "Skill": "skill.invoke",
+    "SlashCommand": "skill.invoke",
+    "Monitor": "agent.control",
+    "TaskStop": "agent.control",
+    "TaskOutput": "agent.control"
+  },
+  "shapes": {
+    "mcp": {
+      "capability": "service.mcp",
+      "$comment": "mcp__<server>[__<tool>] maps to service.mcp scoped by server name; the canonical contract records it as requires.services[{kind: mcp, name: <server>}]."
+    },
+    "namespaced": {
+      "capability": "service.custom",
+      "$comment": "<ns>:<tool> custom platform tool names map to service.custom scoped by namespace, pending Epic 4's per-pack runtime-safety review."
+    }
+  },
+  "dispositions": {
+    "$comment": "Enumerated corpus tokens that parse as 'unknown' — each carries a reason. Every entry below lives in a .source.json mirror subtree: mirror files are upstream-owned and never edited locally (the never-clobber rule), so their shapes are tolerated here and any repair flows by upstreaming. An unknown token NOT listed here fails the coverage gate.",
+    "tolerated": {
+      "tweet_explore": "hermes-tweet mirror: upstream declares bare custom tool names; maps conceptually to service.custom, repair upstream-only",
+      "tweet_read": "hermes-tweet mirror: upstream declares bare custom tool names; maps conceptually to service.custom, repair upstream-only",
+      "tweet_action": "hermes-tweet mirror: upstream declares bare custom tool names; maps conceptually to service.custom, repair upstream-only",
+      "Read Glob Grep Bash": "claude-workflow-skills mirror: upstream uses space-separated tool lists; every member is a mapped builtin, repair upstream-only",
+      "Read Glob Grep Bash WebSearch WebFetch": "claude-workflow-skills mirror: space-separated legacy shape; every member is a mapped builtin, repair upstream-only",
+      "Read Glob Grep Bash Edit Write": "claude-workflow-skills mirror: space-separated legacy shape; every member is a mapped builtin, repair upstream-only"
+    }
+  }
+}

--- a/scripts/check-capability-coverage.mjs
+++ b/scripts/check-capability-coverage.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * check-capability-coverage.mjs — every tool token in the corpus maps to an
+ * abstract capability (blueprint 727, Epic 3 bead 3.3).
+ *
+ * Sweeps every tracked SKILL.md and agent definition, parses the four
+ * tool-list fields (`allowed-tools`, `disallowed-tools` on skills; `tools`,
+ * `disallowedTools` on agents) with a REAL YAML parser, tokenizes through the
+ * single shared parser (scripts/lib/tool-token-parser.mjs), and asserts:
+ *
+ *   builtin     → must be a key in capability-map.json `builtins`
+ *   mcp         → covered by the `shapes.mcp` rule
+ *   namespaced  → covered by the `shapes.namespaced` rule
+ *   unknown     → must appear in `dispositions.tolerated` with a reason;
+ *                 otherwise this gate FAILS, naming file and token
+ *
+ * Frontmatter that js-yaml cannot parse is skipped here — structural
+ * frontmatter validity is the schema validator's jurisdiction (E1.11 made an
+ * unparseable allowlist an ERROR there); this gate owns vocabulary coverage,
+ * not YAML hygiene, and double-reporting the same defect creates two owners
+ * for one fact.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import yaml from 'js-yaml';
+import { parseTokenList } from './lib/tool-token-parser.mjs';
+
+const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
+
+const MAP = JSON.parse(
+  readFileSync(join(ROOT, 'schemas', 'canonical', 'v0', 'capability-map.json'), 'utf-8'),
+);
+
+const FIELDS = ['allowed-tools', 'disallowed-tools', 'tools', 'disallowedTools'];
+
+export function coverageForFrontmatter(fm, map = MAP) {
+  const uncovered = [];
+  const counts = { builtin: 0, mcp: 0, namespaced: 0, tolerated: 0 };
+  for (const field of FIELDS) {
+    if (!(field in (fm ?? {}))) continue;
+    for (const token of parseTokenList(fm[field])) {
+      if (token.kind === 'builtin') {
+        if (map.builtins[token.name]) counts.builtin += 1;
+        else
+          uncovered.push({
+            field,
+            raw: token.raw,
+            why: `builtin "${token.name}" not in capability map`,
+          });
+      } else if (token.kind === 'mcp' || token.kind === 'namespaced') {
+        counts[token.kind] += 1;
+      } else if (map.dispositions?.tolerated?.[token.raw]) {
+        counts.tolerated += 1;
+      } else {
+        uncovered.push({ field, raw: token.raw, why: 'unknown token with no disposition' });
+      }
+    }
+  }
+  return { uncovered, counts };
+}
+
+function trackedTargets() {
+  const files = execFileSync('git', ['ls-files'], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 256 * 1024 * 1024,
+  })
+    .split('\n')
+    .filter(Boolean);
+  return files.filter(
+    (f) =>
+      /(^|\/)SKILL\.md$/.test(f) ||
+      (f.startsWith('plugins/') && /\/agents\/[^/]+\.md$/.test(f)) ||
+      /^\.claude\/agents\/[^/]+\.md$/.test(f),
+  );
+}
+
+export function sweep() {
+  const violations = [];
+  const totals = { files: 0, bearing: 0, tokens: 0, unparseableFrontmatter: 0 };
+  for (const file of trackedTargets()) {
+    totals.files += 1;
+    let text;
+    try {
+      text = readFileSync(join(ROOT, file), 'utf-8');
+    } catch {
+      continue;
+    }
+    const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!m) continue;
+    let fm;
+    try {
+      fm = yaml.load(m[1]);
+    } catch {
+      totals.unparseableFrontmatter += 1; // the validator's jurisdiction
+      continue;
+    }
+    if (!fm || typeof fm !== 'object') continue;
+    if (!FIELDS.some((f) => f in fm)) continue;
+    totals.bearing += 1;
+    const { uncovered, counts } = coverageForFrontmatter(fm);
+    totals.tokens +=
+      counts.builtin + counts.mcp + counts.namespaced + counts.tolerated + uncovered.length;
+    for (const u of uncovered) violations.push({ file, ...u });
+  }
+  return { violations, totals };
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  const { violations, totals } = sweep();
+  for (const v of violations) {
+    console.error(`capability-coverage: VIOLATION — ${v.file} [${v.field}] "${v.raw}": ${v.why}`);
+  }
+  if (violations.length > 0) {
+    console.error(
+      `capability-coverage: FAIL — ${violations.length} uncovered token(s). Map the builtin, or add a dispositions.tolerated entry with a reason.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `capability-coverage: OK (${totals.bearing} allowlist-bearing files of ${totals.files}; ${totals.tokens} tokens all covered; ${totals.unparseableFrontmatter} unparseable frontmatter left to the validator)`,
+  );
+}

--- a/scripts/check-capability-coverage.test.mjs
+++ b/scripts/check-capability-coverage.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseToken, parseTokenList, splitTokenList } from './lib/tool-token-parser.mjs';
+import { coverageForFrontmatter } from './check-capability-coverage.mjs';
+
+test('the parser classifies every corpus token shape', () => {
+  assert.deepEqual(parseToken('Read'), { kind: 'builtin', name: 'Read', scope: null, raw: 'Read' });
+  assert.deepEqual(parseToken('Bash(jq:*, date:*)'), {
+    kind: 'builtin',
+    name: 'Bash',
+    scope: ['jq:*', 'date:*'],
+    raw: 'Bash(jq:*, date:*)',
+  });
+  assert.deepEqual(parseToken('mcp__plane__create_issue'), {
+    kind: 'mcp',
+    name: 'plane',
+    tool: 'create_issue',
+    raw: 'mcp__plane__create_issue',
+  });
+  assert.equal(parseToken('mcp__plane').tool, null);
+  assert.deepEqual(parseToken('triage:fetch_mentions'), {
+    kind: 'namespaced',
+    name: 'triage',
+    tool: 'fetch_mentions',
+    raw: 'triage:fetch_mentions',
+  });
+  assert.equal(parseToken('tweet_explore').kind, 'unknown');
+  assert.equal(parseToken('Read Glob Grep Bash').kind, 'unknown');
+});
+
+test('commas inside Bash scopes never split the token', () => {
+  const tokens = splitTokenList('Read, Bash(git add:*, git commit:*), Write');
+  assert.deepEqual(tokens, ['Read', 'Bash(git add:*, git commit:*)', 'Write']);
+  assert.equal(parseTokenList('Read, Bash(a,b)').length, 2);
+});
+
+test('YAML list values flatten through the same parser', () => {
+  const tokens = parseTokenList(['Read', 'Bash(npm:*)', 'mcp__x__y']);
+  assert.deepEqual(
+    tokens.map((t) => t.kind),
+    ['builtin', 'builtin', 'mcp'],
+  );
+});
+
+test('red run — an unmapped builtin is uncovered', () => {
+  const { uncovered } = coverageForFrontmatter({ 'allowed-tools': 'Read, FutureTool' });
+  assert.equal(uncovered.length, 1);
+  assert.match(uncovered[0].why, /FutureTool/);
+});
+
+test('red run — an unknown token without a disposition is uncovered', () => {
+  const { uncovered } = coverageForFrontmatter({ tools: ['completely_novel_thing'] });
+  assert.equal(uncovered.length, 1);
+  assert.match(uncovered[0].why, /no disposition/);
+});
+
+test('dispositioned mirror shapes and shape-mapped kinds are covered', () => {
+  const { uncovered, counts } = coverageForFrontmatter({
+    'allowed-tools': ['tweet_explore', 'triage:lookup_oncall', 'mcp__plane__query', 'Bash(jq:*)'],
+  });
+  assert.deepEqual(uncovered, []);
+  assert.equal(counts.tolerated, 1);
+  assert.equal(counts.namespaced, 1);
+  assert.equal(counts.mcp, 1);
+  assert.equal(counts.builtin, 1);
+});
+
+test('all four tool fields are swept, skills and agents alike', () => {
+  const fm = {
+    'allowed-tools': 'Read',
+    'disallowed-tools': 'Write',
+    tools: ['Grep'],
+    disallowedTools: ['Bash(rm:*)'],
+  };
+  const { uncovered, counts } = coverageForFrontmatter(fm);
+  assert.deepEqual(uncovered, []);
+  assert.equal(counts.builtin, 4);
+});

--- a/scripts/lib/tool-token-parser.mjs
+++ b/scripts/lib/tool-token-parser.mjs
@@ -1,0 +1,74 @@
+/**
+ * tool-token-parser.mjs — THE tool-token parser (blueprint 727, Epic 3 bead
+ * 3.3: "one parser, one vocabulary").
+ *
+ * Every gate that reads a tool allowlist/denylist token — the capability
+ * coverage check (E3.3), the adapter derive-check (E3.4), the thinness gate
+ * (E3.5), the canonical vendor-literal gate (E3.10), and Epic 4's
+ * runtime-safety gate (E4.2) — parses through THIS module. A second parser is
+ * the anti-pattern this bead exists to end.
+ *
+ * A token parses to { kind, name, scope }:
+ *   kind 'builtin'    name 'Bash'|'Read'|…     scope: the Bash(...) inner text
+ *                                              split on commas, or null
+ *   kind 'mcp'        name 'server' , tool     mcp__server__tool / mcp__server
+ *   kind 'namespaced' name 'ns' , tool         ns:tool — custom platform tool
+ *                                              names some packs declare
+ *   kind 'unknown'    name: raw                anything else — NEVER silently
+ *                                              accepted; callers must fail or
+ *                                              disposition it
+ */
+
+const BUILTIN_SHAPE = /^([A-Z][A-Za-z]*)(?:\((.*)\))?$/;
+const MCP_SHAPE = /^mcp__([A-Za-z0-9_-]+?)(?:__([A-Za-z0-9_-]+))?$/;
+const NAMESPACED_SHAPE = /^([a-z][a-z0-9_-]*):([a-z][a-z0-9_]*)$/;
+
+/** Split a CSV or YAML-list-derived allowlist string into raw tokens. */
+export function splitTokenList(value) {
+  if (Array.isArray(value)) return value.flatMap(splitTokenList);
+  if (typeof value !== 'string') return [];
+  // Commas inside Bash(...) scopes must not split the token.
+  const tokens = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of value) {
+    if (ch === '(') depth += 1;
+    if (ch === ')') depth = Math.max(0, depth - 1);
+    if (ch === ',' && depth === 0) {
+      if (current.trim()) tokens.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) tokens.push(current.trim());
+  return tokens;
+}
+
+export function parseToken(raw) {
+  const token = String(raw).trim();
+  const mcp = token.match(MCP_SHAPE);
+  if (mcp) {
+    return { kind: 'mcp', name: mcp[1], tool: mcp[2] ?? null, raw: token };
+  }
+  const namespaced = token.match(NAMESPACED_SHAPE);
+  if (namespaced) {
+    return { kind: 'namespaced', name: namespaced[1], tool: namespaced[2], raw: token };
+  }
+  const builtin = token.match(BUILTIN_SHAPE);
+  if (builtin) {
+    const scope =
+      builtin[2] === undefined
+        ? null
+        : builtin[2]
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+    return { kind: 'builtin', name: builtin[1], scope, raw: token };
+  }
+  return { kind: 'unknown', name: token, raw: token };
+}
+
+export function parseTokenList(value) {
+  return splitTokenList(value).map(parseToken);
+}


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 3 bead E3.3** (bead `claude-t9s9.3`): the capability vocabulary + the ONE shared tool-token parser + a corpus-total coverage gate. Live sweep: **30,323 tokens across 5,904 allowlist-bearing files, all covered, zero unparseable frontmatter.**

## Why + decision rationale
"One parser, one vocabulary": every later gate (E3.4 adapter derive-check, E3.5 thinness, E3.10 vendor-literal, Epic 4's E4.2 runtime-safety) tokenizes through `scripts/lib/tool-token-parser.mjs` — a second parser is the anti-pattern this bead ends. Chose corpus-total coverage with enumerated dispositions over first-party-only scope because the acceptance is every token; the six tolerated unknowns all live in `.source.json` mirror subtrees where never-clobber forbids local repair (hermes-tweet bare custom tool names; claude-workflow-skills space-separated legacy lists) — repair flows by upstreaming.

## How it works
- Parser shapes: `builtin` (scope-comma-safe `Bash(...)`), `mcp`, `namespaced` `ns:tool`, `unknown` (never silently accepted)
- `schemas/canonical/v0/capability-map.json`: 15 abstract capabilities, 20 builtin mappings (the sweep itself discovered `Monitor`/`TaskStop`/`TaskOutput` → `agent.control`), shape rules, enumerated dispositions
- `check-capability-coverage.mjs` (real YAML parsing over all four tool fields, skills + agents) wired as `validate:capability-coverage` in `doc-governance`; unparseable frontmatter stays the schema validator's jurisdiction (one owner per fact, E1.11)

## Verification (evidence)
Tests **7/7** incl. red runs (unmapped builtin; undispositioned unknown) · live sweep OK at the numbers above · `check-doc-classes` allow=true · docs index 221 · `measure-epic-1 --check` OK · hosted CI final

## Risk / rollback
Additive vocabulary + gate; focused revert. Zero corpus mutation.

## Follow-up & deferred
E3.4 (adapters/compatibility generator over this vocabulary) next; upstreaming candidates for the two mirror shapes per the external-sync model.

Refs: blueprint 000-docs/727 § 13 E3.3, bead claude-t9s9.3, AAR 000-docs/780.