### PR TITLE
fix(governance): stop automatic review requests to Ope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,12 +25,10 @@
 
 # ---------------------------------------------------------------------------
 # area: ci-infra  — HIGH TRUST. A workflow edit can bypass every validator gate.
-# @opeyemiariyo-netizen is an Approver here (Lead promotion 2026-07-16 — see GOVERNANCE
-# § Vetting; the pipeline quiz was waived in favor of learn-on-the-job mentoring).
 # ---------------------------------------------------------------------------
 /.github/                           @jeremylongshore @blueandyellow44
-/.github/workflows/                 @jeremylongshore @blueandyellow44 @opeyemiariyo-netizen
-/.github/workflows/deploy-vps.yml   @jeremylongshore @blueandyellow44 @opeyemiariyo-netizen
+/.github/workflows/                 @jeremylongshore @blueandyellow44
+/.github/workflows/deploy-vps.yml   @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: validator-schema  — HIGH TRUST. The quality bar itself. Changes are
@@ -63,9 +61,8 @@
 
 # ---------------------------------------------------------------------------
 # area: marketplace-site  — the Astro site, design system, build pipeline.
-# @opeyemiariyo-netizen is an Approver here (Lead promotion 2026-07-16).
 # ---------------------------------------------------------------------------
-/marketplace/                       @jeremylongshore @blueandyellow44 @opeyemiariyo-netizen
+/marketplace/                       @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: freshie  — the inventory CMDB, Dolt sync, grading.

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3128,
-        "tracked_files": 23184
+        "tracked_files": 23185
       }
     },
     "2": {
@@ -1780,7 +1780,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23184
+        "tracked_files": 23185
       }
     },
     "47": {


### PR DESCRIPTION
## Summary
- remove Ope from all CODEOWNERS rules
- stop automatic review requests for marketplace and workflow changes
- preserve main branch protection and required status checks unchanged

## Tracking
- Bead: claude-oa2o

## Validation
- `rg -n "@opeyemiariyo-netizen" .github/CODEOWNERS` (no matches)
- `git diff --check`