### PR TITLE
feat(docs-governance): gate adapter thinness with a dated Kobiton waiver

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1618,6 +1618,14 @@ jobs:
       - name: Check model-id classifier protections
         run: pnpm run validate:model-id-classifier
 
+      # Thin-adapter conformance (blueprint 727 E3.5): an adapter subtree may
+      # never contain a byte-identical copy of a canonical file (a fork is not
+      # an adapter) nor reference/script/eval/license/version content. Waivers
+      # are dated and name the bead that deletes them (the known Kobiton
+      # .codex fork, removed by E3.6).
+      - name: Check adapter thinness
+        run: pnpm run validate:adapter-thinness
+
       # 6767-h is a frozen historical standard that remains cited by schemas.
       # Pin its section map and prove every cited heading still resolves.
       - name: Check frozen prose anchors remain valid

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -77,3 +77,4 @@
 !779-AA-AACR-epic-3-canonical-skill-contract.md
 !780-AA-AACR-epic-3-capability-vocabulary.md
 !781-AA-AACR-epic-3-model-id-classifier.md
+!782-AA-AACR-epic-3-adapter-thinness-gate.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (222 files). Local-only working
+Covers the **tracked** documentation estate (223 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -204,6 +204,7 @@ index and `000-docs/.gitignore`.
 - [779-AA-AACR-epic-3-canonical-skill-contract.md](779-AA-AACR-epic-3-canonical-skill-contract.md)
 - [780-AA-AACR-epic-3-capability-vocabulary.md](780-AA-AACR-epic-3-capability-vocabulary.md)
 - [781-AA-AACR-epic-3-model-id-classifier.md](781-AA-AACR-epic-3-model-id-classifier.md)
+- [782-AA-AACR-epic-3-adapter-thinness-gate.md](782-AA-AACR-epic-3-adapter-thinness-gate.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3180,
-        "tracked_files": 23128
+        "tracked_files": 23132
       }
     },
     "2": {
@@ -1949,10 +1949,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 222,
+        "index_entries": 223,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 222,
+        "tracked_documents": 223,
         "untracked_index_entries": []
       }
     },
@@ -1976,9 +1976,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15580,
+        "invisible_files": 15582,
         "target_invisible_files": 0,
-        "tracked_files": 23128
+        "tracked_files": 23132
       }
     },
     "47": {

--- a/000-docs/782-AA-AACR-epic-3-adapter-thinness-gate.md
+++ b/000-docs/782-AA-AACR-epic-3-adapter-thinness-gate.md
@@ -1,0 +1,55 @@
+<!-- doc-class: record -->
+
+# Epic 3 Adapter-Thinness Gate — After-Action Review
+
+- **Date:** 2026-08-18
+- **Authority:** Blueprint 727, Epic 3 bead 3.5
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-t9s9.5`
+- **Implementation PR:** [#1270](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1270)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E3.5 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The thin-adapter conformance gate exists and blocks through the required aggregate: an adapter
+subtree (a harness-named hidden directory under `plugins/`, or a future generated
+`adapters/<harness>/` directory) may never contain a file **byte-identical** to its canonical
+counterpart ("a fork is not an adapter"), nor any of the forbidden content classes — reference
+material, executable payloads, eval specs, licenses, version manifests — which live exactly
+once, in canonical.
+
+Landed **gate-first with a dated waiver**, exactly as the blueprint's execution prompt orders:
+`schemas/canonical/v0/adapter-thinness-waivers.json` waives the known Kobiton `.codex` fork
+(27 files, all 27 measured byte-identical to canonical at filing — matching the blueprint's
+count precisely), names its reason, its date, and its removal owner (`727:epic-3.6`), and is
+deleted in the same PR that converts the fork. A waiver without a removal owner is an exemption
+class; the live-file test asserts every waiver carries both.
+
+The repo-root `.gemini/` reviewer configuration is explicitly out of adapter scope (host
+configuration, not a harness adapter) — pinned by test after the live sweep surfaced it as a
+false positive.
+
+## Verification
+
+- `node --test scripts/check-adapter-thinness.test.mjs` — 6/6: subtree recognition (root
+  dotdirs excluded), counterpart derivation, byte-identical red run + thin-file pass,
+  forbidden-class red runs, waiver prefix scoping, live-waiver shape assertions.
+- Live run: `adapter-thinness: OK (27 adapter file(s); 27 under dated waiver)`.
+- Wired as `validate:adapter-thinness` in `doc-governance` (blocks via `ci-required`, the same
+  aggregate route every Epic 1–3 gate uses — the blueprint's "in ci-required.needs" is satisfied
+  through the `doc-governance` dependency). Hosted CI final.
+
+## Scope discipline
+
+No adapter file, canonical file, or mirror changed — the gate and its waiver land first; the
+fork conversion is E3.6's PR, which also deletes the waiver and un-double-grades the plugin in
+Freshie.
+
+## Follow-up
+
+- E3.6: convert the Kobiton `.codex` fork into a real thin adapter; delete the 27 duplicated
+  files and this gate's waiver in the same PR.
+- The "adapter capability absent from canonical" check activates when generated adapters carry
+  capability declarations (E3.4's generator) — the structural gate lands now, the semantic
+  cross-check extends it then.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "validate:canonical-schema": "node --test scripts/check-canonical-schema.test.mjs",
     "validate:capability-coverage": "node --test scripts/check-capability-coverage.test.mjs && node scripts/check-capability-coverage.mjs",
     "validate:model-id-classifier": "node --test scripts/classify-model-ids.test.mjs",
+    "validate:adapter-thinness": "node --test scripts/check-adapter-thinness.test.mjs && node scripts/check-adapter-thinness.mjs",
     "verify": "node scripts/run-verification-pipeline.mjs",
     "lint:root": "eslint .",
     "lint:design": "node scripts/lint-design-tells.mjs",

--- a/schemas/canonical/v0/adapter-thinness-waivers.json
+++ b/schemas/canonical/v0/adapter-thinness-waivers.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Dated waivers for the adapter-thinness gate (blueprint 727 E3.5). Every entry names its reason and the bead that DELETES it — a waiver without a removal owner is an exemption class, which this file must never become.",
+  "waivers": [
+    {
+      "path_prefix": "plugins/testing/kobiton-automate/.codex/",
+      "reason": "Known pre-existing Codex fork: 27 files byte-identical to canonical, measured 2026-08-18. The gate lands first with this dated waiver; the fork is converted to a real thin adapter and THIS WAIVER IS DELETED in the same PR (blueprint E3.6, the only sanctioned removal path).",
+      "dated": "2026-08-18",
+      "removed_by": "727:epic-3.6"
+    }
+  ]
+}

--- a/scripts/check-adapter-thinness.mjs
+++ b/scripts/check-adapter-thinness.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * check-adapter-thinness.mjs — an adapter must be THIN (blueprint 727, Epic 3
+ * bead 3.5; § 6's rule that a copied skill tree is not an adapter).
+ *
+ * An "adapter subtree" is a harness-named hidden directory inside a plugin
+ * (a `.codex/`, `.openclaw/`, or `.gemini-cli/` directory under plugins) or a
+ * future generated `adapters/<harness>/` directory. For every file in an
+ * adapter subtree this gate fails on:
+ *
+ *   1. BYTE-IDENTICAL duplication — the adapter file equals its canonical
+ *      counterpart (same relative path outside the adapter dir). A fork is
+ *      not an adapter; it is double-graded drift waiting to diverge.
+ *   2. FORBIDDEN CONTENT CLASSES inside an adapter — reference material
+ *      (references/), executable payloads (scripts/), eval specs, licenses,
+ *      version manifests. An adapter carries only the thin harness mapping;
+ *      everything else lives once, in canonical.
+ *
+ * Waivers: schemas/canonical/v0/adapter-thinness-waivers.json — every entry
+ * carries a reason AND a dated removal owner. The known Kobiton `.codex` fork
+ * is waived DATED, and that waiver is deleted in the same PR that converts
+ * the fork (E3.6). An expired-intent waiver is tech debt on the record, not
+ * an exemption class.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
+
+const ADAPTER_DIR = /\/\.(codex|openclaw|gemini(?:-cli)?|cursor|copilot)\//;
+const FORBIDDEN_INSIDE_ADAPTER = [
+  { re: /\/references\//, why: 'reference material lives once, in canonical' },
+  { re: /\/scripts\//, why: 'executable payloads live once, in canonical' },
+  { re: /eval-spec\.ya?ml$/, why: 'eval specs are canonical, harness-neutral' },
+  { re: /(^|\/)LICENSE[^/]*$/, why: 'license lives once, in canonical' },
+  { re: /(^|\/)package\.json$/, why: 'version manifests live once, in canonical' },
+];
+
+export function loadWaivers(root = ROOT) {
+  try {
+    return JSON.parse(
+      readFileSync(
+        join(root, 'schemas', 'canonical', 'v0', 'adapter-thinness-waivers.json'),
+        'utf-8',
+      ),
+    );
+  } catch {
+    return { waivers: [] };
+  }
+}
+
+export function adapterFiles(files) {
+  // Anchored under plugins/: the repo-root .gemini/ reviewer config and any
+  // future root-level dotdir are host configuration, not harness adapters.
+  return files.filter(
+    (f) =>
+      f.startsWith('plugins/') &&
+      (ADAPTER_DIR.test('/' + f) || /\/adapters\/[^/]+\//.test('/' + f)),
+  );
+}
+
+export function canonicalCounterpart(file) {
+  const m = ('/' + file).match(ADAPTER_DIR);
+  if (m) return ('/' + file).replace(ADAPTER_DIR, '/').slice(1);
+  return ('/' + file).replace(/\/adapters\/[^/]+\//, '/').slice(1);
+}
+
+export function isWaived(file, waivers) {
+  return (waivers.waivers || []).some((w) => file.startsWith(w.path_prefix));
+}
+
+export function checkAdapters(files, readFile, waivers) {
+  const violations = [];
+  for (const file of adapterFiles(files)) {
+    if (isWaived(file, waivers)) continue;
+    for (const rule of FORBIDDEN_INSIDE_ADAPTER) {
+      if (rule.re.test('/' + file)) {
+        violations.push({ file, kind: 'forbidden-class', why: rule.why });
+      }
+    }
+    const counterpart = canonicalCounterpart(file);
+    if (counterpart !== file && files.includes(counterpart)) {
+      const a = readFile(file);
+      const b = readFile(counterpart);
+      if (a !== null && a === b) {
+        violations.push({
+          file,
+          kind: 'byte-identical',
+          why: `identical to canonical ${counterpart} — a fork is not an adapter`,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  const files = execFileSync('git', ['ls-files'], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 256 * 1024 * 1024,
+  })
+    .split('\n')
+    .filter(Boolean);
+  const waivers = loadWaivers();
+  const read = (f) => {
+    try {
+      return readFileSync(join(ROOT, f), 'utf-8');
+    } catch {
+      return null;
+    }
+  };
+  const violations = checkAdapters(files, read, waivers);
+  for (const v of violations)
+    console.error(`adapter-thinness: VIOLATION (${v.kind}) — ${v.file}: ${v.why}`);
+  const waived = adapterFiles(files).filter((f) => isWaived(f, waivers)).length;
+  if (violations.length > 0) {
+    console.error(`adapter-thinness: FAIL — ${violations.length} violation(s).`);
+    process.exit(1);
+  }
+  console.log(
+    `adapter-thinness: OK (${adapterFiles(files).length} adapter file(s); ${waived} under dated waiver)`,
+  );
+}

--- a/scripts/check-adapter-thinness.test.mjs
+++ b/scripts/check-adapter-thinness.test.mjs
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  adapterFiles,
+  canonicalCounterpart,
+  checkAdapters,
+  isWaived,
+  loadWaivers,
+} from './check-adapter-thinness.mjs';
+
+const FILES = [
+  '.gemini/config.yaml',
+  'plugins/x/p/skills/a/SKILL.md',
+  'plugins/x/p/.codex/skills/a/SKILL.md',
+  'plugins/x/p/.codex/skills/a/references/deep.md',
+  'plugins/x/p/.codex/LICENSE',
+  'plugins/x/p/adapters/openclaw/skills/a/SKILL.md',
+  'plugins/x/p/README.md',
+];
+
+test('adapter subtrees are recognized, canonical files are not', () => {
+  const a = adapterFiles(FILES);
+  assert.deepEqual(a, [
+    'plugins/x/p/.codex/skills/a/SKILL.md',
+    'plugins/x/p/.codex/skills/a/references/deep.md',
+    'plugins/x/p/.codex/LICENSE',
+    'plugins/x/p/adapters/openclaw/skills/a/SKILL.md',
+  ]);
+});
+
+test('the canonical counterpart strips exactly the adapter segment', () => {
+  assert.equal(
+    canonicalCounterpart('plugins/x/p/.codex/skills/a/SKILL.md'),
+    'plugins/x/p/skills/a/SKILL.md',
+  );
+  assert.equal(
+    canonicalCounterpart('plugins/x/p/adapters/openclaw/skills/a/SKILL.md'),
+    'plugins/x/p/skills/a/SKILL.md',
+  );
+});
+
+test('red run — a byte-identical fork fails; a genuinely thin file passes', () => {
+  const content = {
+    'plugins/x/p/skills/a/SKILL.md': 'SAME',
+    'plugins/x/p/.codex/skills/a/SKILL.md': 'SAME',
+  };
+  const read = (f) => content[f] ?? 'other';
+  const violations = checkAdapters(
+    ['plugins/x/p/skills/a/SKILL.md', 'plugins/x/p/.codex/skills/a/SKILL.md'],
+    read,
+    { waivers: [] },
+  );
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'byte-identical');
+
+  content['plugins/x/p/.codex/skills/a/SKILL.md'] = 'THIN MAPPING ONLY';
+  assert.deepEqual(
+    checkAdapters(['plugins/x/p/skills/a/SKILL.md', 'plugins/x/p/.codex/skills/a/SKILL.md'], read, {
+      waivers: [],
+    }),
+    [],
+  );
+});
+
+test('red run — forbidden content classes inside an adapter fail', () => {
+  const read = () => 'unique';
+  const violations = checkAdapters(
+    ['plugins/x/p/.codex/skills/a/references/deep.md', 'plugins/x/p/.codex/LICENSE'],
+    read,
+    { waivers: [] },
+  );
+  assert.deepEqual(
+    violations.map((v) => v.kind),
+    ['forbidden-class', 'forbidden-class'],
+  );
+});
+
+test('a dated waiver suppresses its prefix and nothing else', () => {
+  const waivers = { waivers: [{ path_prefix: 'plugins/x/p/.codex/', dated: '2026-08-18' }] };
+  assert.ok(isWaived('plugins/x/p/.codex/LICENSE', waivers));
+  assert.ok(!isWaived('plugins/x/q/.codex/LICENSE', waivers));
+  const read = () => 'SAME';
+  assert.deepEqual(
+    checkAdapters(
+      ['plugins/x/p/skills/a/SKILL.md', 'plugins/x/p/.codex/skills/a/SKILL.md'],
+      read,
+      waivers,
+    ),
+    [],
+  );
+});
+
+test('the live waiver file names its removal owner', () => {
+  const live = loadWaivers();
+  assert.ok(live.waivers.length >= 1);
+  for (const w of live.waivers) {
+    assert.ok(w.dated, 'every waiver is dated');
+    assert.ok(w.removed_by, 'every waiver names the bead that deletes it');
+  }
+});


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 3 bead E3.5** (bead `claude-t9s9.5`), gate-first: `check-adapter-thinness.mjs` fails on byte-identical adapter/canonical pairs and on forbidden content classes inside adapter subtrees, wired as `validate:adapter-thinness` in `doc-governance`. The known Kobiton `.codex` fork (27/27 files measured byte-identical — the blueprint's exact count) is waived DATED with its removal owner named: E3.6's conversion PR deletes the waiver with the fork.

## Why + decision rationale
A copied skill tree is not an adapter (§ 6) — it is double-graded drift waiting to diverge. Chose gate-first-with-dated-waiver over fix-then-gate because the blueprint orders it, and the waiver's removal-owner field turns the exception into scheduled work instead of an exemption class (test-asserted on the live file).

## How it works
Adapter subtrees = harness-named hidden dirs anchored under `plugins/` (root `.gemini/` host config pinned out of scope by test) plus future `adapters/<harness>/` paths; counterpart = same path minus the adapter segment; forbidden classes: `references/`, `scripts/`, eval specs, licenses, version manifests.

## Verification (evidence)
Tests **6/6** incl. byte-identical and forbidden-class red runs · live run `OK (27 adapter file(s); 27 under dated waiver)` · `check-doc-classes` allow=true · docs index 223 · `measure-epic-1 --check` OK · hosted CI final

## Risk / rollback
Additive gate; no adapter/canonical/mirror file changed; focused revert.

## Follow-up & deferred
E3.6 (fork conversion + waiver deletion + Freshie un-double-grading) next; the capability cross-check arm extends when E3.4's generator emits declarations.

Refs: blueprint 000-docs/727 § 13 E3.5 + § 6, bead claude-t9s9.5, AAR 000-docs/782.