### PR TITLE
fix(governance): regenerate the Epic 1 scorecard so doc-governance stops failing on main

### DIFF
--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23153
+        "tracked_files": 23155
       }
     },
     "2": {
@@ -1975,7 +1975,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23153
+        "tracked_files": 23155
       }
     },
     "47": {

--- a/scripts/measure-epic-1.mjs
+++ b/scripts/measure-epic-1.mjs
@@ -5,6 +5,20 @@
  *
  * The package-level `measure:e1:check` command runs the resolver and harness
  * fixture suites before invoking this module's artifact drift check.
+ *
+ * ORDERING MATTERS, and getting it wrong looks like a broken generator.
+ * `--check` builds its report from the GIT INDEX, not from the worktree, while
+ * generation WRITES to the worktree. So this sequence never converges:
+ *
+ *     edit inputs -> generate -> stage everything -> --check      (DRIFT)
+ *
+ * because the report was measured against an index that did not yet contain the
+ * edits. The correct order stages the inputs first:
+ *
+ *     edit inputs -> stage inputs -> generate -> stage artifact -> --check  (OK)
+ *
+ * A regeneration run before the inputs are staged measures one state and
+ * verifies another, which reads as non-determinism and is not.
  */
 
 import { spawnSync } from 'node:child_process';


### PR DESCRIPTION
## What

Regenerates `000-docs/742-RA-DATA-epic-1-scorecard.json`. The functional diff is **two lines** — one number, in the two places it appears.

## Why

`doc-governance` has been **red on `main`**, and because it sits in `ci-required`'s `needs:`, every PR opened against this repo inherits a red aggregate.

The cause is two tracked files and nothing else. Commit `190abe16d` regenerated the scorecard at **23,153** tracked files. Two blog posts landed afterwards without regenerating it:

- `marketplace/src/content/blog-posts/the-skip-that-counted-as-a-pass.md`
- `marketplace/src/content/blog-posts/we-told-the-auditors-to-refute-us.md`

So the committed scorecard has claimed 23,153 while the tree holds 23,155.

## The generator was never broken

I previously reported this as a generator that would not round-trip against its own checker. **That was wrong**, and the correction is the more useful half of this PR.

`--check` builds its report from the **git index**; generation **writes to the worktree**. So this never converges:

```
edit inputs → generate → stage everything → --check     DRIFT
```

because the report was measured against an index that did not yet contain the edits. This does:

```
edit inputs → stage inputs → generate → stage artifact → --check     OK
```

A regeneration run before its inputs are staged measures one state and verifies another. It reads as non-determinism and is not. Both orderings are now spelled out in the script header so the next person does not lose the same hour.

## Decision rationale

**Chose regenerating over relaxing the gate**, because the gate is correct — a measurement artifact that silently describes a tree which no longer exists is worth failing over. The real gap is that nothing prompts an author to regenerate when they add a tracked file; that is follow-up, not this PR.

## Layer

Governance/measurement only. No runtime, catalog, or plugin surface is touched.

## Verification

```
# before, on a clean main with zero modified files:
$ git status --short | wc -l
0
$ node scripts/measure-epic-1.mjs --check
epic-1-measurement: DRIFT (000-docs/742-RA-DATA-epic-1-scorecard.json)

# after:
$ node scripts/measure-epic-1.mjs --check
epic-1-measurement: OK (000-docs/742-RA-DATA-epic-1-scorecard.json)
```

Full artifact diff:

```
-        "tracked_files": 23153
+        "tracked_files": 23155
-        "tracked_files": 23153
+        "tracked_files": 23155
```

## Risk

Minimal. The artifact is a derived measurement; the change makes it agree with the tree it describes. Rollback is reverting this commit, which restores the red gate.

## Follow-up

Nothing prompts regeneration when a tracked file is added. Worth a pre-commit hook or a CI hint naming the exact command, so this does not recur the next time a doc lands.

Refs #1297, which was blocked by this and is otherwise green.