### PR TITLE
fix(ci-infra): block unambiguous MCP-config defects and deadline the advisory lane

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -122,12 +122,18 @@ jobs:
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml || true
           python3 scripts/validate-skills-schema.py --agents-only || true
 
-      # .mcp.json advisory validation — surfaces MCP-config findings on every PR.
-      # (kernel-shadow-validation runs this same validator, but only when the
-      # validator itself changes.) ADVISORY ONLY — never pass --strict here; the
-      # promotion to a blocking gate is the DR-049 soak checklist's call.
-      - name: Validate .mcp.json configs (advisory)
-        run: node scripts/validate-mcp-config.mjs || true
+      # .mcp.json validation, two lanes (E4.8, blueprint 727):
+      #   1. UNAMBIGUOUS classes block: JSON parse failures, non-object server
+      #      maps/entries, and a server missing its transport-essential field
+      #      (stdio ⇒ command; http/sse ⇒ url). Landed with zero baseline debt.
+      #   2. Everything else (the IS overlay: description/version/enabled/…)
+      #      stays advisory under the deadline below; full --strict promotion
+      #      remains the DR-049 soak checklist's call — never pass --strict here.
+      # REPORT-ONLY-UNTIL: 2026-11-17
+      - name: Validate .mcp.json configs (advisory + unambiguous gate)
+        run: |
+          node scripts/validate-mcp-config.mjs || true
+          node scripts/validate-mcp-config.mjs --gate-unambiguous
 
       # Design-tell gate (VibeCheck 25/100 regression guard, 2026-05-31).
       # Fails on chrome gradients, glassmorphism, purple/indigo/violet

--- a/000-docs/.gitignore
+++ b/000-docs/.gitignore
@@ -90,3 +90,4 @@
 !793-AA-AACR-epic-4-scan-push-main.md
 !792-AA-AACR-epic-4-gitleaks-deblanket.md
 !794-AA-AACR-epic-4-unverified-secret-pr-scan.md
+!796-AA-AACR-epic-4-mcp-config-gate.md

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -5,7 +5,7 @@
 > **Generated — do not edit.** Stage newly filed documents, then run
 > `node scripts/generate-docs-index.mjs`.
 
-Covers the **tracked** documentation estate (235 files). Local-only working
+Covers the **tracked** documentation estate (236 files). Local-only working
 documents are counted in doc 720 but deliberately not listed here. The inventory excludes only this
 index and `000-docs/.gitignore`.
 
@@ -217,6 +217,7 @@ index and `000-docs/.gitignore`.
 - [792-AA-AACR-epic-4-gitleaks-deblanket.md](792-AA-AACR-epic-4-gitleaks-deblanket.md)
 - [793-AA-AACR-epic-4-scan-push-main.md](793-AA-AACR-epic-4-scan-push-main.md)
 - [794-AA-AACR-epic-4-unverified-secret-pr-scan.md](794-AA-AACR-epic-4-unverified-secret-pr-scan.md)
+- [796-AA-AACR-epic-4-mcp-config-gate.md](796-AA-AACR-epic-4-mcp-config-gate.md)
 - [20260131-RL-REPT-claude-code-plugins-v4.14.0.md](20260131-RL-REPT-claude-code-plugins-v4.14.0.md)
 - [6767-a-SPEC-DR-STND-claude-code-plugins-standard.md](6767-a-SPEC-DR-STND-claude-code-plugins-standard.md)
 - [6767-b-SPEC-DR-STND-claude-skills-standard.md](6767-b-SPEC-DR-STND-claude-skills-standard.md)

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23128
+        "tracked_files": 23129
       }
     },
     "2": {
@@ -1946,10 +1946,10 @@
       ],
       "status": "measured",
       "values": {
-        "index_entries": 235,
+        "index_entries": 236,
         "missing_from_index": [],
         "target_equal": true,
-        "tracked_documents": 235,
+        "tracked_documents": 236,
         "untracked_index_entries": []
       }
     },
@@ -1975,7 +1975,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23128
+        "tracked_files": 23129
       }
     },
     "47": {

--- a/000-docs/796-AA-AACR-epic-4-mcp-config-gate.md
+++ b/000-docs/796-AA-AACR-epic-4-mcp-config-gate.md
@@ -1,0 +1,30 @@
+<!-- doc-class: record -->
+
+# Epic 4 MCP Config Validator Deadline and Fail-Closed Lane — After-Action Review
+
+- **Date:** 2026-08-19
+- **Authority:** Blueprint 727, Epic 4 bead 4.8
+- **Filing standard:** [Document Filing Standard v4.4](000-DR-STND-document-filing-system.md)
+- **Bead:** `claude-or1m.8`
+- **Implementation PR:** [#1284](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/pull/1284)
+- **Merge method:** squash with disclosed, owner-authorized administrator bypass
+- **Status:** E4.8 controls implemented; merge fields are recorded in Beads/Dolt after review
+
+## Outcome
+
+The `.mcp.json` validation step loses its blanket `|| true`. Two lanes now:
+
+1. **Blocking (`--gate-unambiguous`)** — JSON parse failures, non-object server maps/entries,
+   and any server entry missing its transport-essential field (`stdio` ⇒ `command`,
+   `http`/`sse` ⇒ `url`). Landed with **zero baseline debt**: all 13 pre-existing findings
+   are IS-overlay fields (description/version/enabled), none transport-essential.
+2. **Advisory with a deadline** — the overlay findings keep reporting under
+   `REPORT-ONLY-UNTIL: 2026-11-17`, policed by the workflow's existing deadline-enforcement
+   step, so the report-only state can no longer rot indefinitely. Full `--strict` promotion
+   remains the DR-049 soak checklist's call, unchanged.
+
+## Verification
+
+A synthetic probe (`{"type":"http"}` server with no `url`) placed in the scan glob exits 1
+with the violation named; removing it returns exit 0 on the live corpus. Hosted CI runs the
+new step on this PR.

--- a/scripts/validate-mcp-config.mjs
+++ b/scripts/validate-mcp-config.mjs
@@ -63,6 +63,12 @@ const COMPOSED_SCHEMA_ID =
 
 const args = process.argv.slice(2);
 const STRICT = args.includes('--strict');
+// E4.8 (blueprint 727): the fail-closed lane for the UNAMBIGUOUS classes only
+// — JSON parse failures, non-object server maps/entries, and a server entry
+// missing its transport-essential field (stdio ⇒ command; http/sse ⇒ url).
+// Schema-overlay findings (description/version/enabled/…) stay advisory under
+// the workflow step's REPORT-ONLY-UNTIL marker.
+const GATE_UNAMBIGUOUS = args.includes('--gate-unambiguous');
 const JSON_OUT = args.includes('--json');
 
 function die(msg) {
@@ -127,7 +133,9 @@ function main() {
     p.includes(`${join('.claude-plugin')}`),
   );
 
-  const findings = []; // { file, server, source, errors: [...] }
+  const findings = [];
+
+  const unambiguous = []; // { file, server, source, errors: [...] }
   let filesScanned = 0;
   let serversValidated = 0;
   let serversPassed = 0;
@@ -143,6 +151,11 @@ function main() {
         source,
         errors: ['mcpServers is not an object map'],
       });
+      unambiguous.push({
+        file: relTo(file),
+        server: null,
+        error: 'mcpServers is not an object map',
+      });
       return;
     }
     for (const [serverName, config] of Object.entries(servers)) {
@@ -154,7 +167,21 @@ function main() {
           source,
           errors: ['server entry is not an object'],
         });
+        unambiguous.push({
+          file: relTo(file),
+          server: serverName,
+          error: 'server entry is not an object',
+        });
         continue;
+      }
+      const transport = config.type ?? config.transport ?? 'stdio';
+      const essential = transport === 'http' || transport === 'sse' ? 'url' : 'command';
+      if (typeof config[essential] !== 'string' || config[essential].length === 0) {
+        unambiguous.push({
+          file: relTo(file),
+          server: serverName,
+          error: `transport '${transport}' requires a non-empty '${essential}'`,
+        });
       }
       // Projection: the kernel per-server contract requires `name` inside the
       // entry; on-disk configs carry it as the map key.
@@ -192,6 +219,11 @@ function main() {
         source: '.mcp.json',
         errors: [`JSON parse error: ${e.message}`],
       });
+      unambiguous.push({
+        file: relTo(file),
+        server: null,
+        error: `JSON parse error: ${e.message}`,
+      });
       continue;
     }
     const servers =
@@ -215,6 +247,11 @@ function main() {
         server: null,
         source: 'plugin.json',
         errors: [`JSON parse error: ${e.message}`],
+      });
+      unambiguous.push({
+        file: relTo(file),
+        server: null,
+        error: `JSON parse error: ${e.message}`,
       });
       continue;
     }
@@ -312,6 +349,16 @@ function main() {
     }
   }
 
+  if (GATE_UNAMBIGUOUS && unambiguous.length > 0) {
+    console.error('');
+    console.error('  UNAMBIGUOUS-CLASS VIOLATIONS (blocking — E4.8 fail-closed lane):');
+    for (const violation of unambiguous) {
+      console.error(
+        `    ✗ ${violation.file}${violation.server ? ` [${violation.server}]` : ''} — ${violation.error}`,
+      );
+    }
+    process.exit(1);
+  }
   if (STRICT && findings.length > 0) process.exit(1);
   process.exit(0);
 }


### PR DESCRIPTION
## What
Blueprint 727 **Epic 4 bead E4.8** (bead `claude-or1m.8`): the `.mcp.json` step loses its blanket `|| true`. New `--gate-unambiguous` mode in `scripts/validate-mcp-config.mjs` blocks JSON parse failures, non-object server maps/entries, and servers missing their transport-essential field (stdio ⇒ `command`; http/sse ⇒ `url`). The overlay-field advisory lane gains `REPORT-ONLY-UNTIL: 2026-11-17`, policed by the workflow's existing deadline-enforcement step.

## Why + decision rationale
Even invalid JSON passed silently before. Chose transport-essential-only blocking over full-schema `--strict` because the 13 pre-existing findings are overlay fields (description/version/enabled) — real but not unambiguous — and the DR-049 soak checklist owns that promotion; this lands with **zero baseline debt**.

## Verification (evidence)
Synthetic probe (`http` server, no `url`) placed in the scan glob → exit 1 with the violation named; removed → live corpus exit 0. Doc gates green. Hosted CI runs the new step on this PR.

## Risk / rollback
Blocking lane can only fire on genuinely broken configs (currently zero). Rollback: focused revert restores the advisory-only step.

Refs: blueprint 000-docs/727 § 13 E4.8, bead claude-or1m.8, AAR 000-docs/796.