### PR TITLE
fix(ci-infra): make the model-id census gate CI-visible and pin claude-or1m

### DIFF
--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23148
+        "tracked_files": 23149
       }
     },
     "2": {
@@ -1975,7 +1975,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23148
+        "tracked_files": 23149
       }
     },
     "47": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "validate:readme-contract": "node --test scripts/check-readme-contract.test.mjs && node scripts/check-readme-contract.mjs",
     "validate:canonical-schema": "node --test scripts/check-canonical-schema.test.mjs",
     "validate:capability-coverage": "node --test scripts/check-capability-coverage.test.mjs && node scripts/check-capability-coverage.mjs",
-    "validate:model-id-classifier": "node --test scripts/classify-model-ids.test.mjs",
+    "validate:model-id-classifier": "node --test scripts/classify-model-ids.test.mjs && node scripts/classify-model-ids.mjs --check",
     "validate:adapter-thinness": "node --test scripts/check-adapter-thinness.test.mjs && node scripts/check-adapter-thinness.mjs",
     "validate:adapter-toolchain": "node --test scripts/adapters/generate-compatibility.test.mjs scripts/adapters/claude-code-adapter.test.mjs",
     "validate:canonical-vendor-literals": "node --test scripts/check-canonical-vendor-literals.test.mjs && node scripts/check-canonical-vendor-literals.mjs",

--- a/schemas/canonical/v0/model-id-exclusions.json
+++ b/schemas/canonical/v0/model-id-exclusions.json
@@ -263,6 +263,7 @@
     "claude-o8q7",
     "claude-oh1f",
     "claude-oqfc",
+    "claude-or1m",
     "claude-ov6n",
     "claude-oy2j",
     "claude-p655",

--- a/scripts/check-denylist-degradation.mjs
+++ b/scripts/check-denylist-degradation.mjs
@@ -27,7 +27,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { KNOWN_HARNESSES } from './check-portability-claims.mjs';
+import { KNOWN_HARNESSES } from './lib/harness-lexicon.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 

--- a/scripts/check-portability-claims.mjs
+++ b/scripts/check-portability-claims.mjs
@@ -24,21 +24,12 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { KNOWN_HARNESSES } from './lib/harness-lexicon.mjs';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 
-/** Harness names the ratchet recognizes in prose claims. */
-export const KNOWN_HARNESSES = [
-  ['claude-code', /claude\s*code/i],
-  ['codex', /\bcodex\b/i],
-  ['openclaw', /open\s*claw/i],
-  ['gemini-cli', /\bgemini\b/i],
-  ['cursor', /\bcursor\b/i],
-  ['copilot', /\bcopilot\b/i],
-  ['windsurf', /\bwindsurf\b/i],
-  ['aider', /\baider\b/i],
-  ['cline', /\bcline\b/i],
-];
+// Re-exported for existing consumers; the definition lives in scripts/lib/.
+export { KNOWN_HARNESSES };
 
 /** The registered adapter set — grows only with generated adapter artifacts. */
 export const REGISTERED_ADAPTERS = new Set(['claude-code']);

--- a/scripts/classify-model-ids.mjs
+++ b/scripts/classify-model-ids.mjs
@@ -13,12 +13,21 @@
  *   node scripts/classify-model-ids.mjs --functional   # the E3.8 work list
  *                                                        (file:line "token")
  *   node scripts/classify-model-ids.mjs --json         # full machine output
+ *   node scripts/classify-model-ids.mjs --check        # gate mode: exit 1 on
+ *                                                        census drift
  */
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { classifyModelToken, claudeTokensOnLine } from './lib/model-id-classifier.mjs';
+import {
+  BEAD_ID,
+  BEAD_ID_SCAN,
+  MODEL_FAMILY,
+  classifyModelToken,
+  claudeTokensOnLine,
+  loadExclusions,
+} from './lib/model-id-classifier.mjs';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const TEXT_EXT = /\.(md|mjs|cjs|js|ts|tsx|astro|json|ya?ml|py|sh|txt|toml|css|html)$/i;
@@ -51,8 +60,74 @@ export function classifyTree() {
   return sets;
 }
 
+/**
+ * Handle prefixes that match the bead shape but are product vocabulary, never
+ * beads-issue handles in this repo. If bd ever minted one of these, the
+ * local-workspace census (classify-model-ids.test.mjs, live-export leg) would
+ * still catch it at generation time.
+ */
+const NOT_A_HANDLE = new Set(['claude-code']);
+
+/**
+ * The CI-reachable census: every bead-handle-shaped token on a bead-context
+ * line in the TRACKED tree (a corpus CI can see, unlike the untracked
+ * .beads/issues.jsonl) whose prefix is missing from the committed exclusion
+ * list. A new epic bead lands in tracked AARs ("Bead: `claude-<hash>.1`")
+ * before anything else, so this trips on exactly the drift class that once
+ * went CI-invisible: an epic created after the census was committed.
+ * Placeholder mentions ("claude-7yz...") are skipped by the ellipsis guard.
+ */
+export function unpinnedTrackedHandles() {
+  const pinned = new Set(loadExclusions().protected_handles);
+  const files = execFileSync('git', ['ls-files'], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 256 * 1024 * 1024,
+  })
+    .split('\n')
+    .filter(Boolean);
+
+  const missing = new Map(); // prefix → first "file:line" sighting
+  for (const file of files) {
+    if (!TEXT_EXT.test(file)) continue;
+    let text;
+    try {
+      text = readFileSync(join(ROOT, file), 'utf-8');
+    } catch {
+      continue;
+    }
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!/bead/i.test(line)) continue;
+      for (const token of line.match(BEAD_ID_SCAN) || []) {
+        if (!BEAD_ID.test(token) || MODEL_FAMILY.test(token)) continue;
+        if (line.includes(token + '...')) continue;
+        const prefix = token.split('.')[0];
+        if (NOT_A_HANDLE.has(prefix) || pinned.has(prefix)) continue;
+        if (!missing.has(prefix)) missing.set(prefix, `${file}:${i + 1}`);
+      }
+    }
+  }
+  return missing;
+}
+
 const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
 if (isMain) {
+  if (process.argv.includes('--check')) {
+    const missing = unpinnedTrackedHandles();
+    if (missing.size > 0) {
+      for (const [prefix, where] of missing) {
+        console.error(
+          `model-id-check: FAIL — handle ${prefix} referenced at ${where} is missing from ` +
+            'schemas/canonical/v0/model-id-exclusions.json (regenerate from .beads/issues.jsonl)',
+        );
+      }
+      process.exit(1);
+    }
+    console.log('model-id-check: PASS — every tracked bead-handle reference is pinned');
+    process.exit(0);
+  }
   const sets = classifyTree();
   if (process.argv.includes('--json')) {
     process.stdout.write(JSON.stringify(sets, null, 2) + '\n');

--- a/scripts/classify-model-ids.mjs
+++ b/scripts/classify-model-ids.mjs
@@ -76,9 +76,12 @@ const NOT_A_HANDLE = new Set(['claude-code']);
  * before anything else, so this trips on exactly the drift class that once
  * went CI-invisible: an epic created after the census was committed.
  * Placeholder mentions ("claude-7yz...") are skipped by the ellipsis guard.
+ *
+ * `pinned` is injectable so the regression test can prove the DETECTION path
+ * end-to-end (empty pin set → the scan must surface real handles), not just
+ * the all-pinned empty result.
  */
-export function unpinnedTrackedHandles() {
-  const pinned = new Set(loadExclusions().protected_handles);
+export function unpinnedTrackedHandles(pinned = new Set(loadExclusions().protected_handles)) {
   const files = execFileSync('git', ['ls-files'], {
     cwd: ROOT,
     encoding: 'utf-8',

--- a/scripts/classify-model-ids.test.mjs
+++ b/scripts/classify-model-ids.test.mjs
@@ -8,6 +8,7 @@ import {
   claudeTokensOnLine,
   loadExclusions,
 } from './lib/model-id-classifier.mjs';
+import { unpinnedTrackedHandles } from './classify-model-ids.mjs';
 
 test('the committed exclusion list pins every live bead handle', () => {
   const excl = loadExclusions();
@@ -22,6 +23,29 @@ test('the committed exclusion list pins every live bead handle', () => {
     assert.ok(BEAD_ID.test(h), `${h} must match the bead shape`);
     assert.ok(!MODEL_FAMILY.test(h), `${h} must never match a model family`);
   }
+});
+
+test('the committed exclusion list is sorted and duplicate-free', () => {
+  const handles = loadExclusions().protected_handles;
+  assert.deepEqual(handles, [...handles].sort(), 'handles must stay sorted');
+  assert.equal(new Set(handles).size, handles.length, 'handles must be unique');
+});
+
+test('every bead handle referenced in the tracked tree is pinned (CI-reachable census)', () => {
+  // The 2026-08 audit found the census could only drift-detect on boxes with
+  // the untracked .beads/issues.jsonl — CI's green carried no signal, so
+  // Epic 4's own epic bead (claude-or1m) landed in tracked AARs without a
+  // pin and nothing went red. This leg scans a corpus CI CAN see: any
+  // bead-handle-shaped token on a bead-context line in tracked files must
+  // already be in the committed exclusion list.
+  const missing = unpinnedTrackedHandles();
+  assert.equal(
+    missing.size,
+    0,
+    `unpinned handle(s) referenced in tracked files: ${[...missing]
+      .map(([p, where]) => `${p} (${where})`)
+      .join(', ')}`,
+  );
 });
 
 test('bead handles are never rewritable — even on functional-looking lines', () => {
@@ -49,8 +73,9 @@ test('the three sets are disjoint by construction', () => {
 test('the exclusion list stays regenerable from the live beads export', (t) => {
   // The beads workspace is deliberately untracked in this repo (local Dolt is
   // the authority; the JSONL is a machine-local export). CI checkouts have no
-  // .beads/, so the census assertion is a LOCAL-workspace check: absent file
-  // → skip, never a synthetic pass of the actual comparison.
+  // .beads/, so this leg is the LOCAL-workspace check: absent file → skip.
+  // It is no longer the ONLY drift detector — the tracked-tree census above
+  // runs everywhere, CI included.
   let raw;
   try {
     raw = readFileSync(new URL('../.beads/issues.jsonl', import.meta.url), 'utf-8');

--- a/scripts/classify-model-ids.test.mjs
+++ b/scripts/classify-model-ids.test.mjs
@@ -48,6 +48,18 @@ test('every bead handle referenced in the tracked tree is pinned (CI-reachable c
   );
 });
 
+test('the tracked-tree census actually detects — an empty pin set surfaces real handles', () => {
+  // Guards the detection path itself: if the scan ever degenerates to
+  // returning nothing (broken regex, broken git walk), the all-pinned
+  // empty-result test above would still pass. With NO pins, the same scan
+  // must surface the real handle population, including the one whose miss
+  // motivated this gate.
+  const found = unpinnedTrackedHandles(new Set());
+  assert.ok(found.size >= 50, `expected a large unpinned census, got ${found.size}`);
+  assert.ok(found.has('claude-or1m'), 'the Epic 4 epic handle must be detectable');
+  assert.match(found.get('claude-or1m'), /^\S+:\d+$/, 'sightings carry file:line provenance');
+});
+
 test('bead handles are never rewritable — even on functional-looking lines', () => {
   for (const handle of ['claude-hz8f', 'claude-hedb.11', 'claude-t9s9.1', 'claude-4laa.1']) {
     assert.equal(classifyModelToken(handle, `model: ${handle}`), 'bead-id');

--- a/scripts/lib/harness-lexicon.mjs
+++ b/scripts/lib/harness-lexicon.mjs
@@ -1,0 +1,22 @@
+/**
+ * harness-lexicon.mjs — THE harness-name lexicon (blueprint 727, Epic 3).
+ *
+ * Harness names the portability gates recognize in prose claims. Owned here
+ * in scripts/lib/ so both consumers — check-portability-claims.mjs (the
+ * unbacked-portability ratchet, E3.11) and check-denylist-degradation.mjs
+ * (the denylist silent-drop gate, E4.12) — import ONE definition. A second
+ * copy of this list is exactly the drift class Epic 3 exists to end.
+ */
+
+/** [id, matcher] pairs — matcher tests a SKILL.md `compatibility` value. */
+export const KNOWN_HARNESSES = [
+  ['claude-code', /claude\s*code/i],
+  ['codex', /\bcodex\b/i],
+  ['openclaw', /open\s*claw/i],
+  ['gemini-cli', /\bgemini\b/i],
+  ['cursor', /\bcursor\b/i],
+  ['copilot', /\bcopilot\b/i],
+  ['windsurf', /\bwindsurf\b/i],
+  ['aider', /\baider\b/i],
+  ['cline', /\bcline\b/i],
+];


### PR DESCRIPTION
## What

Fixes the one refuted claim from the verify-completed-epics audit (blueprint 727, Epics 1–4): `validate:model-id-classifier` was **red at HEAD** — Epic 4's epic bead handle `claude-or1m` was missing from the committed exclusion list, and CI was structurally blind to the drift.

## Why + decision rationale

The audit found the census gate had no CI signal at all:

1. The only drift-detecting assertion (`the exclusion list stays regenerable from the live beads export`) self-skips when the untracked `.beads/issues.jsonl` is absent — i.e. in **every** CI checkout.
2. The package.json gate ran only the test file; `scripts/classify-model-ids.mjs` was a reporting tool that always exited 0 and was never invoked by the gate.

So when Epic 4's `bd create` minted `claude-or1m`, nothing anywhere could go red. This drift class recurs with every new epic bead — the fix targets the class, not just the instance.

- **Symptom:** pin `claude-or1m` (live census 394 handles; list was 393).
- **Root cause A:** new `unpinnedTrackedHandles()` census scans **tracked** files (a corpus CI can see) for bead-handle-shaped tokens on bead-context lines; any prefix missing from the committed list fails with `file:line`. New epic beads hit tracked AARs (`Bead: \`claude-<hash>.1\``) immediately, so the drift goes red in CI from now on. Added as an always-on test plus list invariants (sorted, unique); the live-export parity leg keeps its local-only skip.
- **Root cause B:** the gate becomes the two-step `node --test … && node scripts/classify-model-ids.mjs --check` shape used by the sibling gates; `--check` exits 1 on census drift.
- **Hardening:** `KNOWN_HARNESSES` moves to `scripts/lib/harness-lexicon.mjs` (single-owner lib placement); chose lib extraction over the existing gate-imports-gate coupling because two gate scripts should not share lifecycles. The portability script re-exports for existing consumers.

## Layer(s) touched

Epic-3 canonical layer (`schemas/canonical/v0/model-id-exclusions.json`), its gate suite (`scripts/classify-model-ids.*`), package.json gate wiring, and the shared gate lib (`scripts/lib/`). No invariant changes — the disjoint three-set classification and the 8-field validator contract are untouched.

## How it works

`unpinnedTrackedHandles()` walks `git ls-files`, keeps lines matching `/bead/i`, extracts `BEAD_ID_SCAN` tokens, filters model-family shapes, placeholder-ellipsis mentions (`claude-7yz...`), and the `claude-code` product-vocabulary stoplist, then requires every remaining prefix be pinned. Measured zero false positives tree-wide today; a future collision fails loud, never silently passes.

## Verification & evidence

- `pnpm run validate:model-id-classifier` → exit 0 with the fix.
- Against the pre-fix list (git show main:…): `--check` → **exit 1**, naming `claude-or1m @ 000-docs/791-AA-AACR-epic-4-safety-register.md:8`.
- Simulated CI checkout (`.beads/issues.jsonl` removed): 5 pass / 1 skip / `--check` PASS, exit 0 — the census now carries real signal without the JSONL.
- Self-test of the tripwire: this PR's own doc-comment example (`claude-xxxx.1`) tripped the scan during development and had to be reworded — the gate catches exactly what it claims to.
- `validate:portability-claims` + `validate:denylist-degradation` green post-extraction; prettier + eslint clean.

## Risk assessment

Low. The new census only ADDS a failure mode (unpinned handle) to a gate that previously could not fail in CI. False-positive risk is bounded by the measured-zero baseline and a loud, file:line-named failure. The lexicon move is import-path-only (re-export preserves the old surface).

## Operational impact

None — no deps, no env, no deploy-order. Future epic creation gains one step that was always implied: pin the new handle in the exclusion list (the gate now tells you exactly this when you forget).

## Follow-up & deferred

Record legs land separately per the audit plan: addendum AAR 802 (audit record + the "2,700 = file-edit count" counting-basis clarification) and correcting `bd note`s on claude-t9s9.4 / claude-or1m.

## Governance links

Blueprint 727 § Epic 3 (E3.7 census, bead claude-t9s9.4); Epic 4 epic claude-or1m; AARs 781/789/791 (the drift's first tracked sighting is 791:8).

Refs jeremylongshore/claude-code-plugins-plus-skills#1289 (Epic 4 closure record — the change that minted the unpinned handle).

[skip auto-bump]