### PR TITLE
fix(ci-infra): fail the daily stats run red when BOT_PR_TOKEN is gone

### DIFF
--- a/.github/workflows/update-npm-stats.yml
+++ b/.github/workflows/update-npm-stats.yml
@@ -29,13 +29,28 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      # Fail RED the moment the token is missing — no silent fallback. The
+      # 2026-08 audit found `BOT_PR_TOKEN || GITHUB_TOKEN` meant token expiry
+      # would silently regress to the GITHUB_TOKEN path, whose stats PRs never
+      # re-trigger required checks (anti-recursion) — the exact zero-checks
+      # failure the token was added to fix, wearing a green badge.
+      - name: Require BOT_PR_TOKEN (no silent fallback)
+        env:
+          BOT_PR_TOKEN: ${{ secrets.BOT_PR_TOKEN }}
+        run: |
+          if [ -z "$BOT_PR_TOKEN" ]; then
+            echo "::error::BOT_PR_TOKEN is absent or empty (expired, revoked, or never set). This workflow refuses to fall back to GITHUB_TOKEN because its PRs cannot re-trigger required checks. Rotate the fine-grained PAT (contents:write + pull-requests:write) and re-run."
+            exit 1
+          fi
+          echo "BOT_PR_TOKEN present."
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # BOT_PR_TOKEN (fine-grained PAT, contents:write + pull-requests:write) re-triggers required checks; GITHUB_TOKEN cannot (anti-recursion). See ops-review bead claude-k0h2.
           # This persisted credential authenticates the branch push below.
-          # Falls back to GITHUB_TOKEN (today's behavior) until the secret exists.
-          token: ${{ secrets.BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # No fallback: the guard step above fails red when the secret is gone.
+          token: ${{ secrets.BOT_PR_TOKEN }}
 
       - uses: actions/setup-node@v6
         with:
@@ -47,18 +62,24 @@ jobs:
       - name: Report tracked stats freshness (advisory)
         run: node scripts/check-stats-freshness.mjs --report
 
+      # timeout: a 2026-08-18 scheduled run hung ~29 minutes inside this fetch
+      # and was only ended by the next dispatch's concurrency cancel — a hang
+      # must fail fast and loud, not linger until something else kills it.
       - name: Fetch stats and update artifacts
+        timeout-minutes: 10
         run: node scripts/fetch-npm-stats.mjs
 
       # skills.sh install count — the credibility figure shown in the hero.
       # Fails soft (exit 0, leaves the data file untouched) so a skills.sh blip
       # never blocks the npm refresh or the resulting PR.
       - name: Fetch skills.sh install count
+        timeout-minutes: 5
         run: node scripts/fetch-skills-stats.mjs
 
       # Star count for the homepage credibility line. Same fail-soft contract:
       # a GitHub blip leaves the last known good value in place and exits 0.
       - name: Fetch GitHub star count
+        timeout-minutes: 5
         run: node scripts/fetch-github-stats.mjs
 
       # E1.10 hard gate AFTER fetching: the fetch scripts fail soft by design,
@@ -89,7 +110,8 @@ jobs:
         # automated commit doesn't OOM on prettier across the staged set.
         env:
           # BOT_PR_TOKEN (fine-grained PAT, contents:write + pull-requests:write) re-triggers required checks; GITHUB_TOKEN cannot (anti-recursion). See ops-review bead claude-k0h2.
-          GH_TOKEN: ${{ secrets.BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # No fallback: the guard step at the top fails red when the secret is gone.
+          GH_TOKEN: ${{ secrets.BOT_PR_TOKEN }}
         run: |
           set -euo pipefail
           BRANCH="automation/npm-stats"


### PR DESCRIPTION
## What

Removes the silent `secrets.BOT_PR_TOKEN || secrets.GITHUB_TOKEN` fallback from `.github/workflows/update-npm-stats.yml` (both token sites), adds a first guard step that fails RED with rotation instructions when the secret is absent/empty, and puts `timeout-minutes` on the three network fetch steps (10/5/5).

## Why + decision rationale

Verify-completed-epics audit finding B (Epic 1 residual): if `BOT_PR_TOKEN` expires, the workflow silently degrades to the `GITHUB_TOKEN` path, whose stats PRs never re-trigger required checks (anti-recursion) — the exact zero-checks failure the token was added to fix, wearing a green badge. That fallback is also why the pre-fix scheduled runs looked "green." Separately, the 2026-08-18 scheduled run hung ~29 minutes inside the npm fetch and was only ended by the next manual dispatch's concurrency cancel — hangs must fail fast and alert, not linger.

Chose a dedicated guard step over an `if:` expression on checkout because a failed guard carries an explicit `::error` naming the rotation fix, while a failed checkout reads as infrastructure noise.

## Layer(s) touched

One workflow file, no scripts, no invariants. The workflow's PR-opening pattern, freshness gates, and concurrency group are untouched.

## How it works

Step 1 reads `secrets.BOT_PR_TOKEN` into env and exits 1 with `::error` if empty — before checkout ever runs. Checkout and the `GH_TOKEN` env then reference the secret directly. `timeout-minutes: 10` on the npm fetch, `5` on the two fail-soft fetchers, so a network hang becomes a red step within minutes.

## Verification & evidence

- `actionlint` clean on the edited workflow.
- Guard logic asserted both ways locally: empty `BOT_PR_TOKEN` → exit 1; present → exit 0.
- `gh secret list` shows `BOT_PR_TOKEN` updated 2026-08-19T01:34Z — the secret exists today, so merging cannot break tonight's run.
- Schedule-trigger proof is the deferred leg: the next 00:15 UTC cron's conclusion gets recorded on the Epic 1 bead cluster (per the audit plan); if it fails, fix forward.

## Risk assessment

Low. The only behavior change on the happy path is nil (secret present → identical flow). On the failure path, behavior changes from "silently open a zero-checks PR" to "fail red with instructions" — the designed direction. Timeouts are generous (a healthy fetch takes seconds).

## Operational impact

Token expiry now pages via a failed scheduled run instead of passing silently. Rotation procedure is named in the error message (fine-grained PAT, contents:write + pull-requests:write).

## Follow-up & deferred

Record the next cron run's conclusion on bead claude-hz8f's cluster (audit Slice 2 step 3); addendum AAR 802 lands separately.

## Governance links

Blueprint 727 Epic 1 (E1.10 freshness gates); ops-review bead claude-k0h2; audit record AAR 802 (incoming).

[skip auto-bump]