### PR TITLE
Add ki-sop-pack-situation-router (skill-enhancers)

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1206,6 +1206,28 @@ sources:
       - '**/node_modules/**'
       - '**/*.log'
 
+  # ============================================================
+  # KI SOP Pack (Keith Infinity)
+  # https://github.com/jalano0i9u8y7-lab/ki-sop-pack
+  # ============================================================
+
+  - name: ki-sop-pack-situation-router
+    description: Situation router — decide implement-directly vs. stress-test-first vs. spec-first before touching a request. Free module of KI SOP Pack v1 (adapted from mattpocock/skills ask-matt, MIT).
+    repo: jalano0i9u8y7-lab/ki-sop-pack
+    source_path: skills/situation-router
+    target_path: plugins/skill-enhancers/ki-sop-pack-situation-router
+    author:
+      name: Keith Infinity
+      github: jalano0i9u8y7-lab
+    license: MIT
+    category: skill-enhancers
+    verified: false
+    include:
+      - 'SKILL.md'
+    exclude:
+      - 'node_modules/**'
+      - '.git/**'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)


### PR DESCRIPTION
## What
Adds one external source entry to `sources.yaml`: `ki-sop-pack-situation-router`, a standalone free skill from `jalano0i9u8y7-lab/ki-sop-pack`.

## About the skill
A situation router — decides whether a request needs direct implementation, a plan stress-test first, or a chat-to-spec conversion first, before any code/spec gets written. Adapted from mattpocock/skills' `ask-matt` router pattern (MIT), reframed as a standalone tool-agnostic router skill.

- Source repo: https://github.com/jalano0i9u8y7-lab/ki-sop-pack
- Skill path: `skills/situation-router/SKILL.md`
- License: MIT (both the adaptation and the upstream lineage)
- Category: `skill-enhancers`
- `verified: false` (new source, happy to have it reviewed/vetted)

This is the free module of a 4-module bundle (KI SOP Pack v1); the other three modules are not included here — only this standalone router is being contributed to the marketplace.

## Checklist
- [x] Entry follows the documented `sources.yaml` schema (name/description/repo/source_path/target_path/author/license/category/include/exclude)
- [x] `include` limited to `SKILL.md`
- [x] License is MIT, compatible with marketplace mirroring
- [x] Attribution to upstream mattpocock/skills preserved in the skill's own frontmatter/README