### PR TITLE
fix(ci-infra): pin scoped tool grants at zero

### DIFF
--- a/scripts/safety-ratchet-baseline.json
+++ b/scripts/safety-ratchet-baseline.json
@@ -1,18 +1,18 @@
 {
   "$comment": "Triple-keyed safety-ratchet baseline (E4.3/E4.4/E4.11). Regenerate ONLY via `node scripts/check-safety-ratchet.mjs --write` in the PR that shrinks a class; the gate fails any growth or swap. shell_substitution is never waivable.",
-  "pinned_at": "2026-08-26",
+  "pinned_at": "2026-08-30",
   "schema_version": "4.1.0",
   "agents_terminal_error_count": 236,
   "classes": {
     "bare_bash": {
-      "count": 1,
-      "set_sha256": "e0724e4263bb5cd3fcafa9b2c12d2b67e7adcedcb3113f1887e5ad05622de115",
-      "members": ["plugins/community/framecraft/skills/demo-video/SKILL.md"]
+      "count": 0,
+      "set_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "members": []
     },
     "tier2_tool_safety": {
-      "count": 1,
-      "set_sha256": "e0724e4263bb5cd3fcafa9b2c12d2b67e7adcedcb3113f1887e5ad05622de115",
-      "members": ["plugins/community/framecraft/skills/demo-video/SKILL.md"]
+      "count": 0,
+      "set_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "members": []
     },
     "shell_substitution": {
       "count": 0,


### PR DESCRIPTION
## Summary

Completes Blueprint 727 E8.10 by locking the achieved first-party safety denominator at zero.

- reproduces the pinned Blueprint base: 222 unscoped Bash = 1 first-party + 221 mirrors; 185 tier-2 = 1 first-party + 184 mirrors
- records the sole human first-party decision: framecraft only needs the named uv operation, already scoped manually in commit 9ab1c492 as Bash(uv:*)
- confirms current canonical first-party metrics are 0 bare Bash, 0 tier-2 tool-safety, and 0 shell substitution
- confirms all 222 current raw unscoped-Bash paths are .source.json mirrors and all 222 are QUARANTINE in the disposition ledger
- re-pins only bare_bash and tier2_tool_safety from 1 to 0; no mirror file changes

Bead: claude-5e0c.10

## Verification

- node --test scripts/check-safety-ratchet.test.mjs
- node scripts/check-safety-ratchet.mjs
- pnpm run validate:disposition-ledger
- pnpm run validate:mirror-quarantine
- pnpm run measure:e1:check against staged index
- pnpm run verify
- pnpm run format:check
- git diff --check

## Provenance boundary

The remaining raw 222/185 are upstream-owned across six mirror roots. Blueprint section 13 explicitly prohibits editing any path beneath a .source.json ancestor. All are ledger-quarantined; this PR changes only the generated shrink-only first-party baseline.