### PR TITLE
fix(ci): enforce privileged action SHA pins

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -27,10 +27,10 @@ jobs:
     name: pre-deploy gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -64,7 +64,7 @@ jobs:
           echo "build artifacts present (max line: $MAX_LINE chars)"
 
       - name: Upload dist as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: marketplace-dist
           path: marketplace/dist

--- a/.github/workflows/publish-all-packages.yml
+++ b/.github/workflows/publish-all-packages.yml
@@ -102,7 +102,7 @@ jobs:
       count: ${{ steps.list.outputs.count }}
       packages_json: ${{ steps.list.outputs.packages_json }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
@@ -140,11 +140,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [guard, enumerate, preflight]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
@@ -186,11 +186,11 @@ jobs:
     outputs:
       publication_report: ${{ steps.publish.outputs.publication_report }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-changed-packages.yml
+++ b/.github/workflows/publish-changed-packages.yml
@@ -103,7 +103,7 @@ jobs:
       count: ${{ steps.build.outputs.count }}
       packages_json: ${{ steps.build.outputs.packages_json }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
@@ -156,11 +156,11 @@ jobs:
     outputs:
       publication_report: ${{ steps.publish.outputs.publication_report }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -51,7 +51,7 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: steps.check.outputs.should_run == 'true'
 
       - name: Install mcp-publisher

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -390,6 +390,11 @@ jobs:
       - name: Test npm publication locks
         run: node --test scripts/npm-publication-lock.test.mjs
 
+      # E7.9: any workflow that can mint OIDC credentials, publish to npm, or
+      # sign evidence must pin every external action to an immutable commit.
+      - name: Enforce privileged action SHA pins
+        run: pnpm run validate:privileged-action-pins
+
       - name: Pin the required skill-conform harness exactly
         run: node --test scripts/check-audit-harness-pin.test.mjs
 

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3130,
-        "tracked_files": 23128
+        "tracked_files": 23130
       }
     },
     "2": {
@@ -1548,17 +1548,27 @@
       }
     },
     "36": {
-      "cohort": "tracked privileged workflows",
+      "cohort": "tracked OIDC, npm-token, and signing workflows selected by the E7.9 privileged-action policy",
       "dimension": "Third-party actions on mutable tags in privileged workflows",
-      "reason_code": "MISSING_PRIVILEGED_WORKFLOW_POLICY",
       "reproduce": "pnpm run measure:e1 --row=36 --stdout",
-      "required_inputs": [
-        "machine-readable privileged-workflow definition",
-        "trusted-action pin policy"
+      "source": [
+        ".github/workflows/cli-publish.yml",
+        ".github/workflows/deploy-vps.yml",
+        ".github/workflows/emit-evidence.yml",
+        ".github/workflows/emit-publication-evidence.yml",
+        ".github/workflows/publish-all-packages.yml",
+        ".github/workflows/publish-changed-packages.yml",
+        ".github/workflows/publish-mcp-registry.yml",
+        ".github/workflows/release.yml",
+        ".github/workflows/verify-npm-production-credential.yml"
       ],
-      "source": [],
-      "status": "not_reproducible",
-      "values": null
+      "status": "measured",
+      "values": {
+        "distinct_actions": 8,
+        "mutable_uses": [],
+        "target_mutable_uses": 0,
+        "total_uses": 36
+      }
     },
     "37": {
       "cohort": "tracked .github Dependabot configuration",
@@ -1788,7 +1798,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23128
+        "tracked_files": 23130
       }
     },
     "47": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "validate:stats-freshness": "node --test scripts/check-stats-freshness.test.mjs && node scripts/check-stats-freshness.mjs --report",
     "validate:sources-lock-parity": "node --test scripts/check-sources-lock-parity.test.mjs && node scripts/check-sources-lock-parity.mjs",
     "validate:mirror-licenses": "node scripts/check-mirror-licenses.mjs",
+    "validate:privileged-action-pins": "node --test scripts/check-privileged-action-pins.test.mjs && node scripts/check-privileged-action-pins.mjs",
     "validate:mcp-plaintext-creds": "node --test scripts/check-mcp-plaintext-creds.test.mjs && node scripts/check-mcp-plaintext-creds.mjs",
     "validate:gitleaks-config": "node --test scripts/check-gitleaks-config.test.mjs && node scripts/check-gitleaks-config.mjs",
     "validate:mcp-destructive-policy": "node --test scripts/check-mcp-destructive-policy.test.mjs && node scripts/check-mcp-destructive-policy.mjs",

--- a/scripts/check-privileged-action-pins.mjs
+++ b/scripts/check-privileged-action-pins.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_DIRECTORY = '.github/workflows';
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
+export function isPrivilegedWorkflowText(text) {
+  return (
+    /\bid-token:\s*write\b/.test(text) ||
+    /\bsecrets\.NPM_TOKEN\b/.test(text) ||
+    /\bsigstore\/cosign-installer@/.test(text)
+  );
+}
+
+export function externalActionUses(path, text) {
+  const uses = [];
+  for (const [index, line] of text.split('\n').entries()) {
+    const match = line.match(/\buses:\s*([^\s#]+)/);
+    if (!match || match[1].startsWith('./') || match[1].startsWith('docker://')) continue;
+    const at = match[1].lastIndexOf('@');
+    if (at <= 0) {
+      uses.push({ action: match[1], line: index + 1, path, ref: '' });
+      continue;
+    }
+    uses.push({
+      action: match[1].slice(0, at),
+      line: index + 1,
+      path,
+      ref: match[1].slice(at + 1),
+    });
+  }
+  return uses;
+}
+
+export function inspectWorkflowEntries(entries) {
+  const privileged = entries.filter((entry) => isPrivilegedWorkflowText(entry.text));
+  const uses = privileged.flatMap((entry) => externalActionUses(entry.path, entry.text));
+  return {
+    distinctActions: [...new Set(uses.map((entry) => entry.action))].sort(),
+    privilegedWorkflows: privileged.map((entry) => entry.path).sort(),
+    unpinned: uses.filter((entry) => !FULL_SHA.test(entry.ref)),
+    uses,
+  };
+}
+
+export function inspectPrivilegedActionPins(root = ROOT) {
+  const directory = join(root, WORKFLOW_DIRECTORY);
+  const entries = readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+    .map((entry) => {
+      const absolute = join(directory, entry.name);
+      return {
+        path: relative(root, absolute).replaceAll('\\', '/'),
+        text: readFileSync(absolute, 'utf8'),
+      };
+    });
+  return inspectWorkflowEntries(entries);
+}
+
+function main() {
+  const report = inspectPrivilegedActionPins();
+  if (report.unpinned.length > 0) {
+    console.error('privileged-action-pins: FAIL — mutable external action references found');
+    for (const entry of report.unpinned) {
+      console.error(`  ${entry.path}:${entry.line} ${entry.action}@${entry.ref || '<missing>'}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `privileged-action-pins: OK (${report.privilegedWorkflows.length} workflows, ${report.uses.length} uses, ${report.distinctActions.length} distinct actions)`,
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-privileged-action-pins.test.mjs
+++ b/scripts/check-privileged-action-pins.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  inspectPrivilegedActionPins,
+  inspectWorkflowEntries,
+} from './check-privileged-action-pins.mjs';
+
+test('all current privileged and signing workflows use immutable action SHAs', () => {
+  const report = inspectPrivilegedActionPins();
+  assert.deepEqual(report.unpinned, []);
+  assert.ok(report.privilegedWorkflows.length >= 8);
+  assert.ok(report.uses.length >= 13);
+  assert.ok(report.distinctActions.length >= 6);
+});
+
+test('a mutable tag in an OIDC-capable workflow fails the policy', () => {
+  const report = inspectWorkflowEntries([
+    {
+      path: '.github/workflows/publish.yml',
+      text: 'permissions:\n  id-token: write\nsteps:\n  - uses: actions/checkout@v6\n',
+    },
+  ]);
+  assert.deepEqual(report.unpinned, [
+    {
+      action: 'actions/checkout',
+      line: 4,
+      path: '.github/workflows/publish.yml',
+      ref: 'v6',
+    },
+  ]);
+});
+
+test('local reusable workflows are outside the third-party pin rule', () => {
+  const report = inspectWorkflowEntries([
+    {
+      path: '.github/workflows/publish.yml',
+      text: 'permissions:\n  id-token: write\njobs:\n  sign:\n    uses: ./.github/workflows/sign.yml\n',
+    },
+  ]);
+  assert.deepEqual(report.unpinned, []);
+  assert.deepEqual(report.uses, []);
+});

--- a/scripts/measure-epic-1-scorecard.mjs
+++ b/scripts/measure-epic-1-scorecard.mjs
@@ -14,6 +14,7 @@ import { canonicalDocumentLinks, inspectAuthorityMetadata } from './check-doc-au
 import { CORPUS_COHORTS, resolveCorpus } from './corpus-resolver.mjs';
 import { scanDeadDomainPolicy } from './dead-domain-policy.mjs';
 import { artifactRegistration } from './generated-artifact-registry.mjs';
+import { inspectWorkflowEntries } from './check-privileged-action-pins.mjs';
 
 const DEAD_DOMAIN_BASELINE_RECEIPT = Object.freeze({
   head_sha: '3543d5d167bd4e8d27666c8893080bca3bd72950',
@@ -129,16 +130,6 @@ const UNRESOLVED_ROWS = new Map([
       required_inputs: [
         'resolved upstream commit per mirror',
         'retained primary upstream license text',
-      ],
-    },
-  ],
-  [
-    36,
-    {
-      reason_code: 'MISSING_PRIVILEGED_WORKFLOW_POLICY',
-      required_inputs: [
-        'machine-readable privileged-workflow definition',
-        'trusted-action pin policy',
       ],
     },
   ],
@@ -1356,7 +1347,22 @@ export function buildExtendedScorecardRows({
     sboms,
     { sboms: sboms.length, target_minimum: 15 },
   );
-  output[36] = unresolved(36, 'tracked privileged workflows');
+  const workflowEntries = reader.paths
+    .filter((path) => /^\.github\/workflows\/[^/]+\.ya?ml$/.test(path))
+    .map((path) => ({ path, text: reader.text(path) ?? '' }));
+  const actionPins = inspectWorkflowEntries(workflowEntries);
+  output[36] = baseRow(
+    36,
+    'measured',
+    'tracked OIDC, npm-token, and signing workflows selected by the E7.9 privileged-action policy',
+    actionPins.privilegedWorkflows,
+    {
+      distinct_actions: actionPins.distinctActions.length,
+      mutable_uses: actionPins.unpinned.map((entry) => `${entry.path}:${entry.line}`),
+      target_mutable_uses: 0,
+      total_uses: actionPins.uses.length,
+    },
+  );
   const dependabot = reader.paths.filter((path) => /^\.github\/dependabot\.ya?ml$/.test(path));
   output[37] = baseRow(37, 'measured', 'tracked .github Dependabot configuration', dependabot, {
     present: dependabot.length === 1,

--- a/scripts/measure-epic-1-scorecard.test.mjs
+++ b/scripts/measure-epic-1-scorecard.test.mjs
@@ -24,6 +24,7 @@ function fixture() {
   const files = {
     '.github/dependabot.yml': 'version: 2\nupdates: []\n',
     '.github/workflows/publish-changed-packages.yml': `on:\n  workflow_run:\n    workflows: ['Validate Plugins']\njobs:\n  preflight:\n    steps:\n      - run: node scripts/npm-publication-preflight.mjs\n  publish:\n    environment: npm-production\n    steps:\n      - run: node scripts/publish-candidate-report.mjs && npm publish\n`,
+    '.github/workflows/emit-evidence.yml': `permissions:\n  id-token: write\njobs:\n  sign:\n    steps:\n      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803\n`,
     '.github/workflows/validate-plugins.yml': `on:\n  pull_request:\n  push:\n    branches: [main]\njobs:\n  validate:\n    steps:\n      - run: python3 scripts/validate-skills-schema.py --marketplace\n      - run: python3 -m unittest tests.test_prose_anchors\n  ci-required:\n    needs:\n      - validate\n`,
     '.gitleaks.toml': "[allowlist]\npaths = ['''(?i).*/README\\.md$''']\nregexes = []\n",
     '.claude-plugin/marketplace.extended.json': JSON.stringify({
@@ -328,12 +329,28 @@ test('link instrumentation stays excluded while domain instrumentation cannot by
 test('unresolved rows fail closed with null values rather than fabricated zeroes', () => {
   const rows = buildExtendedScorecardRows(input(fixture()));
   for (const number of [
-    7, 8, 9, 15, 16, 17, 18, 19, 23, 29, 36, 49, 50, 51, 52, 53, 54, 55, 58, 60, 61, 62,
+    7, 8, 9, 15, 16, 17, 18, 19, 23, 29, 49, 50, 51, 52, 53, 54, 55, 58, 60, 61, 62,
   ]) {
     assert.equal(rows[number].values, null, `row ${number}`);
     assert.match(rows[number].reason_code, /^[A-Z][A-Z0-9_]+$/);
     assert.ok(rows[number].required_inputs.length > 0);
   }
+});
+
+test('measures privileged workflow action pins and exposes mutable references', () => {
+  const base = fixture();
+  let row = buildExtendedScorecardRows(input(base))[36];
+  assert.equal(row.status, 'measured');
+  assert.deepEqual(row.values.mutable_uses, []);
+  assert.equal(row.values.total_uses, 1);
+
+  put(
+    base.root,
+    '.github/workflows/emit-evidence.yml',
+    'permissions:\n  id-token: write\njobs:\n  sign:\n    steps:\n      - uses: actions/checkout@v6\n',
+  );
+  row = buildExtendedScorecardRows(input(base))[36];
+  assert.deepEqual(row.values.mutable_uses, ['.github/workflows/emit-evidence.yml:6']);
 });
 
 test('measurements follow fixture inputs and do not preserve historical blueprint numbers', () => {


### PR DESCRIPTION
## Summary

- reopen Blueprint 727 E7.9 after completion audit found mutable action tags in live credential-bearing workflows
- SHA-pin all remaining external actions in npm, MCP publication, and Tailscale OIDC deployment paths
- add a dynamic policy that discovers OIDC-, npm-token-, and signing-capable workflows
- make the policy blocking inside the existing `validate` job
- turn Epic 1 scorecard row 36 from unresolved into a reproducible measurement

## Beads

- `claude-jqvw.6`

## Evidence

- `pnpm run validate:privileged-action-pins` — 3/3 tests; 9 workflows, 36 uses, 8 distinct actions, 0 mutable references
- planted `actions/checkout@v6` in an OIDC fixture is refused
- `pnpm run measure:e1:check` — 38/38 tests and tracked scorecard byte-current
- publication/evidence/pin focused suite — 18/18 tests
- ESLint, Prettier, Actionlint, and diff checks passed
- `pnpm run verify` exited 0

## Security boundary

No new required context and no branch-protection changes. The invariant runs inside `validate`, which already feeds `ci-required`.
