### PR TITLE
feat(plugins-business-tools): add postwire — publish natively to every social network

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -9776,6 +9776,27 @@
         "skills": 32,
         "total": 32
       }
+    },
+    {
+      "name": "postwire",
+      "source": "./plugins/business-tools/postwire",
+      "description": "Publish and schedule to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord from your agent - writing a separate native post for each network instead of the same text everywhere, and refusing posts that would fail before they are queued.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "social-media",
+        "tiktok",
+        "instagram",
+        "scheduling",
+        "mcp"
+      ],
+      "author": {
+        "name": "PostWire",
+        "url": "https://postwire.io"
+      },
+      "homepage": "https://postwire.io",
+      "repository": "https://github.com/Perufitlife/postwire-skills",
+      "license": "MIT"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8496,6 +8496,27 @@
         "email": "jeremy@intentsolutions.io"
       },
       "license": "MIT"
+    },
+    {
+      "name": "postwire",
+      "source": "./plugins/business-tools/postwire",
+      "description": "Publish and schedule to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord from your agent - writing a separate native post for each network instead of the same text everywhere, and refusing posts that would fail before they are queued.",
+      "version": "1.0.0",
+      "category": "business-tools",
+      "keywords": [
+        "social-media",
+        "tiktok",
+        "instagram",
+        "scheduling",
+        "mcp"
+      ],
+      "author": {
+        "name": "PostWire",
+        "url": "https://postwire.io"
+      },
+      "homepage": "https://postwire.io",
+      "repository": "https://github.com/Perufitlife/postwire-skills",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/business-tools/postwire/.claude-plugin/plugin.json
+++ b/plugins/business-tools/postwire/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "postwire",
+  "version": "1.0.0",
+  "description": "Publish and schedule to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord from your agent \u2014 writing a separate native post for each network instead of the same text everywhere, and refusing posts that would fail before they are queued.",
+  "author": {
+    "name": "PostWire",
+    "url": "https://postwire.io"
+  },
+  "homepage": "https://postwire.io",
+  "license": "MIT",
+  "keywords": [
+    "social-media",
+    "tiktok",
+    "instagram",
+    "scheduling",
+    "mcp"
+  ],
+  "skills": [
+    "./skills/postwire"
+  ]
+}

--- a/plugins/business-tools/postwire/.mcp.json
+++ b/plugins/business-tools/postwire/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "postwire": {
+      "type": "http",
+      "url": "https://postwire.io/mcp"
+    }
+  }
+}

--- a/plugins/business-tools/postwire/LICENSE
+++ b/plugins/business-tools/postwire/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PostWire
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/business-tools/postwire/README.md
+++ b/plugins/business-tools/postwire/README.md
@@ -1,0 +1,42 @@
+# PostWire
+
+Publish one idea to every social network, with a **different post written for each one**.
+
+TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and
+Discord, through a single API key. Accounts are connected once by OAuth in the PostWire dashboard,
+so there is no per-platform developer app or review queue to maintain.
+
+## Why not just send the same string everywhere
+
+Because it reads badly and the platforms suppress it. A LinkedIn post written like a tweet performs
+like neither. PostWire has a generate step that writes a caption per network — length, tone, hashtags
+and link handling — from one prompt.
+
+## The part that matters in an agent loop
+
+Media rules are checked **before** the post is queued:
+
+| network | requires |
+|---|---|
+| TikTok, YouTube | a video |
+| Instagram | a photo or video |
+| everything else | text is enough |
+
+So an agent gets `media_required` at the moment it asks, rather than a silent failure at 7am. The
+skill documents the error codes worth branching on: `not_connected`, `media_required`, `preview_key`.
+
+## Install
+
+The plugin ships both a skill and an MCP server:
+
+- **Skill** — `skills/postwire/SKILL.md`, documents the REST API with verified examples.
+- **MCP** — `https://postwire.io/mcp` (HTTP), so the agent calls tools instead of writing curl.
+
+Set `POSTWIRE_API_KEY` from the **API & MCP** page of the dashboard. The free tier is one brand and
+30 posts a month, no card.
+
+## Links
+
+- Site: https://postwire.io
+- MCP endpoint: https://postwire.io/mcp
+- npm (stdio variant): https://www.npmjs.com/package/postwire-mcp

--- a/plugins/business-tools/postwire/SECURITY.md
+++ b/plugins/business-tools/postwire/SECURITY.md
@@ -1,0 +1,98 @@
+# PostWire hosted MCP — security note
+
+Written for the marketplace's hosted-MCP audit. It describes what the server does today, including
+the parts that are not implemented; anything listed as missing is missing.
+
+## What the plugin talks to
+
+- **Hosted MCP:** `https://postwire.io/api/mcp` — Streamable HTTP, stateless (a fresh server and
+  transport per request, so no session state is retained between calls).
+- **Local alternative:** `npx -y postwire-mcp` over stdio, same five tools.
+
+Both are thin adapters. Every tool proxies to PostWire's REST API with the caller's key, so
+authentication, plan limits, rate limiting and validation are enforced in one place rather than
+duplicated in the MCP layer.
+
+## Authentication: storage and transport
+
+- **Transport is HTTPS.** Plain HTTP is answered with a 308 redirect to the HTTPS URL; the API is
+  not served over an unencrypted connection.
+- **The key is supplied by the caller per request**, as `Authorization: Bearer pw_live_...`. The
+  server holds no credential of its own for the caller, and stores nothing between requests.
+- **Keys are stored hashed.** The database keeps a SHA-256 hash (`key_hash`) plus a short
+  non-secret prefix for display. The raw key is shown once at creation and cannot be recovered — a
+  database read does not yield a usable credential.
+- **Keys can be revoked** (`revoked` flag, checked on every lookup) and may carry an expiry.
+- **Scoped keys:** a key created before the account's email is verified has `scope: "preview"` and
+  cannot publish; it is promoted to `full` only when the address is confirmed.
+- The endpoint also accepts the key as a `?api_key=` query parameter, because several MCP clients
+  cannot set headers. **This is less safe** — query strings appear in proxy and server logs — and
+  the header form should be preferred wherever the client supports it.
+- **The social network tokens never leave the server.** The caller's API key is not a social token;
+  OAuth credentials are held server-side and are never returned by any tool.
+
+## Tool annotations
+
+Declared on every tool, in both the hosted and stdio servers, so a client can decide what needs
+confirmation:
+
+| Tool | readOnly | destructive | idempotent | openWorld |
+|---|---|---|---|---|
+| `generate_posts` | yes | no | no | yes |
+| `post_to_social` | **no** | **yes** | **no** | yes |
+| `get_post_status` | yes | no | yes | yes |
+| `list_platforms` | yes | no | yes | yes |
+| `my_account` | yes | no | yes | yes |
+
+`post_to_social` is the only public write. It is marked destructive because once a network accepts a
+post it is visible to a real audience, and PostWire cannot reliably retract it — deletion support
+varies by platform and is not exposed as a tool.
+
+## Server-side enforcement
+
+None of this depends on the client behaving well; it is enforced in the API:
+
+- **Ownership** — every call resolves to an account through the key; a caller can only touch its own
+  connections and posts.
+- **Plan limits** — the monthly post count is checked *before* publishing, and only successful posts
+  are billed.
+- **Rate limits** — per-account buckets (for example 60 posts/minute, 60 media uploads/hour).
+- **Pre-flight validation** — before anything is sent: the account must have connected each
+  requested network, the text must be within that platform's character limit, and video networks
+  must have a video. A request naming a network the account has not connected is refused **whole**,
+  rather than publishing to the others and leaving a partial result.
+- **Media** — uploads are restricted by content type and size, and stored under a per-account path.
+
+## Replay and duplicate posts
+
+**There is no idempotency key today, and this is the weakest point of the design.** A repeated
+`post_to_social` call with the same arguments will publish again. Two consequences worth stating
+plainly:
+
+- An agent that retries on a network timeout can double-post. The publish call is not safe to
+  retry blindly.
+- `idempotentHint: false` on `post_to_social` reflects this honestly rather than claiming a
+  guarantee the server does not provide.
+
+What exists instead is partial mitigation: a per-account rate limit, and a scheduler that treats a
+partially successful run as done specifically so a retry cannot repost the items that already
+worked. An explicit client-supplied idempotency key is the correct fix and is not implemented.
+
+## Confirm before publishing
+
+The skill instructs the agent to show the drafts and get explicit confirmation before calling
+`post_to_social`. **That instruction is a prompt, not an enforcement mechanism** — a model can
+ignore it.
+
+What is enforced in code is narrower and should not be mistaken for the same thing: the destructive
+annotation above (so clients that gate destructive tools will prompt), plan and rate limits, and
+refusal of an entire request when any platform would fail. The server does not, and cannot, verify
+that a human saw the draft.
+
+Operators who need a hard gate should run the tool in a client that requires approval for
+non-read-only tools.
+
+## Reporting
+
+Security reports: **privacy@postwire.io**, or the support form at https://postwire.io/support.html
+(both are monitored by the maintainer).

--- a/plugins/business-tools/postwire/docs/PRD.md
+++ b/plugins/business-tools/postwire/docs/PRD.md
@@ -1,0 +1,69 @@
+# PRD: postwire
+
+**Author:** Renzo Madueño (PostWire)
+**Date:** 2026-09-02
+**Status:** Active
+
+## Problem
+
+Publishing one idea to several social networks is not one job, it is five, and the failure is
+silent. Each network wants a different shape — YouTube needs a title, description and tags; TikTok
+caps at 2,200 characters and rewards a hook in the first line; LinkedIn suppresses reach on posts
+with a link in the body; X cuts at 280. An agent that sends identical text everywhere produces a
+post that underperforms on four of the five, and nobody tells it.
+
+The second half of the problem is worse: partial failure. Ask for four networks, get two. From
+PostWire's own logs, one user made **30 publish attempts and got 3 successes** over six hours,
+because the API accepted requests naming networks that account had never connected and published to
+whichever ones happened to work. Of eight accounts that connected a network and never published,
+**four had connected only YouTube and TikTok** — both refuse a post without a video, and nothing
+said so until after the post was written.
+
+Connecting the accounts is its own wall. TikTok's App Review asks for a demo video of the working
+integration you cannot build until you are approved.
+
+## Target users
+
+| User                     | Context                                                         | Primary need                                              |
+| ------------------------ | --------------------------------------------------------------- | --------------------------------------------------------- |
+| Developer with an agent  | Wants the agent to publish, not to hand back a draft to paste    | One tool call that actually posts, and fails loudly        |
+| Solo founder / creator   | Announcing releases across networks without writing five posts   | A native version per network from one idea                 |
+| Small agency             | Several client brands, each with its own set of accounts         | Per-brand separation, flat pricing, no per-network fee     |
+| Automation builder (n8n) | A workflow that should post a video from Drive or a blog RSS     | HTTP endpoints that validate before publishing             |
+
+## Success criteria
+
+1. **No partial publishes.** A request naming an unconnected network, a caption over that platform's
+   limit, or a video network with no video is refused whole, before anything goes out.
+2. **A different post per network.** `generate_posts` returns a distinct draft per platform —
+   correct length, hashtag convention, and YouTube title plus tags — never the same string repeated.
+3. **Every failure names its fix.** An error states the platform, the actual number where a limit
+   applies, and the action to take. "youtube requires a video_url" is a fact; "youtube needs a video
+   — upload one in the composer or pass video_url" is an instruction.
+4. **A first post is reachable without a media file.** A user whose only connected networks require
+   video is offered a network that accepts text, rather than a dead end.
+
+## Functional requirements
+
+- **FR-1:** `post_to_social` publishes to one or more networks in a single call, and validates
+  connection, character limit and media requirements for every named platform **before** sending
+  any of them.
+- **FR-2:** `generate_posts` turns one prompt into a per-platform draft, applying that platform's
+  limit, format and hashtag conventions.
+- **FR-3:** `list_platforms` answers **without an API key**, so an agent can show what is supported
+  before its user has signed up.
+- **FR-4:** `my_account` reports plan, monthly usage and connected accounts, so an agent can explain
+  a quota refusal instead of retrying into it.
+- **FR-5:** Tool annotations mark `post_to_social` as non-read-only and destructive, so a client can
+  require confirmation before a public write.
+
+## Out of scope
+
+- **Analytics and engagement metrics.** This publishes; it does not report on how a post performed.
+- **Deleting or editing published posts.** Retraction support varies by platform and is deliberately
+  not exposed as a tool — see `SECURITY.md`.
+- **Replying, commenting or DMs.** Publishing only.
+- **Hosting a media library.** Uploads are a short-lived staging step to give a network a URL it can
+  read, not durable storage.
+- **Guaranteed idempotency.** There is no idempotency key today; a repeated publish call posts
+  again. Stated plainly in `SECURITY.md` rather than implied away.

--- a/plugins/business-tools/postwire/skills/postwire/SKILL.md
+++ b/plugins/business-tools/postwire/skills/postwire/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: postwire
+category: social-media
+description: "Publish and schedule to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord through one PostWire API call — writing a separate, native version of the post for each network instead of sending identical text everywhere. Use when the user wants to publish or schedule one idea across several platforms, wants per-network captions, or wants to know why a post was rejected before it is sent."
+license: MIT
+requires:
+  env: [POSTWIRE_API_KEY]
+---
+
+# PostWire
+
+Publish one idea to many social networks, with a **different post written for each one**.
+
+Accounts are connected once through OAuth in the PostWire dashboard, so there is no per-platform
+developer app, review queue, or token refresh to maintain. One API key covers every network.
+
+## When to Use This Skill
+
+- The user wants the same idea published to several networks, but written properly for each
+- The user wants a post scheduled for later, or a week of posts queued from one topic
+- The user asks why a post failed, or whether a post *will* fail before sending it
+- The user is publishing video to TikTok or YouTube from an automation
+
+## What Makes This Different
+
+Most multi-posting APIs take one string and send it to every platform. That reads badly and gets
+suppressed: a LinkedIn post written like a tweet performs like neither. PostWire has a `/api/generate`
+step that writes a caption per network — length, tone, hashtags and link handling — from a single
+prompt, which you then pass to publish or schedule.
+
+It also **refuses posts that are going to fail**, before they are queued rather than after the
+platform rejects them:
+
+| network | requires |
+|---|---|
+| TikTok, YouTube | a video (`video_url`) |
+| Instagram | a photo or a video |
+| everything else | text is enough |
+
+## Prerequisites
+
+- An account at [postwire.io](https://postwire.io) — free tier: 1 brand, 30 posts/month, no card
+- Networks connected in the dashboard (one OAuth click each)
+- `POSTWIRE_API_KEY` in the environment
+
+**Auth is `Authorization: Bearer $POSTWIRE_API_KEY`.**
+
+One gotcha worth knowing: the dashboard shows a *preview* key immediately after signup, before the
+email is confirmed. That key cannot publish. If the API answers `"This is a preview key"`
+(`code: "preview_key"`), confirm the email and take the key from **API & MCP** in the dashboard.
+
+## How to Use
+
+Base URL: `https://postwire.io/api`
+
+### Check what is connected
+
+```bash
+curl https://postwire.io/api/me -H "Authorization: Bearer $POSTWIRE_API_KEY"
+```
+
+Returns the plan, the monthly usage, and `connections[]` — publish only to networks listed there,
+otherwise the call fails with `code: "not_connected"` and the offending platforms.
+
+### Write a native caption per network
+
+```bash
+curl -X POST https://postwire.io/api/generate \
+  -H "Authorization: Bearer $POSTWIRE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "We shipped streaming uploads: 1GB videos now go through in 11 seconds",
+    "platforms": ["linkedin", "x", "bluesky"]
+  }'
+```
+
+Returns `{ "drafts": { "linkedin": {...}, "x": {...}, "bluesky": {...} } }`. Pass that object
+straight through as `per_platform` below.
+
+### Publish now
+
+```bash
+curl -X POST https://postwire.io/api/post \
+  -H "Authorization: Bearer $POSTWIRE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platforms": ["linkedin", "x"],
+    "per_platform": { "linkedin": {"text": "..."}, "x": {"text": "..."} }
+  }'
+```
+
+Without `per_platform`, a single `text` is used everywhere — simpler, but it is the behaviour this
+tool exists to avoid.
+
+The response is **per platform**, and one failure does not cancel the rest:
+
+```json
+{ "results": [ { "ok": true, "platform": "linkedin", "id": "..." },
+               { "ok": false, "platform": "x", "error": "..." } ] }
+```
+
+### Schedule instead
+
+```bash
+curl -X POST https://postwire.io/api/schedule \
+  -H "Authorization: Bearer $POSTWIRE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "run_at": "2026-09-01T09:00:00Z",
+    "platforms": ["linkedin", "instagram"],
+    "photo_url": "https://example.com/image.jpg",
+    "label": "Launch announcement"
+  }'
+```
+
+`run_at` is ISO 8601. The schedule endpoint validates connections *and* the media rules up front, so
+a post that cannot work is rejected now instead of failing quietly at 7am.
+
+### Fill a week from one topic
+
+```bash
+curl -X POST https://postwire.io/api/week \
+  -H "Authorization: Bearer $POSTWIRE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "topic": "what we learned running a one-person SaaS", "platforms": ["linkedin", "x"], "days": 5 }'
+```
+
+Five angles on one topic, queued across five days. Text-only networks only — the video platforms
+would reject every one of them, and the endpoint says so rather than queueing them to fail.
+
+## Errors Worth Handling
+
+| code | meaning | fix |
+|---|---|---|
+| `preview_key` | key from before email confirmation | confirm email, use the key in API & MCP |
+| `email_unverified` | mailbox not confirmed yet | open the emailed link |
+| `not_connected` | platform not connected; `platforms[]` lists which | connect it in the dashboard |
+| `media_required` | TikTok/YouTube without video, Instagram without media | add `video_url` or `photo_url` |
+| 429 | monthly plan limit or a burst guard | check `usage` in `/api/me` |
+
+## Media Notes
+
+- Media is passed by URL (`video_url`, `photo_url`); PostWire fetches and forwards the bytes.
+- TikTok and YouTube videos are streamed in chunks, so they can be up to **1GB**. Other networks and
+  hosts that do not send `Content-Length` are capped at 80MB, because the file has to be held in memory.
+- `POST /api/media/upload-url` returns a signed URL to upload a file directly (max 50MB) if you do
+  not have somewhere to host it.
+
+## Also Available
+
+PostWire ships an **MCP server**, so an agent can call these as tools rather than as HTTP requests,
+and there are n8n templates for the same flows. Both are linked from the dashboard.

--- a/plugins/business-tools/postwire/skills/postwire/SKILL.md
+++ b/plugins/business-tools/postwire/skills/postwire/SKILL.md
@@ -74,8 +74,25 @@ curl -X POST https://postwire.io/api/generate \
   }'
 ```
 
-Returns `{ "drafts": { "linkedin": {...}, "x": {...}, "bluesky": {...} } }`. Pass that object
-straight through as `per_platform` below.
+Returns `{ "drafts": { "linkedin": {...}, "x": {...}, "bluesky": {...} } }`. That object is what
+`per_platform` takes below — but show it to the user first, for the reason in the next section.
+
+## Confirm Before Publishing
+
+`/api/post` and `/api/schedule` are **visible writes**: they put text under the user's own name, in
+public, where other people see it. Treat them the way you would treat sending an email as them.
+
+Before either call, show the user:
+
+- the **exact text** that will go out, per network — not the prompt that generated it
+- **which networks** it is going to
+- **when** it publishes (now, or the exact `run_at`)
+
+and wait for a yes.
+
+This matters most right after `/api/generate`. Those drafts are model output: passing them straight
+into `per_platform` without showing them means the user finds out what they said by reading their own
+timeline. Generate, show, confirm, then post.
 
 ### Publish now
 

--- a/plugins/business-tools/postwire/skills/postwire/SKILL.md
+++ b/plugins/business-tools/postwire/skills/postwire/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: postwire
-category: social-media
-description: "Publish and schedule to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord through one PostWire API call — writing a separate, native version of the post for each network instead of sending identical text everywhere. Use when the user wants to publish or schedule one idea across several platforms, wants per-network captions, or wants to know why a post was rejected before it is sent."
+description: "Publish and schedule to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord through one PostWire API call — writing a separate, native version of the post for each network instead of sending identical text everywhere. Use when the user wants to publish or schedule one idea across several platforms, wants per-network captions, or wants to know why a post was rejected before it is sent. Trigger with \"post this to X and LinkedIn\", \"schedule a week of posts\", or \"why did my TikTok post fail\"."
+allowed-tools: mcp__postwire__generate_posts, mcp__postwire__post_to_social, mcp__postwire__get_post_status, mcp__postwire__list_platforms, mcp__postwire__my_account
+version: 1.0.0
+author: PostWire <privacy@postwire.io>
 license: MIT
-requires:
-  env: [POSTWIRE_API_KEY]
+compatibility: Claude Code, Claude Desktop, Cursor, VS Code and Windsurf. Uses PostWire's hosted MCP server at https://postwire.io/api/mcp (Streamable HTTP) or the postwire-mcp npm package over stdio. Requires a PostWire API key; the free tier covers one brand and 30 posts a month.
+tags: [social-media, publishing, scheduling, mcp, tiktok, instagram, youtube, linkedin, cross-posting]
 ---
 
 # PostWire
@@ -20,6 +22,12 @@ developer app, review queue, or token refresh to maintain. One API key covers ev
 - The user wants a post scheduled for later, or a week of posts queued from one topic
 - The user asks why a post failed, or whether a post *will* fail before sending it
 - The user is publishing video to TikTok or YouTube from an automation
+
+## Overview
+
+PostWire turns one idea into a separate, native post per network and publishes it through a
+single call. Accounts are connected once by OAuth in the PostWire dashboard, so there is no
+per-platform developer app, review queue or token refresh to maintain.
 
 ## What Makes This Different
 
@@ -145,7 +153,7 @@ curl -X POST https://postwire.io/api/week \
 Five angles on one topic, queued across five days. Text-only networks only — the video platforms
 would reject every one of them, and the endpoint says so rather than queueing them to fail.
 
-## Errors Worth Handling
+## Error Handling
 
 | code | meaning | fix |
 |---|---|---|
@@ -167,3 +175,48 @@ would reject every one of them, and the endpoint says so rather than queueing th
 
 PostWire ships an **MCP server**, so an agent can call these as tools rather than as HTTP requests,
 and there are n8n templates for the same flows. Both are linked from the dashboard.
+
+## Output
+
+`generate_posts` returns `{ drafts: { <platform>: { text, title?, tags? } } }` — one draft per
+requested network, each already within that platform's limits.
+
+`post_to_social` returns `{ results: [...] }`, one entry per platform, each either
+`{ ok: true, platform, id, url }` or `{ ok: false, platform, error, code }`. The call is
+**all-or-nothing on validation**: if any named platform would fail a pre-flight check (not
+connected, caption too long, video network with no video) the whole request is refused before
+anything publishes, so a four-network post never leaves two live and two silently missing.
+
+`my_account` returns the plan, the month's usage against its limit, and the connected accounts.
+
+## Examples
+
+**Publish one idea, written per network**
+
+```
+1. generate_posts { prompt: "we shipped scheduling today", platforms: ["x","linkedin","bluesky"] }
+2. show the three drafts to the user and get confirmation
+3. post_to_social { platforms: ["x","linkedin","bluesky"], per_platform: <drafts from step 1> }
+```
+
+**Publish a video to TikTok and YouTube**
+
+```
+post_to_social {
+  platforms: ["tiktok","youtube"],
+  video_url: "https://example.com/clip.mp4",
+  per_platform: { youtube: { title: "...", text: "...", tags: [...] }, tiktok: { text: "..." } },
+  privacy: "public"
+}
+```
+
+**Check what is supported before signing up** — `list_platforms` needs no API key, so an agent can
+answer "can you post to Mastodon?" before the user has an account.
+
+## Resources
+
+- Dashboard and API key: https://postwire.io/dashboard.html
+- Hosted MCP endpoint: `https://postwire.io/api/mcp` (Streamable HTTP)
+- npm package: https://www.npmjs.com/package/postwire-mcp
+- Per-client setup: https://postwire.io/mcp/
+- Security note for this plugin: `SECURITY.md`, in the plugin root next to this skill


### PR DESCRIPTION
Adds `plugins/business-tools/postwire` with a skill **and** a hosted MCP server.

**What it does:** publishes and schedules to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Facebook, Threads, Reddit, Telegram and Discord through one API key, writing a **separate caption per network** rather than sending the same string everywhere.

**Why the distinction matters for an agent:** a LinkedIn post written like a tweet performs like neither, and the platforms suppress it. There is a generate step that produces one draft per network from a single prompt.

**The part most useful in an agent loop:** the media rules are validated *before* the post is queued — TikTok and YouTube need a video, Instagram needs media — so the agent gets a `media_required` code at the moment it asks, instead of a silent failure at 7am. The skill lists the error codes worth branching on: `not_connected`, `media_required`, `preview_key`.

**MCP included:** `https://postwire.io/mcp` (HTTP), so the agent can call tools directly rather than composing curl.

Notes on the diff:
- Both marketplace files are **+21 / -0**. I inserted the entry as text rather than reserialising the JSON, so there is no reformatting noise in the diff.
- Every endpoint, response shape and error code in `SKILL.md` was checked against the live API before opening this, including the failure cases, so the examples are what the API returns rather than what the docs claim.

Disclosure: I build PostWire. Happy to adjust structure, category or wording to match the collection.