### PR TITLE
docs(docs-governance): file the E3.12 adapter-surface AAR

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -82,3 +82,4 @@
 !784-AA-AACR-epic-3-model-class-and-runtime-bindings.md
 !785-AA-AACR-epic-3-canonical-vendor-literal-gate.md
 !786-AA-AACR-epic-3-portability-claim-withdrawal.md
+!787-AA-AACR-epic-3-adapter-matrix-surface.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (227 files). Local-only working
+Covers the **tracked** documentation estate (228 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -209,6 +209,7 @@ index and `000-docs/.gitignore`.
 - [784-AA-AACR-epic-3-model-class-and-runtime-bindings.md](784-AA-AACR-epic-3-model-class-and-runtime-bindings.md)
 - [785-AA-AACR-epic-3-canonical-vendor-literal-gate.md](785-AA-AACR-epic-3-canonical-vendor-literal-gate.md)
 - [786-AA-AACR-epic-3-portability-claim-withdrawal.md](786-AA-AACR-epic-3-portability-claim-withdrawal.md)
+- [787-AA-AACR-epic-3-adapter-matrix-surface.md](787-AA-AACR-epic-3-adapter-matrix-surface.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23117
+        "tracked_files": 23118
       }
     },
     "2": {
@@ -1941,10 +1941,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 227,
+        "index_entries": 228,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 227,
+        "tracked_documents": 228,
         "untracked_index_entries": []
       }
     },
@@ -1968,9 +1968,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15575,
+        "invisible_files": 15576,
         "target_invisible_files": 0,
-        "tracked_files": 23117
+        "tracked_files": 23118
       }
     },
     "47": {

--- a/000-docs/787-AA-AACR-epic-3-adapter-matrix-surface.md
+++ b/000-docs/787-AA-AACR-epic-3-adapter-matrix-surface.md
@@ -1,0 +1,39 @@
+<!-- doc-class: record -->
+
+# Epic 3 Marketplace Adapter Surface — After-Action Review
+
+- **Date:** 2026-08-19
+- **Authority:** Blueprint 727, Epic 3 bead 3.12
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-t9s9.10`
+- **Implementation PR:** [#1274](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1274) — the detail-page change rode the E3.11 PR as an undisclosed-at-merge rider (both slices shared a working tree; the sweep's `add -A` collected it). Disclosed here and in the bead record; the filing PR for this AAR is [#1275](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1275).
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E3.12 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+1. **"No page reads the free-text string" was verified TRUE before any change**: a repo-wide
+   sweep found zero marketplace pages or components consuming the frontmatter `compatibility`
+   value — the only occurrences are the grading page's rubric documentation, which shows the
+   honest example. Half of this bead's acceptance was already satisfied by construction; the
+   record here is the verification, not a retirement.
+2. **The declared adapter state now renders**: plugin detail pages carry an
+   `Adapters (declared)` stats item derived from the registered adapter set (`claude-code` —
+   the E3.2 schema enum, which grows only with generated adapter artifacts). The label says
+   _declared_ because that is the claim's exact strength: a registered, working harness — not a
+   prose aspiration. When per-skill `skill-card.yaml` files land (organic T2+ adoption after
+   E3.11), the same slot renders their `adapters[]` + `unsupported[]` detail per card.
+3. **Route budget untouched**: no new routes; one stats item on an existing page. The
+   2,800–4,500 route budget and 48 MB size budget are unaffected.
+
+## Verification
+
+- Repo-wide `compatibility` consumer sweep: zero page/component reads (grading-page rubric
+  documentation only).
+- Marketplace build validates the Astro change in CI (`marketplace-validation` +
+  `check-performance` budgets); hosted CI final.
+
+## Follow-up
+
+- Per-card rendering activates with skill-card adoption; `unsupported[]` reasons render from the
+  card when present.


### PR DESCRIPTION
## What
Files `000-docs/787` for blueprint 727 **Epic 3 bead E3.12** (bead `claude-t9s9.10`). The implementation (the `Adapters (declared)` stats item on plugin detail pages, registry-derived) rode PR #1274 as a shared-working-tree rider — disclosed in the AAR — and the acceptance's other half was verified true by construction: zero marketplace pages read the free-text compatibility string.

## Why one-line
§ 13 E3.12 requires the declared matrix rendered and free-text retired from the UI; this filing completes the slice's record with the rider disclosed.

Refs: blueprint 000-docs/727 § 13 E3.12, bead claude-t9s9.10, PRs #1274/#1275.