### PR TITLE
feat(marketplace): add optional deep-dive links

### DIFF
--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3175,
-        "tracked_files": 23156
+        "tracked_files": 23157
       }
     },
     "2": {
@@ -1975,7 +1975,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23156
+        "tracked_files": 23157
       }
     },
     "47": {

--- a/marketplace/src/data/spotlights.json
+++ b/marketplace/src/data/spotlights.json
@@ -38,6 +38,11 @@
       "skillCount": 1,
       "category": "community",
       "link": "https://github.com/polyxmedia/mnemos",
+      "assets": {
+        "prd": "/templates/skill-docs/examples/mnemos/PRD.md",
+        "adr": "/templates/skill-docs/examples/mnemos/ADR.md",
+        "onePager": "/templates/skill-docs/examples/mnemos/ONE-PAGER.md"
+      },
       "quote": "A memory layer for AI coding agents — because Claude Code keeps forgetting, and that gets old fast."
     },
     {

--- a/scripts/promote-spotlight.mjs
+++ b/scripts/promote-spotlight.mjs
@@ -28,7 +28,7 @@
  *   pluginSlug, headline, author, authorGithub, grade, category, link
  *
  * Optional fields:
- *   whyKiller, quote, skillCount
+ *   whyKiller, quote, skillCount, assets:{prd,adr,onePager,cfo}
  *
  * Exit codes:
  *   0 — success
@@ -91,6 +91,26 @@ function validateSpotlight(s) {
     console.error(`✗ new-spotlight JSON missing required fields: ${missing.join(', ')}`);
     console.error(`  Required: ${REQUIRED.join(', ')}`);
     process.exit(2);
+  }
+  if (s.assets !== undefined) {
+    if (!s.assets || typeof s.assets !== 'object' || Array.isArray(s.assets)) {
+      console.error(
+        '✗ new-spotlight assets must be an object with optional prd, adr, onePager, and cfo links',
+      );
+      process.exit(2);
+    }
+    const invalid = Object.entries(s.assets).filter(
+      ([key, value]) =>
+        !['prd', 'adr', 'onePager', 'cfo'].includes(key) ||
+        typeof value !== 'string' ||
+        !value.trim(),
+    );
+    if (invalid.length) {
+      console.error(
+        '✗ new-spotlight assets accepts only non-empty prd, adr, onePager, and cfo string links',
+      );
+      process.exit(2);
+    }
   }
 }
 

--- a/scripts/render-spotlight.mjs
+++ b/scripts/render-spotlight.mjs
@@ -22,6 +22,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import prettier from 'prettier';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
@@ -30,6 +31,12 @@ const README = join(ROOT, 'README.md');
 
 const START = '<!-- KILLER-SKILL:START — do not edit; run `node scripts/render-spotlight.mjs` -->';
 const END = '<!-- KILLER-SKILL:END -->';
+const DEEP_DIVE_LINKS = [
+  ['prd', 'PRD'],
+  ['adr', 'ADR'],
+  ['onePager', 'One-pager'],
+  ['cfo', 'CFO brief'],
+];
 
 const MONTHS = [
   'January',
@@ -63,11 +70,21 @@ function isoWeekToLabel(isoWeek, lastUpdated) {
 // Plugin link: external (https://...) keeps the URL; internal (/plugins/x)
 // gets prefixed with the marketplace domain so the README link works
 // outside the site.
-function externalize(link) {
+export function externalize(link) {
   if (!link) return null;
   if (link.startsWith('http://') || link.startsWith('https://')) return link;
   if (link.startsWith('/')) return `https://tonsofskills.com${link}`;
   return link;
+}
+
+export function renderDeepDive(assets) {
+  if (!assets || typeof assets !== 'object' || Array.isArray(assets)) return null;
+  const links = DEEP_DIVE_LINKS.flatMap(([key, label]) => {
+    const rawLink = assets[key];
+    if (typeof rawLink !== 'string' || !rawLink.trim()) return [];
+    return [`[${label}](${externalize(rawLink.trim())})`];
+  });
+  return links.length ? `> Deep dive: ${links.join(' · ')}` : null;
 }
 
 function bestLinkLabel(s) {
@@ -76,7 +93,7 @@ function bestLinkLabel(s) {
   return 'Browse on Marketplace';
 }
 
-function renderBlock(data) {
+export function renderBlock(data) {
   const s = data.spotlight;
   if (!s) throw new Error('spotlights.json has no `spotlight` field');
 
@@ -100,12 +117,14 @@ function renderBlock(data) {
   const headlineLine = s.headline ? `> **${s.headline}**\n>\n` : '';
   const whyLine = s.whyKiller ? `> ${s.whyKiller}\n>\n` : '';
   const quoteLine = s.quote ? `> *"${s.quote}"* — ${s.author || 'Anonymous'}\n>\n` : '';
+  const deepDiveLine = renderDeepDive(s.assets);
 
   const lines = [
     START,
     `> **${data.title || 'Killer Skill of the Week'}** — [${s.pluginSlug}](${link}) by ${authorLink}`,
     '>',
     `${headlineLine}${whyLine}${quoteLine}> Grade: ${s.grade || 'A'} | ${weekLabel} | [${linkLabel}](${link})`,
+    ...(deepDiveLine ? ['>', deepDiveLine] : []),
     '>',
     `> Previous picks: ${previous || '_(none yet)_'}. See all at [tonsofskills.com](https://tonsofskills.com).`,
     END,
@@ -158,7 +177,10 @@ async function main() {
   console.log('✓ README KILLER-SKILL block regenerated from spotlights.json');
 }
 
-main().catch((err) => {
-  console.error(err.message || err);
-  process.exit(1);
-});
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  main().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+  });
+}

--- a/scripts/render-spotlight.test.mjs
+++ b/scripts/render-spotlight.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { renderBlock, renderDeepDive } from './render-spotlight.mjs';
+
+test('renders only the supplied deep-dive assets in stable label order', () => {
+  assert.equal(
+    renderDeepDive({ onePager: '/brief.md', cfo: 'https://example.com/cfo', prd: '/prd.md' }),
+    '> Deep dive: [PRD](https://tonsofskills.com/prd.md) · [One-pager](https://tonsofskills.com/brief.md) · [CFO brief](https://example.com/cfo)',
+  );
+});
+
+test('omits the deep-dive row when an entry has no assets', () => {
+  const rendered = renderBlock({
+    week: '2026-W01',
+    spotlight: { pluginSlug: 'example', author: 'Example', grade: 'A', link: '/plugins/example' },
+  });
+  assert.doesNotMatch(rendered, /Deep dive:/);
+});
+
+test('renders deep-dive links in the generated README block', () => {
+  const rendered = renderBlock({
+    week: '2026-W01',
+    spotlight: {
+      pluginSlug: 'example',
+      author: 'Example',
+      grade: 'A',
+      link: '/plugins/example',
+      assets: { adr: '/adr.md' },
+    },
+  });
+  assert.match(rendered, /> Deep dive: \[ADR\]\(https:\/\/tonsofskills\.com\/adr\.md\)/);
+});


### PR DESCRIPTION
## Summary
- allow spotlight entries to link optional PRD, ADR, one-pager, and CFO-brief artifacts
- render a bounded Deep dive row in the README spotlight block when assets are present
- validate promoted spotlight asset shape and add renderer regression coverage

## Verification
- `node --test scripts/render-spotlight.test.mjs`
- `node scripts/render-spotlight.mjs --check`
- `node scripts/check-readme-contract.mjs`
- `pnpm eslint scripts/render-spotlight.mjs scripts/render-spotlight.test.mjs scripts/promote-spotlight.mjs`
- `pnpm prettier --check scripts/render-spotlight.mjs scripts/render-spotlight.test.mjs scripts/promote-spotlight.mjs marketplace/src/data/spotlights.json README.md`
- `node scripts/measure-epic-1.mjs --check`

Closes claude-ss50.6