### PR TITLE
feat(ci): enforce marketplace compliance metric ratchets

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -534,12 +534,13 @@ jobs:
           done
           echo "✅ Dependency scan complete"
 
-  # Blueprint 727 E6.4: R1 needs an independently visible, always-reporting
-  # blocking job.  It is listed in ci-required below rather than being folded
-  # into `validate`, so a pre-existing failure in an unrelated validation lane
-  # cannot obscure the compliance-ratchet result.  The validator emits the
-  # complete skills/commands/agents/manifests corpus; observed runtime is
-  # about 70 seconds, bounded here at two minutes.
+  # Blueprint 727 E6.4/E6.7: R1 plus the post-observation R2/R4 monotone metric
+  # checks need an independently visible, always-reporting blocking job.  It
+  # is listed in ci-required below rather than folded into `validate`, so a
+  # pre-existing failure in an unrelated validation lane cannot obscure the
+  # compliance-ratchet result.  The validator emits the complete
+  # skills/commands/agents/manifests corpus; observed runtime is about 70
+  # seconds, bounded here at two minutes.
   marketplace-compliance-ratchet:
     name: marketplace-compliance-ratchet
     runs-on: ubuntu-latest
@@ -567,7 +568,7 @@ jobs:
             --check-growth-only \
             --base "origin/$BASE_REF" \
             --head-ref "$HEAD_REF"
-      - name: Reject marketplace compliance debt outside the pinned baseline
+      - name: Enforce R1/R2/R4 marketplace compliance ratchet
         run: |
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml
           python3 scripts/check-marketplace-compliance-baseline.py

--- a/scripts/check-marketplace-compliance-baseline.py
+++ b/scripts/check-marketplace-compliance-baseline.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -64,6 +65,52 @@ def metadata_drift(baseline: dict[str, Any], current: dict[str, Any]) -> list[st
             errors.append(f"unknown live rule id(s): {', '.join(added)}")
         if removed:
             errors.append(f"baseline rule id(s) absent from live inventory: {', '.join(removed)}")
+    return errors
+
+
+def metric_drift(baseline: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    """Return violations of the E6.7 monotone marketplace metrics.
+
+    R2 prevents a fix from increasing the total number of validator errors.
+    R4 prevents corpus dilution by requiring the A-plus-B share to hold or
+    improve.  These checks deliberately compare the emitted totals rather than
+    recomputing them here, keeping the canonical validator the sole owner of
+    metric classification.
+    """
+
+    errors: list[str] = []
+    baseline_totals = baseline.get("totals")
+    current_totals = current.get("totals")
+    if not isinstance(baseline_totals, dict) or not isinstance(current_totals, dict):
+        return ["baseline and live payload must declare object totals"]
+
+    for key in ("errors", "grade_A_plus_B_pct"):
+        baseline_value = baseline_totals.get(key)
+        current_value = current_totals.get(key)
+        if isinstance(baseline_value, bool) or not isinstance(baseline_value, (int, float)):
+            errors.append(f"baseline totals.{key} must be a finite number")
+            continue
+        if isinstance(current_value, bool) or not isinstance(current_value, (int, float)):
+            errors.append(f"live totals.{key} must be a finite number")
+            continue
+        if not math.isfinite(baseline_value):
+            errors.append(f"baseline totals.{key} must be a finite number")
+            continue
+        if not math.isfinite(current_value):
+            errors.append(f"live totals.{key} must be a finite number")
+            continue
+        if baseline_value < 0 or current_value < 0:
+            errors.append(f"totals.{key} must be non-negative")
+            continue
+        if key == "errors" and current_value > baseline_value:
+            errors.append(
+                f"totals.errors increased: baseline={baseline_value:g}, live={current_value:g}"
+            )
+        elif key == "grade_A_plus_B_pct" and current_value < baseline_value:
+            errors.append(
+                "totals.grade_A_plus_B_pct fell: "
+                f"baseline={baseline_value:g}, live={current_value:g}"
+            )
     return errors
 
 
@@ -159,6 +206,13 @@ def main() -> int:
     if drift:
         print("marketplace-compliance-ratchet: FAIL — baseline contract drift:", file=sys.stderr)
         for error in drift:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    metric_failures = metric_drift(baseline, current)
+    if metric_failures:
+        print("marketplace-compliance-ratchet: FAIL — non-monotone marketplace metrics:", file=sys.stderr)
+        for error in metric_failures:
             print(f"  {error}", file=sys.stderr)
         return 1
 

--- a/scripts/check-marketplace-compliance-baseline.py
+++ b/scripts/check-marketplace-compliance-baseline.py
@@ -103,14 +103,9 @@ def metric_drift(baseline: dict[str, Any], current: dict[str, Any]) -> list[str]
             errors.append(f"totals.{key} must be non-negative")
             continue
         if key == "errors" and current_value > baseline_value:
-            errors.append(
-                f"totals.errors increased: baseline={baseline_value:g}, live={current_value:g}"
-            )
+            errors.append(f"totals.errors increased: baseline={baseline_value:g}, live={current_value:g}")
         elif key == "grade_A_plus_B_pct" and current_value < baseline_value:
-            errors.append(
-                "totals.grade_A_plus_B_pct fell: "
-                f"baseline={baseline_value:g}, live={current_value:g}"
-            )
+            errors.append(f"totals.grade_A_plus_B_pct fell: baseline={baseline_value:g}, live={current_value:g}")
     return errors
 
 

--- a/tests/test_marketplace_compliance_ratchet.py
+++ b/tests/test_marketplace_compliance_ratchet.py
@@ -62,6 +62,45 @@ class MarketplaceComplianceRatchetTests(unittest.TestCase):
             ["schema_version drift: baseline=4.1.0, live=4.2.0"],
         )
 
+    def test_monotone_metrics_allow_equal_or_improved_values(self):
+        baseline = {
+            "totals": {"errors": 10, "grade_A_plus_B_pct": 75.0},
+        }
+        current = {
+            "totals": {"errors": 9, "grade_A_plus_B_pct": 80.0},
+        }
+        self.assertEqual(self.ratchet.metric_drift(baseline, current), [])
+
+    def test_error_total_growth_fails_r2(self):
+        baseline = {"totals": {"errors": 10, "grade_A_plus_B_pct": 75.0}}
+        current = {"totals": {"errors": 11, "grade_A_plus_B_pct": 75.0}}
+        self.assertEqual(
+            self.ratchet.metric_drift(baseline, current),
+            ["totals.errors increased: baseline=10, live=11"],
+        )
+
+    def test_a_plus_b_share_dilution_fails_r4(self):
+        baseline = {"totals": {"errors": 10, "grade_A_plus_B_pct": 75.0}}
+        current = {"totals": {"errors": 10, "grade_A_plus_B_pct": 74.5}}
+        self.assertEqual(
+            self.ratchet.metric_drift(baseline, current),
+            ["totals.grade_A_plus_B_pct fell: baseline=75, live=74.5"],
+        )
+
+    def test_monotone_metrics_fail_closed_when_totals_are_missing(self):
+        self.assertEqual(
+            self.ratchet.metric_drift({}, {"totals": {}}),
+            ["baseline and live payload must declare object totals"],
+        )
+
+    def test_monotone_metrics_fail_closed_on_non_numeric_values(self):
+        baseline = {"totals": {"errors": 10, "grade_A_plus_B_pct": 75.0}}
+        current = {"totals": {"errors": "10", "grade_A_plus_B_pct": 75.0}}
+        self.assertEqual(
+            self.ratchet.metric_drift(baseline, current),
+            ["live totals.errors must be a finite number"],
+        )
+
     def test_baseline_growth_is_refused_on_a_regular_pull_request(self):
         baseline = {"entries": ["a/SKILL.md :: E-ONE :: name"]}
         current = {"entries": ["a/SKILL.md :: E-ONE :: name", "b/SKILL.md :: E-TWO :: tags"]}


### PR DESCRIPTION
## Summary

- rescue Blueprint 727 E6.7 from unrelated PR #1340 onto a clean modernization branch
- refuse growth in `totals.errors` (R2)
- refuse dilution of `totals.grade_A_plus_B_pct` (R4)
- keep the validator as the sole metric owner

## Beads

- `claude-nfzl.7`

## Evidence

- `python3 -m unittest tests.test_marketplace_compliance_ratchet tests.test_marketplace_compliance_baseline` — 18 passed
- `python3 scripts/check-marketplace-compliance-baseline.py` — OK, 2,097 live triples; no entries outside baseline
- Python compile, Ruff, Prettier, Actionlint, and `git diff --check` passed
- `./scripts/quick-test.sh` exited 0: build and lint passed; existing standard-tier validator debt remained report-only (386 errors)

## Timing boundary

This lands the implementation but does not prematurely close E6.7. Blueprint 727 requires the R1 observation window to mature on/after 2026-09-09, followed by a fresh live receipt.

## Review boundary

No branch-protection or required-context changes. Required contexts remain `ci-required`, `gitleaks`, and `skill-conform`.
