### PR TITLE
test(docs-governance): lock post-rename compatibility

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1785,6 +1785,14 @@ jobs:
       - name: Check the README landing contract
         run: pnpm run validate:readme-contract
 
+      # Model-neutral rename compatibility (blueprint 727 E11.10 / decision
+      # 803): canonical repository/catalog endpoints coexist with the frozen
+      # marketplace slug, npm package, ccpi command, and tons binary alias.
+      # Public redirects are checked separately with the script's --live mode;
+      # required CI remains deterministic and network-free.
+      - name: Check the post-rename identity compatibility contract
+        run: pnpm run validate:identity-compatibility
+
       # The canonical harness-free skill contract (blueprint 727 § 5.2, Epic 3
       # E3.2): schemas/canonical/v0 must compile under Ajv 2020 strict and hold
       # its red runs (closed schema, no vendor-literal model class, registry-

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3130,
-        "tracked_files": 23137
+        "tracked_files": 23139
       }
     },
     "2": {
@@ -1842,7 +1842,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23137
+        "tracked_files": 23139
       }
     },
     "47": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "sweep:certification-expiry": "node scripts/sweep-certification-expiry.mjs",
     "validate:certification-separation": "node --test scripts/check-certification-separation.test.mjs",
     "validate:readme-contract": "node --test scripts/check-readme-contract.test.mjs && node scripts/check-readme-contract.mjs",
+    "validate:identity-compatibility": "node --test scripts/check-identity-compatibility.test.mjs && node scripts/check-identity-compatibility.mjs",
     "validate:canonical-schema": "node --test scripts/check-canonical-schema.test.mjs",
     "validate:capability-coverage": "node --test scripts/check-capability-coverage.test.mjs && node scripts/check-capability-coverage.mjs",
     "validate:model-id-classifier": "node --test scripts/classify-model-ids.test.mjs && node scripts/classify-model-ids.mjs --check",

--- a/scripts/check-identity-compatibility.mjs
+++ b/scripts/check-identity-compatibility.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Protect the model-neutral rename's deliberately frozen compatibility surface.
+ *
+ * The required CI lane runs the local contract only. `--live` additionally
+ * follows the public redirects as an operator receipt; it is intentionally not
+ * part of required CI because GitHub and skills.sh availability are external.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = join(SCRIPT_DIR, '..');
+
+export const IDENTITY = Object.freeze({
+  canonicalRepository: 'jeremylongshore/tons-of-skills-marketplace',
+  rootRepositoryUrl: 'git+https://github.com/jeremylongshore/tons-of-skills-marketplace.git',
+  cliRepositoryUrl: 'https://github.com/jeremylongshore/tons-of-skills-marketplace.git',
+  catalogUrl:
+    'https://raw.githubusercontent.com/jeremylongshore/tons-of-skills-marketplace/main/.claude-plugin/marketplace.json',
+  marketplaceSlug: 'claude-code-plugins-plus',
+  packageName: '@intentsolutionsio/ccpi',
+  cliEntry: './dist/index.js',
+  installCommand: '/plugin marketplace add jeremylongshore/claude-code-plugins',
+  skillsRoute: 'https://skills.sh/jeremylongshore/tons-of-skills-marketplace',
+});
+
+export const LIVE_REDIRECTS = Object.freeze([
+  {
+    label: 'legacy GitHub install repository',
+    source: 'https://github.com/jeremylongshore/claude-code-plugins',
+    destination: 'https://github.com/jeremylongshore/tons-of-skills-marketplace',
+  },
+  {
+    label: 'legacy GitHub repository',
+    source: 'https://github.com/jeremylongshore/claude-code-plugins-plus-skills',
+    destination: 'https://github.com/jeremylongshore/tons-of-skills-marketplace',
+  },
+  {
+    label: 'legacy GitHub clone endpoint',
+    source: 'https://github.com/jeremylongshore/claude-code-plugins-plus-skills.git',
+    destination: 'https://github.com/jeremylongshore/tons-of-skills-marketplace',
+  },
+  {
+    label: 'legacy skills.sh discovery route',
+    source: 'https://skills.sh/jeremylongshore/claude-code-plugins-plus-skills',
+    destination: IDENTITY.skillsRoute,
+  },
+]);
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+export function loadIdentitySnapshot(root = DEFAULT_ROOT) {
+  return {
+    rootPackage: readJson(join(root, 'package.json')),
+    cliPackage: readJson(join(root, 'packages/cli/package.json')),
+    extendedCatalog: readJson(join(root, '.claude-plugin/marketplace.extended.json')),
+    generatedCatalog: readJson(join(root, '.claude-plugin/marketplace.json')),
+    readme: readFileSync(join(root, 'README.md'), 'utf8'),
+    cliConstantsSource: readFileSync(join(root, 'packages/cli/src/utils/constants.ts'), 'utf8'),
+    cliProgramSource: readFileSync(join(root, 'packages/cli/src/program.ts'), 'utf8'),
+  };
+}
+
+function hasExportedString(source, name, value) {
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^\\s*export\\s+const\\s+${name}\\s*=\\s*['"]${escaped}['"]\\s*;`, 'm').test(
+    source,
+  );
+}
+
+export function checkIdentityCompatibility(snapshot) {
+  const violations = [];
+  const {
+    rootPackage,
+    cliPackage,
+    extendedCatalog,
+    generatedCatalog,
+    readme,
+    cliConstantsSource,
+    cliProgramSource,
+  } = snapshot;
+
+  if (rootPackage.repository?.url !== IDENTITY.rootRepositoryUrl) {
+    violations.push('root package repository URL is not canonical');
+  }
+  if (
+    cliPackage.repository?.url !== IDENTITY.cliRepositoryUrl ||
+    cliPackage.repository?.directory !== 'packages/cli'
+  ) {
+    violations.push('CLI package repository metadata is not canonical');
+  }
+  if (cliPackage.name !== IDENTITY.packageName) {
+    violations.push(`published CLI package identity must remain ${IDENTITY.packageName}`);
+  }
+  if (cliPackage.bin?.ccpi !== IDENTITY.cliEntry || cliPackage.bin?.tons !== IDENTITY.cliEntry) {
+    violations.push('ccpi and tons binary aliases must both resolve to the same CLI entry point');
+  }
+  if (
+    extendedCatalog.name !== IDENTITY.marketplaceSlug ||
+    generatedCatalog.name !== IDENTITY.marketplaceSlug
+  ) {
+    violations.push(`marketplace install identity must remain ${IDENTITY.marketplaceSlug}`);
+  }
+  if (!readme.includes(IDENTITY.installCommand)) {
+    violations.push(`frozen install command is missing: ${IDENTITY.installCommand}`);
+  }
+  if (!readme.includes(IDENTITY.skillsRoute)) {
+    violations.push(`canonical skills.sh route is missing: ${IDENTITY.skillsRoute}`);
+  }
+  if (!hasExportedString(cliConstantsSource, 'MARKETPLACE_REPO', IDENTITY.canonicalRepository)) {
+    violations.push('CLI marketplace repository constant is not canonical');
+  }
+  if (!hasExportedString(cliConstantsSource, 'MARKETPLACE_SLUG', IDENTITY.marketplaceSlug)) {
+    violations.push('CLI marketplace slug no longer preserves the install identity');
+  }
+  if (!hasExportedString(cliConstantsSource, 'CATALOG_URL', IDENTITY.catalogUrl)) {
+    violations.push('CLI catalog URL is not canonical');
+  }
+  if (!/^\s*\.name\(\s*['"]ccpi['"]\s*\)/m.test(cliProgramSource)) {
+    violations.push('existing ccpi program identity is missing');
+  }
+  if (!/^\s*\.command\(\s*['"]skills['"]\s*\)/m.test(cliProgramSource)) {
+    violations.push('portable capability is not exposed through the tons skills command family');
+  }
+
+  return violations;
+}
+
+function normalizedDestination(value) {
+  const url = new URL(value);
+  url.hostname = url.hostname.replace(/^www\./, '');
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\.git\/?$/, '').replace(/\/$/, '');
+  return url.toString().replace(/\/$/, '');
+}
+
+export function checkRedirectResult(contract, response) {
+  const violations = [];
+  if (response.status < 200 || response.status >= 300) {
+    violations.push(`${contract.label} returned HTTP ${response.status}`);
+  }
+  if (normalizedDestination(response.url) !== normalizedDestination(contract.destination)) {
+    violations.push(
+      `${contract.label} resolved to ${response.url}, expected ${contract.destination}`,
+    );
+  }
+  return violations;
+}
+
+export async function checkLiveRedirects(fetchImpl = globalThis.fetch) {
+  if (typeof fetchImpl !== 'function') {
+    throw new TypeError('a fetch implementation is required for live redirect checks');
+  }
+
+  const results = [];
+  for (const contract of LIVE_REDIRECTS) {
+    const response = await fetchImpl(contract.source, {
+      redirect: 'follow',
+      headers: { 'user-agent': 'tons-of-skills-identity-check/1.0' },
+    });
+    const violations = checkRedirectResult(contract, response);
+    results.push({
+      ...contract,
+      status: response.status,
+      resolved: response.url,
+      violations,
+    });
+    if (response.body && typeof response.body.cancel === 'function') await response.body.cancel();
+  }
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((arg) => arg !== '--live');
+  if (unknown.length > 0) {
+    console.error(`identity-compatibility: unknown argument(s): ${unknown.join(', ')}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const violations = checkIdentityCompatibility(loadIdentitySnapshot());
+  for (const violation of violations) {
+    console.error(`identity-compatibility: VIOLATION — ${violation}`);
+  }
+  if (violations.length > 0) {
+    console.error(`identity-compatibility: FAIL — ${violations.length} local violation(s)`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    'identity-compatibility: OK (canonical repository + frozen install/package/CLI identities)',
+  );
+
+  if (args.includes('--live')) {
+    const results = await checkLiveRedirects();
+    const liveViolations = results.flatMap((result) => result.violations);
+    for (const result of results) {
+      console.log(
+        `identity-compatibility: ${result.label}: HTTP ${result.status} -> ${result.resolved}`,
+      );
+    }
+    for (const violation of liveViolations) {
+      console.error(`identity-compatibility: LIVE VIOLATION — ${violation}`);
+    }
+    if (liveViolations.length > 0) {
+      console.error(
+        `identity-compatibility: LIVE FAIL — ${liveViolations.length} redirect violation(s)`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log('identity-compatibility: LIVE OK');
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) await main();

--- a/scripts/check-identity-compatibility.test.mjs
+++ b/scripts/check-identity-compatibility.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  IDENTITY,
+  LIVE_REDIRECTS,
+  checkIdentityCompatibility,
+  checkLiveRedirects,
+  loadIdentitySnapshot,
+} from './check-identity-compatibility.mjs';
+
+const LIVE = loadIdentitySnapshot();
+
+function snapshot(overrides = {}) {
+  return JSON.parse(JSON.stringify({ ...LIVE, ...overrides }));
+}
+
+test('the repository satisfies the complete post-rename identity contract', () => {
+  assert.deepEqual(checkIdentityCompatibility(LIVE), []);
+});
+
+test('renaming the published CLI package is rejected', () => {
+  const candidate = snapshot();
+  candidate.cliPackage.name = '@intentsolutionsio/tons';
+  assert.match(checkIdentityCompatibility(candidate).join('\n'), /package identity/);
+});
+
+test('both ccpi and tons must remain aliases for one executable', () => {
+  for (const bin of ['ccpi', 'tons']) {
+    const candidate = snapshot();
+    delete candidate.cliPackage.bin[bin];
+    assert.match(checkIdentityCompatibility(candidate).join('\n'), /binary aliases/);
+  }
+  const split = snapshot();
+  split.cliPackage.bin.tons = './dist/tons.js';
+  assert.match(checkIdentityCompatibility(split).join('\n'), /binary aliases/);
+});
+
+test('the marketplace slug is frozen in both source and generated catalogs', () => {
+  for (const catalog of ['extendedCatalog', 'generatedCatalog']) {
+    const candidate = snapshot();
+    candidate[catalog].name = 'tons-of-skills-marketplace';
+    assert.match(checkIdentityCompatibility(candidate).join('\n'), /install identity/);
+  }
+});
+
+test('the legacy install command and canonical skills.sh route are both required', () => {
+  const commandDrift = snapshot({
+    readme: LIVE.readme.replace(
+      IDENTITY.installCommand,
+      '/plugin marketplace add jeremylongshore/tons-of-skills-marketplace',
+    ),
+  });
+  assert.match(checkIdentityCompatibility(commandDrift).join('\n'), /frozen install command/);
+
+  const routeDrift = snapshot({
+    readme: LIVE.readme.replace(IDENTITY.skillsRoute, 'https://skills.sh/example/drift'),
+  });
+  assert.match(checkIdentityCompatibility(routeDrift).join('\n'), /skills\.sh route/);
+});
+
+test('canonical repository and catalog endpoints cannot regress', () => {
+  const rootDrift = snapshot();
+  rootDrift.rootPackage.repository.url = 'git+https://github.com/example/drift.git';
+  assert.match(checkIdentityCompatibility(rootDrift).join('\n'), /root package repository/);
+
+  const cliDrift = snapshot();
+  cliDrift.cliConstantsSource = cliDrift.cliConstantsSource.replace(
+    IDENTITY.canonicalRepository,
+    'example/drift',
+  );
+  assert.match(checkIdentityCompatibility(cliDrift).join('\n'), /repository constant/);
+
+  const catalogDrift = snapshot();
+  catalogDrift.cliConstantsSource = catalogDrift.cliConstantsSource.replace(
+    IDENTITY.catalogUrl,
+    'https://example.com/catalog.json',
+  );
+  assert.match(checkIdentityCompatibility(catalogDrift).join('\n'), /catalog URL/);
+
+  const commentedRelic = snapshot();
+  commentedRelic.cliConstantsSource = commentedRelic.cliConstantsSource
+    .replace(IDENTITY.marketplaceSlug, 'tons-of-skills-marketplace')
+    .concat(`\n// export const MARKETPLACE_SLUG = '${IDENTITY.marketplaceSlug}';\n`);
+  assert.match(checkIdentityCompatibility(commentedRelic).join('\n'), /marketplace slug/);
+});
+
+test('the ccpi program identity and portable skills family remain registered', () => {
+  const missingCcpi = snapshot({
+    cliProgramSource: LIVE.cliProgramSource.replace(".name('ccpi')", ".name('tons')"),
+  });
+  assert.match(checkIdentityCompatibility(missingCcpi).join('\n'), /ccpi program identity/);
+
+  const missingSkills = snapshot({
+    cliProgramSource: LIVE.cliProgramSource.replace(".command('skills')", ".command('portable')"),
+  });
+  assert.match(checkIdentityCompatibility(missingSkills).join('\n'), /tons skills/);
+});
+
+test('live redirect verifier follows every legacy route to the canonical destination', async () => {
+  const seen = [];
+  const results = await checkLiveRedirects(async (url) => {
+    seen.push(url);
+    const contract = LIVE_REDIRECTS.find((item) => item.source === url);
+    const destination = new URL(contract.destination);
+    if (destination.hostname === 'skills.sh') destination.hostname = 'www.skills.sh';
+    return { status: 200, url: destination.toString(), body: null };
+  });
+
+  assert.deepEqual(
+    seen,
+    LIVE_REDIRECTS.map((item) => item.source),
+  );
+  assert.deepEqual(
+    results.flatMap((result) => result.violations),
+    [],
+  );
+});
+
+test('live redirect verifier rejects errors and destinations outside the contract', async () => {
+  const results = await checkLiveRedirects(async () => ({
+    status: 404,
+    url: 'https://example.com/wrong',
+    body: null,
+  }));
+  const violations = results.flatMap((result) => result.violations).join('\n');
+  assert.match(violations, /HTTP 404/);
+  assert.match(violations, /resolved to/);
+});


### PR DESCRIPTION
## Summary

- add a deterministic E11.10 identity-compatibility checker for canonical repository/catalog endpoints and deliberately frozen install/package/CLI identities
- add nine red/green regression tests, including fail-closed simulated redirect checks
- wire the network-free contract into the existing unconditional `doc-governance` job; retain `--live` as an operator receipt
- refresh the governed Epic 1 tracked-file denominator for the two new scripts

## Beads

- `claude-rblh.10`

## Evidence

- `pnpm run validate:identity-compatibility`
- `node scripts/check-identity-compatibility.mjs --live` (four routes, HTTP 200, canonical destinations)
- `pnpm run lint:root`
- `pnpm run validate:readme-contract`
- `pnpm run validate:generated-artifacts`
- `pnpm run validate:doc-fact-assertions`
- `pnpm run measure:e1:check` (40 tests + exact scorecard)
- `pnpm run sync-marketplace` (zero drift)
- `./scripts/quick-test.sh` (build/lint pass; existing whole-corpus 386-error standard-tier baseline remains warning-only)
- independent read-only audit: PASS, no findings

## Compatibility boundary

This does not rename the npm package, the `ccpi` command, or the internal marketplace slug. Required CI performs no external fetch. The explicit `--live` operator mode verifies the retired GitHub and skills.sh redirects separately.
