### PR TITLE
fix(freshie): enforce run completeness in dry runs

### DIFF
--- a/freshie/scripts/dolt-sync.py
+++ b/freshie/scripts/dolt-sync.py
@@ -1372,6 +1372,12 @@ def main() -> int:
         run_id_row = conn.execute("SELECT MAX(id) FROM discovery_runs").fetchone()
         run_id = int(run_id_row[0] or 0)
 
+        # A dry run is a publish preflight, not merely a DDL preview.  It must
+        # reject the same phantom/internally inconsistent inventory runs that
+        # a real export rejects, before printing a plan that could be mistaken
+        # for approval to publish.
+        gate_run_completeness(conn, run_id)
+
         if args.dry_run:
             for t in tables:
                 print(ddls[t] + "\n")
@@ -1381,7 +1387,6 @@ def main() -> int:
                 f"JSON checks on {[f'{t}.{c}' for t, c in JSON_CHECKSUM_COLUMNS]}")
             return 0
 
-        gate_run_completeness(conn, run_id)
         gate_varchar_lengths(conn, guards)
         ensure_repo(repo)
 

--- a/tests/test_dolt_sync.py
+++ b/tests/test_dolt_sync.py
@@ -580,6 +580,31 @@ class RunCompletenessGateTests(unittest.TestCase):
         self.assertIn("mismatch", message)
         conn.close()
 
+    def test_dry_run_refuses_internally_inconsistent_latest_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / "inventory.sqlite"
+            with sqlite3.connect(db) as conn:
+                conn.executescript(
+                    self.DDL
+                    + "INSERT INTO discovery_runs (id, total_skills) VALUES (6, 3000);"
+                )
+                conn.executemany(
+                    "INSERT INTO skills (id, name, run_id) VALUES (?, ?, 6)",
+                    [(index, f"skill-{index}") for index in range(1, 20)],
+                )
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--db", str(db), "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("3000", result.stdout)
+        self.assertIn("19", result.stdout)
+        self.assertIn("mismatch", result.stdout)
+
     def test_run_zero_passes(self):
         conn = fixture_conn(self.DDL)
         dolt_sync.gate_run_completeness(conn, 0)  # empty DB — nothing to judge


### PR DESCRIPTION
Bead: claude-h05s.1\n\nA dry-run is a publish preflight and now rejects an internally inconsistent newest run before emitting a DDL plan. Adds a hermetic 3000-header/19-row CLI regression without modifying the live inventory.\n\nValidation:\n- python3 -m unittest tests.test_dolt_sync.RunCompletenessGateTests -v\n- python3 -m unittest tests.test_dolt_sync -v (53 tests)