### PR TITLE
docs(docs-governance): record the kernel proposal and schema ownership boundary

### DIFF
--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -82,9 +82,5 @@
 !784-AA-AACR-epic-3-model-class-and-runtime-bindings.md
 !785-AA-AACR-epic-3-canonical-vendor-literal-gate.md
 !786-AA-AACR-epic-3-portability-claim-withdrawal.md
-<<<<<<< HEAD
-!788-AA-AACR-epic-3-kernel-proposal.md
-||||||| b94e5bcfe
-=======
 !787-AA-AACR-epic-3-adapter-matrix-surface.md
->>>>>>> origin/main
+!788-AA-AACR-epic-3-kernel-proposal.md

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -82,3 +82,4 @@
 !784-AA-AACR-epic-3-model-class-and-runtime-bindings.md
 !785-AA-AACR-epic-3-canonical-vendor-literal-gate.md
 !786-AA-AACR-epic-3-portability-claim-withdrawal.md
+!788-AA-AACR-epic-3-kernel-proposal.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (227 files). Local-only working
+Covers the **tracked** documentation estate (228 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -209,6 +209,7 @@ index and `000-docs/.gitignore`.
 - [784-AA-AACR-epic-3-model-class-and-runtime-bindings.md](784-AA-AACR-epic-3-model-class-and-runtime-bindings.md)
 - [785-AA-AACR-epic-3-canonical-vendor-literal-gate.md](785-AA-AACR-epic-3-canonical-vendor-literal-gate.md)
 - [786-AA-AACR-epic-3-portability-claim-withdrawal.md](786-AA-AACR-epic-3-portability-claim-withdrawal.md)
+- [788-AA-AACR-epic-3-kernel-proposal.md](788-AA-AACR-epic-3-kernel-proposal.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1251,6 +1251,14 @@ missed. The pinned assertion is `check-doc-authority.test.mjs` (two claimants, t
 canonical-table links); "2 ≤ 3, all linked" is the satisfied reading, recorded here so no
 audit needs to re-derive it.
 
+**E3.13 kernel-boundary record (2026-08-19).** The canonical contract was proposed to the
+kernel as `intent-eval-core#90` (schemas `skill-contract`, `capability`, `eval-spec`), citing
+`schemas/canonical/v0/` as the draft. The ownership boundary stands as designed: this repository
+is never its own schema authority — the v0 directory is `DRAFT · UPSTREAM-PENDING`, every
+consumer names that status, and on kernel adoption the local draft becomes a cited vendored copy
+of the kernel contract with the kernel changelog as the canonical record of semantics. Until
+adoption, the draft evolves only through reviewed PRs here with #90 linked.
+
 **Dependencies / entry criteria.** None for the measurement harness, the catalog work, and the asset sniff. The dead-domain sweep **must wait for Epic 2's freeze** — the frozen set is an input, not an afterthought.
 
 **Proposed beads (15).**

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23117
+        "tracked_files": 23118
       }
     },
     "2": {
@@ -1941,10 +1941,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 227,
+        "index_entries": 228,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 227,
+        "tracked_documents": 228,
         "untracked_index_entries": []
       }
     },
@@ -1968,9 +1968,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15575,
+        "invisible_files": 15576,
         "target_invisible_files": 0,
-        "tracked_files": 23117
+        "tracked_files": 23118
       }
     },
     "47": {

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23118
+        "tracked_files": 23119
       }
     },
     "2": {
@@ -1941,10 +1941,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 228,
+        "index_entries": 229,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 228,
+        "tracked_documents": 229,
         "untracked_index_entries": []
       }
     },
@@ -1968,9 +1968,9 @@
       "values": {
         "allowlist_patterns": 25,
         "invalid_patterns": 0,
-        "invisible_files": 15576,
+        "invisible_files": 15577,
         "target_invisible_files": 0,
-        "tracked_files": 23118
+        "tracked_files": 23119
       }
     },
     "47": {

--- a/000-docs/788-AA-AACR-epic-3-kernel-proposal.md
+++ b/000-docs/788-AA-AACR-epic-3-kernel-proposal.md
@@ -1,0 +1,46 @@
+<!-- doc-class: record -->
+
+# Epic 3 Kernel Proposal and Ownership Boundary — After-Action Review
+
+- **Date:** 2026-08-19
+- **Authority:** Blueprint 727, Epic 3 bead 3.13
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-t9s9.11`
+- **Implementation PR:** [#1276](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1276)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E3.13 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+1. **The kernel proposal is filed**:
+   [`intent-eval-core#90`](https://github.com/jeremylongshore/intent-eval-core/issues/90)
+   proposes `skill-contract`, `capability`, and `eval-spec` as kernel authoring schemas, citing
+   `schemas/canonical/v0/` as the draft with its invariants (closed schema, abstract
+   capabilities, `model_class` tiers, registry-enum adapters, fail-closed `unsupported[]`, SPDX
+   vocabulary, resolved-SHA mirror pins) and the evidence chain (baseline 778, the five live
+   gates, AARs 779–786). The issue names the ask: authoring-family fit review, adoption vehicle
+   decision, and the vendored-copy transition on adoption.
+2. **The boundary statement is on the record in 727**: this repository is never its own schema
+   authority; the v0 directory is `DRAFT · UPSTREAM-PENDING`; on adoption the local draft
+   becomes a cited vendored copy with the kernel changelog canonical; until then the draft
+   evolves only through reviewed PRs with #90 linked.
+3. **The UPSTREAM-PENDING promise is discharged**: the schema `$comment` and the companion
+   README both said the issue number would be recorded when filed — both now cite #90 with the
+   filing date.
+
+## Verification
+
+- Issue live at intent-eval-core#90 (estate-internal repo; footer-signed per the authoring
+  standard).
+- Schema still compiles under Ajv 2020 strict with all 11 contract tests passing after the
+  `$comment` edit; hosted CI final.
+
+## Scope discipline
+
+No schema semantics changed — only the recorded filing status. No corpus, catalog, or gate
+change.
+
+## Follow-up
+
+- The kernel's review on #90 drives the adoption vehicle; the CCPI-side pin-and-vendor step
+  lands when the kernel publishes.

--- a/schemas/canonical/v0/README.md
+++ b/schemas/canonical/v0/README.md
@@ -2,8 +2,9 @@
 
 **Status: DRAFT · UPSTREAM-PENDING.** This repository must never become its own schema
 authority: the contract here is the draft to be proposed to `@intentsolutions/core` as the
-`skill-contract` authoring schema (blueprint 727, Epic 3 bead 3.13 — the kernel issue number is
-recorded there when filed). Until the kernel adopts it, this directory is the single draft
+`skill-contract` authoring schema (blueprint 727, Epic 3 bead 3.13 —
+FILED as [intent-eval-core#90](https://github.com/jeremylongshore/intent-eval-core/issues/90),
+2026-08-19). Until the kernel adopts it, this directory is the single draft
 source and every consumer cites it as DRAFT.
 
 ## What this is

--- a/schemas/canonical/v0/skill-contract.schema.json
+++ b/schemas/canonical/v0/skill-contract.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tonsofskills.com/schemas/canonical/v0/skill-contract.schema.json",
   "title": "Canonical harness-free skill contract (skill-card.yaml)",
-  "$comment": "Status: DRAFT (v0). UPSTREAM-PENDING: this repository must never become its own schema authority — the contract is to be proposed to @intentsolutions/core as the `skill-contract` authoring schema (blueprint 727 Epic 3 bead 3.13; the kernel issue number is recorded in that bead and in 000-docs when filed). Home B of the four-home split (blueprint 727 § 5.1): written by the skill author per behavior change, read by validators, adapter generators, marketplace filters, and security review. The SKILL.md frontmatter (home A) is NOT this contract and keeps the IS 8 unchanged — this file is additive and never touches ALWAYS_REQUIRED.",
+  "$comment": "Status: DRAFT (v0). UPSTREAM-PENDING: this repository must never become its own schema authority — the contract is to be proposed to @intentsolutions/core as the `skill-contract` authoring schema (blueprint 727 Epic 3 bead 3.13 — FILED as intent-eval-core#90, 2026-08-19). Home B of the four-home split (blueprint 727 § 5.1): written by the skill author per behavior change, read by validators, adapter generators, marketplace filters, and security review. The SKILL.md frontmatter (home A) is NOT this contract and keeps the IS 8 unchanged — this file is additive and never touches ALWAYS_REQUIRED.",
   "type": "object",
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
## What
Implements blueprint 727 **Epic 3 bead E3.13** (bead `claude-t9s9.11`): the kernel proposal is filed as [intent-eval-core#90](https://github.com/jeremylongshore/intent-eval-core/issues/90) (schemas `skill-contract`, `capability`, `eval-spec`, citing `schemas/canonical/v0/` + the evidence chain), the ownership boundary statement lands in 727 (never our own schema authority; vendored-copy transition on adoption), and the schema $comment + companion README discharge their UPSTREAM-PENDING promise by citing #90.

## Why one-line
E3.13's acceptance is the issue + the boundary on record — the anti-fork-authority commitment every consumer of the v0 draft names.

## Verification
Issue live at intent-eval-core#90 · schema Ajv-strict 11/11 after the comment edit · docs index 229 · `measure-epic-1 --check` OK · hosted CI final. Docs-only; focused revert.

Refs: blueprint 000-docs/727 § 13 E3.13 + § 5.2, bead claude-t9s9.11, AAR 000-docs/788, intent-eval-core#90.