### PR TITLE
chore(governance): add editor and dependency policies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig keeps the mixed Node, Python, YAML, and Markdown repository
+# consistent across local editors. Repository-specific formatters remain
+# authoritative where they are configured.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,cjs,mjs,ts,tsx,json,jsonc,yml,yaml,css,astro}]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /marketplace
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /ci/emit-evidence
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -41,8 +41,8 @@
       "target_status": "informational",
       "values": {
         "plugin_agent_files": 347,
-        "raw_tracked_plugin_skill_files": 3130,
-        "tracked_files": 22797
+        "raw_tracked_plugin_skill_files": 3129,
+        "tracked_files": 22792
       }
     },
     "2": {
@@ -1561,10 +1561,10 @@
       "cohort": "tracked .github Dependabot configuration",
       "dimension": "Dependabot configuration",
       "reproduce": "pnpm run measure:e1 --row=37 --stdout",
-      "source": [],
+      "source": [".github/dependabot.yml"],
       "status": "measured",
       "values": {
-        "present": false,
+        "present": true,
         "target_present": true
       }
     },
@@ -1778,7 +1778,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 22797
+        "tracked_files": 22792
       }
     },
     "47": {


### PR DESCRIPTION
## Summary

- add a repository-wide EditorConfig for the Node, Python, YAML, and Markdown surfaces
- add Dependabot coverage for the root pnpm workspace, marketplace npm app, evidence package, and GitHub Actions
- preserve the existing GitHub governance documents and purpose-built CI workflows rather than duplicating them

Closes claude-4k45

## Validation

- pnpm exec prettier --check .github/dependabot.yml
- git diff --check
- pre-commit formatter, harness-hash, and plaintext-credential checks
