### PR TITLE
fix(freshie): make stub detection deterministic

### DIFF
--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -16,17 +16,17 @@
     "values": {
       "a_error_total": 219,
       "a_failing": 131,
-      "ab_error_total": 2140,
-      "ab_failing": 953,
-      "b_failing": 822,
+      "ab_error_total": 2149,
+      "ab_failing": 956,
+      "b_failing": 825,
       "error_files": 1962,
       "error_total": 7193,
       "grade_distribution": {
         "A": 1595,
-        "B": 1007,
-        "C": 882,
-        "D": 182,
-        "F": 9
+        "B": 1010,
+        "C": 879,
+        "D": 184,
+        "F": 7
       },
       "rows": 3675
     }
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23157
+        "tracked_files": 23159
       }
     },
     "2": {
@@ -106,17 +106,17 @@
         "skill_rows": {
           "a_error_total": 219,
           "a_failing": 131,
-          "ab_error_total": 2140,
-          "ab_failing": 953,
-          "b_failing": 822,
+          "ab_error_total": 2149,
+          "ab_failing": 956,
+          "b_failing": 825,
           "error_files": 1962,
           "error_total": 7193,
           "grade_distribution": {
             "A": 1595,
-            "B": 1007,
-            "C": 882,
-            "D": 182,
-            "F": 9
+            "B": 1010,
+            "C": 879,
+            "D": 184,
+            "F": 7
           },
           "rows": 3675
         }
@@ -132,15 +132,15 @@
         "average_score": 85.2,
         "grade_distribution": {
           "A": 1595,
-          "B": 1007,
-          "C": 882,
-          "D": 182,
-          "F": 9
+          "B": 1010,
+          "C": 879,
+          "D": 184,
+          "F": 7
         },
         "grade_percentages": {
           "A": 43.4,
-          "B": 27.4,
-          "C": 24,
+          "B": 27.5,
+          "C": 23.9,
           "D": 5,
           "F": 0.2
         },
@@ -156,10 +156,10 @@
       "values": {
         "a_error_total": 219,
         "a_failing": 131,
-        "ab_error_total": 2140,
-        "ab_failing": 953,
-        "b_error_total": 1921,
-        "b_failing": 822,
+        "ab_error_total": 2149,
+        "ab_failing": 956,
+        "b_error_total": 1930,
+        "b_failing": 825,
         "certified_target": 0,
         "skill_summary_rows": 3675
       }
@@ -1975,7 +1975,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23157
+        "tracked_files": 23159
       }
     },
     "47": {

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -1608,10 +1608,6 @@ def calculate_modifiers(path: Path, body: str, fm: dict) -> dict:
     # === ANTI-PATTERN DETECTION (graduated penalty system) ===
     # Each detected anti-pattern reduces score by 1pt, floor at -5
     skill_dir = path.parent
-    code_blocks = len(re.findall(r"```", body)) // 2
-    md_links = len(re.findall(r"\[.*?\]\((?!https?://)[^)]+\)", body))
-    body_word_count = len(body.split())
-
     anti_patterns_found = []
 
     # AP1: Over-constrained — excessive MUST/NEVER/ALWAYS keywords
@@ -1650,28 +1646,10 @@ def calculate_modifiers(path: Path, body: str, fm: dict) -> dict:
         if orphan_refs:
             anti_patterns_found.append(f"orphan references: {', '.join(orphan_refs[:3])}")
 
-    # AP5: Stub detection (replaces old flat -3 penalty with graduated system)
-    placeholder_tokens = ["TODO", "FIXME", "REPLACE_ME", "TBD", "[YOUR_", "<insert"]
-    placeholder_count = sum(len(re.findall(re.escape(tok), body, re.IGNORECASE)) for tok in placeholder_tokens) + len(
-        re.findall(r"\{[a-z_]+\}", body)
-    )
-    placeholder_density = placeholder_count / body_word_count if body_word_count > 0 else 0.0
-    stub_signals = 0
-    stub_reasons_mod = []
-    if lines < 30:
-        stub_signals += 1
-        stub_reasons_mod.append(f"{lines} lines")
-    if code_blocks == 0 and md_links == 0:
-        stub_signals += 1
-        stub_reasons_mod.append("no code blocks or links")
-    if body_word_count < 150:
-        stub_signals += 1
-        stub_reasons_mod.append(f"{body_word_count} words")
-    if placeholder_density > 0.05:
-        stub_signals += 1
-        stub_reasons_mod.append(f"placeholder density {placeholder_density:.1%}")
-    if stub_signals >= 2:
-        anti_patterns_found.append(f"stub skill: {', '.join(stub_reasons_mod)}")
+    # Stub classification belongs exclusively to deterministic_stub_flags(),
+    # which evaluates the complete run.  Do not reintroduce thin-content,
+    # placeholder-density, or link-count guesses here: those are local
+    # heuristics and disagree with the persisted Freshie is_stub verdict.
 
     # AP6: Ecosystem coherence — bonus for cross-referencing siblings
     has_cross_ref = bool(re.search(r"(?i)(see also|related skill|sibling|cross-reference|companion)", body))

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -46,6 +46,7 @@ Schema:  3.8.0  (see 000-docs/SCHEMA_CHANGELOG.md)
 
 import argparse
 import difflib
+import hashlib
 import json as json_module
 import os
 import re
@@ -4652,6 +4653,47 @@ def validate_plugin(plugin_dir: Path, tier: str = TIER_STANDARD, strict: bool = 
 # === COMPLIANCE DATABASE ===
 
 
+def deterministic_stub_flags(records: list) -> dict:
+    """Return run-scoped stub findings without heuristic thin-content guesses.
+
+    A finding is limited to repeated normalized content within one plugin pack
+    (three or more skills) or a relative in-plugin link to a missing path.
+    Templates are intentionally excluded and A/B graded skills are protected.
+    """
+    hashes: Dict[Tuple[str, str], list] = {}
+    flags: Dict[str, list] = {}
+    for record in records:
+        path = record["path"]
+        if "templates" in path.parts:
+            continue
+        normalized = re.sub(r"\s+", " ", record["body"].strip()).lower()
+        if normalized:
+            digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+            hashes.setdefault((str(record["pack"]), digest), []).append(record)
+        for target in re.findall(r"\[[^\]]*\]\(([^)]+)\)", record["body"]):
+            target = target.strip().split("#", 1)[0]
+            if not target or re.match(r"(?:https?:|mailto:|/)", target):
+                continue
+            resolved = (path.parent / target).resolve()
+            try:
+                resolved.relative_to(record["pack"].resolve())
+            except ValueError:
+                continue
+            if not resolved.exists():
+                flags.setdefault(str(path), []).append(f"missing in-plugin reference: {target}")
+    for (_pack, _digest), members in hashes.items():
+        if len(members) >= 3:
+            for record in members:
+                flags.setdefault(str(record["path"]), []).append(
+                    f"normalized body hash shared by {len(members)} skills in pack"
+                )
+    return {
+        path: reasons
+        for path, reasons in flags.items()
+        if next(record for record in records if str(record["path"]) == path)["grade"] not in {"A", "B"}
+    }
+
+
 def populate_compliance_db(
     db_path: str, skill_results: list, agent_results: list = None, validator_version: str = "5.0.0"
 ):
@@ -4948,6 +4990,28 @@ def populate_compliance_db(
 
     now = datetime.now(timezone.utc).isoformat()
 
+    # Build the complete run snapshot before writing rows: duplicate stamping
+    # cannot be established safely while visiting one skill at a time.
+    stub_records = []
+    for result in skill_results:
+        raw = result.get("path", "")
+        skill_file = Path(raw)
+        if not skill_file.is_absolute():
+            skill_file = repo_root_for_paths / skill_file
+        if skill_file.is_dir():
+            skill_file = skill_file / "SKILL.md"
+        try:
+            _fm, body = parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+        except Exception:
+            body = ""
+        parts = skill_file.parts
+        try:
+            pack = Path(*parts[: parts.index("skills")])
+        except ValueError:
+            pack = skill_file.parent
+        stub_records.append({"path": skill_file, "pack": pack, "body": body, "grade": result.get("grade", "F")})
+    deterministic_stubs = deterministic_stub_flags(stub_records)
+
     for result in skill_results:
         raw_skill_path = result.get("path", "")
         # Read the file via the raw (possibly absolute) path before normalizing
@@ -4982,28 +5046,8 @@ def populate_compliance_db(
         total_fields = anthropic_fields + enterprise_fields
         missing = [k for k in ALWAYS_REQUIRED if k not in fm]
 
-        # Compute stub criteria from body
-        _db_stub_reasons: list = []
-        if body_for_stub:
-            _db_lines = len(body_for_stub.strip().splitlines())
-            _db_code_blocks = len(re.findall(r"```", body_for_stub)) // 2
-            _db_md_links = len(re.findall(r"\[.*?\]\((?!https?://)[^)]+\)", body_for_stub))
-            _db_word_count = len(body_for_stub.split())
-            _db_placeholder_tokens = ["TODO", "FIXME", "REPLACE_ME", "TBD", "[YOUR_", "<insert"]
-            _db_placeholder_count = sum(
-                len(re.findall(re.escape(tok), body_for_stub, re.IGNORECASE)) for tok in _db_placeholder_tokens
-            ) + len(re.findall(r"\{[a-z_]+\}", body_for_stub))
-            _db_placeholder_density = _db_placeholder_count / _db_word_count if _db_word_count > 0 else 0.0
-            if _db_lines < 30:
-                _db_stub_reasons.append(f"body < 30 lines ({_db_lines})")
-            if _db_code_blocks == 0 and _db_md_links == 0:
-                _db_stub_reasons.append("no code blocks and no markdown links")
-            if _db_word_count < 150:
-                _db_stub_reasons.append(f"word count < 150 ({_db_word_count})")
-            if _db_placeholder_density > 0.05:
-                _db_stub_reasons.append(f"placeholder density > 5% ({_db_placeholder_density:.1%})")
-        # Require 2+ stub signals to flag as stub (single signal = false positive)
-        is_stub_val = 1 if len(_db_stub_reasons) >= 2 else 0
+        _db_stub_reasons = deterministic_stubs.get(str(skill_file), [])
+        is_stub_val = 1 if _db_stub_reasons else 0
 
         try:
             mtime = (

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -1561,7 +1561,6 @@ def calculate_modifiers(path: Path, body: str, fm: dict) -> dict:
     modifiers = {}
     name = str(fm.get("name", ""))
     desc = str(fm.get("description", ""))
-    lines = len(body.splitlines())
 
     # Bonuses (up to +5)
     # Gerund-style name (verb-ing pattern) +1

--- a/tests/test_deterministic_stub_flags.py
+++ b/tests/test_deterministic_stub_flags.py
@@ -1,0 +1,35 @@
+"""Regression coverage for Freshie's run-wide stub classifier."""
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("validator", ROOT / "scripts" / "validate-skills-schema.py")
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+def record(path, pack, body, grade="F"):
+    return {"path": Path(path), "pack": Path(pack), "body": body, "grade": grade}
+
+
+def test_flags_three_normalized_duplicates_but_protects_a_grade(tmp_path):
+    pack = tmp_path / "pack"
+    paths = [pack / "skills" / name / "SKILL.md" for name in ("a", "b", "c")]
+    rows = [record(path, pack, "# Same\n\nbody", "A" if i == 0 else "F") for i, path in enumerate(paths)]
+    flags = validator.deterministic_stub_flags(rows)
+    assert str(paths[0]) not in flags
+    assert str(paths[1]) in flags and str(paths[2]) in flags
+
+
+def test_flags_missing_in_pack_reference_but_exempts_templates(tmp_path):
+    pack = tmp_path / "pack"
+    skill = pack / "skills" / "a" / "SKILL.md"
+    templated = pack / "templates" / "a" / "SKILL.md"
+    flags = validator.deterministic_stub_flags([
+        record(skill, pack, "See [missing](../../references/nope.md)"),
+        record(templated, pack, "See [missing](../../references/nope.md)"),
+    ])
+    assert str(skill) in flags
+    assert str(templated) not in flags

--- a/tests/test_deterministic_stub_flags.py
+++ b/tests/test_deterministic_stub_flags.py
@@ -33,3 +33,24 @@ def test_flags_missing_in_pack_reference_but_exempts_templates(tmp_path):
     ])
     assert str(skill) in flags
     assert str(templated) not in flags
+
+
+def test_duplicate_hashes_do_not_cross_pack_boundaries(tmp_path):
+    body = "# Shared\n\nThis identical body is only a finding within one pack."
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    rows = [
+        record(first / "skills" / name / "SKILL.md", first, body)
+        for name in ("a", "b")
+    ] + [record(second / "skills" / "c" / "SKILL.md", second, body)]
+    assert validator.deterministic_stub_flags(rows) == {}
+
+
+def test_existing_in_pack_reference_is_not_a_dangling_pointer(tmp_path):
+    pack = tmp_path / "pack"
+    skill = pack / "skills" / "a" / "SKILL.md"
+    target = pack / "references" / "real.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("present", encoding="utf-8")
+    rows = [record(skill, pack, "See [real](../../references/real.md)")]
+    assert validator.deterministic_stub_flags(rows) == {}


### PR DESCRIPTION
Implements run-8 deterministic stub classification: pack-scoped normalized duplicate hashes, missing in-pack references, templates exemption, and A/B protection. Adds focused regression coverage.\n\n[skip auto-bump]