### PR TITLE
Add external mirror source: personal-pack

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1765,6 +1765,33 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # Personal Pack (Adam Radek)
+  # https://github.com/adamradek-ux/claude-code-personal-pack
+  # ============================================================
+
+  - name: personal-pack
+    description: Personal assistant pack for Claude Code - lifestyle agents (Czech, Brno-flavored), discipline skills, opt-in guardrail hooks
+    repo: adamradek-ux/claude-code-personal-pack
+    source_path: .
+    target_path: plugins/community/personal-pack
+    author:
+      name: Adam Radek
+      github: adamradek-ux
+    license: MIT
+    category: community
+    include:
+      - '.claude-plugin/**'
+      - 'agents/**'
+      - 'skills/**'
+      - 'hooks/**'
+      - 'config/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'LICENSE'
+    exclude:
+      - '.github/**'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
Adds `adamradek-ux/claude-code-personal-pack` to `sources.yaml` as an external mirror source (Path A per the file's header comment - plugin stays maintained in my repo, you mirror weekly).

**What it is:** a personal assistant pack for Claude Code - 9 lifestyle agents (Czech/Brno-flavored with English descriptions, honestly labeled as templates), 4 discipline skills in English (verify-before-done completion gate, session-capture, research-to-vault, memory-audit), and 7 guardrail hooks with an example settings wiring.

**Notes:**
- MIT licensed, tagged `v0.1.0`, CI green (compile + shell syntax + manifest JSON + frontmatter checks).
- Hooks are **opt-in by design** - installing the plugin never activates them; they ship as scripts + a settings example the user wires up deliberately. Stated up front in the README.
- Valid `.claude-plugin/plugin.json` + `marketplace.json` (self-referencing root marketplace, kepano-style).
- I'm not claiming `verified`/`curated` flags - those are yours to set.

Happy to adjust the entry (category, include globs) to whatever fits your conventions.