### PR TITLE
fix(freshie): gate exports before Dolt identity setup

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -541,6 +541,11 @@ jobs:
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v6
+        with:
+          # E6.6 compares the PR range to origin/main. The default one-commit
+          # checkout makes Git treat both refs as shallow roots, so the
+          # fail-closed range check cannot find their merge base.
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -552,7 +557,7 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git fetch --no-tags origin "$BASE_REF"
           python3 scripts/check-marketplace-compliance-baseline.py \
             --check-growth-only \
             --base "origin/$BASE_REF" \

--- a/freshie/scripts/dolt-sync.py
+++ b/freshie/scripts/dolt-sync.py
@@ -1319,7 +1319,6 @@ def main() -> int:
             lock_fd = acquire_lock(repo.parent / ".sync.lock")
             if (repo / ".dolt").is_dir():
                 refuse_if_server_running(repo)
-            ensure_dolt_identity()
             # This is intentionally before VACUUM INTO: the snapshot is the
             # public-export input and must carry the demoted class, not merely
             # diagnose it after the fact.
@@ -1348,6 +1347,12 @@ def main() -> int:
         # Membership gate FIRST (also in --dry-run): an unknown table must
         # hard-fail before any DDL/plan output normalizes its presence.
         gate_export_allowlist(tables)
+        # A source that cannot be exported must fail before environment-
+        # dependent publication setup can mask the security refusal.  Once it
+        # is known publishable, a real export still requires a configured Dolt
+        # identity before it can create or update the destination repository.
+        if not args.dry_run:
+            ensure_dolt_identity()
         violations = scan_type_violations(conn, schema)
         widen = frozenset(violations)
         for (t, c), n in sorted(violations.items()):


### PR DESCRIPTION
Fixes CI run 33130480805 where a clean runner's missing Dolt identity hid the required source-table allowlist refusal.\n\nBead: claude-h05s.15\n\nValidation:\n- python3 -m unittest tests.test_dolt_sync.ForgeProofRetentionGateTests.test_cli_refuses_leaked_jrig_table_before_creating_dolt_repo -v\n- python3 -m unittest tests.test_dolt_sync -v (52 tests)