### PR TITLE
fix(ci-infra): pin frontmatter remediation at zero

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -112,6 +112,14 @@ jobs:
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml
           pnpm run validate:safety-ratchet
 
+      # Blueprint 727 E8.8: missing-required-frontmatter remediation stops at
+      # a .source.json boundary. The canonical validator reports editable
+      # first-party and upstream mirror records separately; first-party debt is
+      # pinned at zero with count + set-hash + members, while every mirror row
+      # must remain QUARANTINE in the disposition ledger. No waiver path exists.
+      - name: Enforce the structural remediation ratchet
+        run: pnpm run validate:structural-ratchet
+
       # Blueprint 727 E8.1: Freshie's graded cohort is the authority for the
       # disposition ledger. Regenerate-and-compare proves each current graded
       # artifact has exactly one first-match-wins outcome; missing/stale rows

--- a/000-docs/727-AT-ARCH-master-modernization-blueprint.md
+++ b/000-docs/727-AT-ARCH-master-modernization-blueprint.md
@@ -1800,6 +1800,20 @@ E2 freeze ──▶ 1.13             (cross-epic: the frozen set is an input)
 | 8.14 | Archive the dead-domain and superseded references outside the authority documents.             | task · P2    | Consumes Epic 1 bead 1.13 after Epic 2's freeze.                                                                                                         |
 | 8.15 | Certify the first cohort with real behavioral evidence and publish grades with their class.    | feature · P1 | A capped cohort (10–15 skills, § 18.6) reaches E2/E3 with retained hash-matched artifacts; grades publish with their evidence class and a `recall_note`. |
 
+**E8.8 ownership correction (2026-08-30).** The original 728-record row remains the
+ratified historical baseline, but its literal remediation reading conflicts with this epic's
+own `.source.json` stop-rule. A clean run at base `478aaf177` reproduces 728 missing-required-
+frontmatter records across 294 skills: **one editable first-party record** (Hyperfocus,
+`allowed-tools`) and **727 upstream-owned mirror records**. Commit `7ed360083` clears the sole
+first-party record by declaring the minimal `Read` capability. Mirror bytes are not credited as
+remediation: commit `1243dac98` removed 137 failing mirror records, and `2aba004d4` removed or
+rewrote 12 `llm-box` records while introducing two `x-twitter-scraper` records. The governed
+current state is 580 records across 265 mirror skills, all ledgered `QUARANTINE`, and zero
+first-party records. Therefore the operative acceptance is: editable first-party debt reaches
+and remains at zero; every raw mirror finding stays unedited and quarantined; the structural
+ratchet fails any first-party growth or equal-count swap. The correction changes neither the
+historical count nor the prohibition on editing upstream-owned files.
+
 **Bead dependency graph.**
 
 ```

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3130,
-        "tracked_files": 23141
+        "tracked_files": 23144
       }
     },
     "2": {
@@ -1842,7 +1842,7 @@
         "invalid_patterns": 0,
         "invisible_files": 21,
         "target_invisible_files": 0,
-        "tracked_files": 23141
+        "tracked_files": 23144
       }
     },
     "47": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "validate:mcp-destructive-policy": "node --test scripts/check-mcp-destructive-policy.test.mjs && node scripts/check-mcp-destructive-policy.mjs",
     "validate:denylist-degradation": "node --test scripts/check-denylist-degradation.test.mjs && node scripts/check-denylist-degradation.mjs",
     "validate:safety-ratchet": "node --test scripts/check-safety-ratchet.test.mjs && node scripts/check-safety-ratchet.mjs",
+    "validate:structural-ratchet": "node --test scripts/check-structural-ratchet.test.mjs && node scripts/check-structural-ratchet.mjs",
     "validate:doc-fact-assertions": "node --test scripts/check-doc-fact-assertions.test.mjs && node scripts/check-doc-fact-assertions.mjs",
     "evaluate:certification": "node scripts/evaluate-certification.mjs",
     "generate:disposition-ledger": "node scripts/generate-disposition-ledger.mjs",

--- a/scripts/check-structural-ratchet.mjs
+++ b/scripts/check-structural-ratchet.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// check-structural-ratchet.mjs — Blueprint 727 E8 structural-debt boundary.
+//
+// The canonical validator owns classification. This gate pins editable,
+// first-party missing-required-frontmatter records by count, sorted-set hash,
+// and members. Growth and equal-count swaps fail. Provenance-marked mirror
+// findings are not "fixed" locally: every affected skill must instead have a
+// QUARANTINE row in the disposition ledger.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BASELINE = resolve(ROOT, 'scripts/structural-ratchet-baseline.json');
+const LEDGER = resolve(ROOT, 'freshie/disposition-ledger.json');
+const WRITE = process.argv.includes('--write');
+const REQUIRED_CLASS = 'first_party_missing_required_frontmatter';
+
+const sha = (items) => createHash('sha256').update(items.join('\n')).digest('hex');
+
+function collectMetrics() {
+  const output = execFileSync(
+    'python3',
+    ['scripts/validate-skills-schema.py', '--structural-metrics'],
+    { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  return JSON.parse(output);
+}
+
+function skillPath(member) {
+  const separator = member.lastIndexOf('::');
+  if (separator <= 0 || separator === member.length - 2) {
+    throw new Error(`structural-ratchet: malformed validator member: ${member}`);
+  }
+  return member.slice(0, separator);
+}
+
+export function validateBaseline(baseline) {
+  const failures = [];
+  if (!baseline || typeof baseline !== 'object' || typeof baseline.schema_version !== 'string') {
+    failures.push('baseline must declare a string schema_version');
+    return failures;
+  }
+  if (!baseline.classes || typeof baseline.classes !== 'object') {
+    failures.push('baseline must declare classes');
+    return failures;
+  }
+  if (!Object.hasOwn(baseline.classes, REQUIRED_CLASS)) {
+    failures.push(`baseline is missing required class ${REQUIRED_CLASS}`);
+  }
+  for (const [name, entry] of Object.entries(baseline.classes)) {
+    if (!Number.isInteger(entry?.count) || entry.count < 0 || !Array.isArray(entry.members)) {
+      failures.push(`${name}: baseline count/members are malformed`);
+      continue;
+    }
+    if (entry.members.length !== entry.count) {
+      failures.push(`${name}: baseline member length does not equal count`);
+    }
+    if (entry.set_sha256 !== sha(entry.members)) {
+      failures.push(`${name}: baseline set_sha256 does not match members`);
+    }
+    if (name === REQUIRED_CLASS && entry.count !== 0) {
+      failures.push(`${name}: the achieved zero target may not be raised`);
+    }
+  }
+  return failures;
+}
+
+export function compare(baseline, current) {
+  const failures = validateBaseline(baseline);
+  if (baseline.schema_version !== current.schema_version) {
+    failures.push(
+      `schema version changed ${baseline.schema_version} → ${current.schema_version}; review and re-pin`,
+    );
+  }
+  for (const [name, baseEntry] of Object.entries(baseline.classes ?? {})) {
+    const nowMembers = current[name];
+    if (!Array.isArray(nowMembers)) {
+      failures.push(`${name}: current validator metrics must be an array`);
+      continue;
+    }
+    const baseSet = new Set(baseEntry.members ?? []);
+    if (nowMembers.length > baseEntry.count) {
+      failures.push(
+        `${name}: count grew ${baseEntry.count} → ${nowMembers.length} (monotone non-increasing)`,
+      );
+    }
+    const newcomers = nowMembers.filter((member) => !baseSet.has(member));
+    if (newcomers.length > 0) {
+      failures.push(
+        `${name}: ${newcomers.length} member(s) not in the baseline (a swap is new debt): ${newcomers
+          .slice(0, 5)
+          .join(' | ')}`,
+      );
+    }
+  }
+  return failures;
+}
+
+export function checkMirrorDisposition(members, ledger) {
+  const rows = new Map((ledger?.artifacts ?? []).map((row) => [row.path, row]));
+  const paths = [...new Set(members.map(skillPath))].sort();
+  const failures = [];
+  for (const path of paths) {
+    const row = rows.get(path);
+    if (!row) {
+      failures.push(`${path}: mirror finding is absent from the disposition ledger`);
+    } else if (row.disposition !== 'QUARANTINE') {
+      failures.push(
+        `${path}: mirror finding must be QUARANTINE, found ${row.disposition ?? '(missing)'}`,
+      );
+    }
+  }
+  return { failures, paths };
+}
+
+function main() {
+  const metrics = collectMetrics();
+  const classMembers = metrics.first_party_missing_required_frontmatter;
+  const mirrorMembers = metrics.mirror_missing_required_frontmatter;
+  if (!Array.isArray(classMembers) || !Array.isArray(mirrorMembers)) {
+    console.error('structural-ratchet: FAIL — canonical validator omitted a required metric array');
+    process.exit(1);
+  }
+  const ledger = JSON.parse(readFileSync(LEDGER, 'utf8'));
+  const mirrorCheck = checkMirrorDisposition(mirrorMembers, ledger);
+  if (mirrorCheck.failures.length > 0) {
+    for (const failure of mirrorCheck.failures) {
+      console.error(`structural-ratchet: FAIL — ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  if (WRITE) {
+    if (classMembers.length !== 0) {
+      console.error(
+        `structural-ratchet: FAIL — refusing to write a nonzero first-party baseline (${classMembers.length})`,
+      );
+      process.exit(1);
+    }
+    const pinned = {
+      $comment:
+        'E8 structural-ratchet baseline. Regenerate ONLY via `node scripts/check-structural-ratchet.mjs --write` in the PR that shrinks editable first-party debt. Mirror records are never edited; the gate requires their ledger disposition to remain QUARANTINE.',
+      pinned_at: new Date().toISOString().slice(0, 10),
+      schema_version: metrics.schema_version,
+      historical_reconciliation: {
+        blueprint_base: '478aaf17731714fed9b1779284de6a5b3729ef6e',
+        missing_required_frontmatter_records: 728,
+        first_party_records: 1,
+        mirror_records: 727,
+      },
+      classes: {
+        first_party_missing_required_frontmatter: {
+          count: classMembers.length,
+          set_sha256: sha(classMembers),
+          members: classMembers,
+        },
+      },
+    };
+    writeFileSync(BASELINE, `${JSON.stringify(pinned, null, 2)}\n`);
+    console.log(
+      `structural-ratchet: baseline written (first_party_missing_required_frontmatter=${classMembers.length}; ${mirrorMembers.length} mirror records quarantined)`,
+    );
+    return;
+  }
+
+  const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+  const failures = compare(baseline, metrics);
+  if (failures.length > 0) {
+    for (const failure of failures) console.error(`structural-ratchet: FAIL — ${failure}`);
+    console.error(
+      'structural-ratchet: fix first-party debt; mirror-owned files have no local-edit or waiver path',
+    );
+    process.exit(1);
+  }
+
+  const baselineCount = baseline.classes.first_party_missing_required_frontmatter.count;
+  if (classMembers.length < baselineCount) {
+    console.log(
+      `structural-ratchet: OK — first-party debt SHRANK (${baselineCount} → ${classMembers.length}); lock it in with --write`,
+    );
+    return;
+  }
+  console.log(
+    `structural-ratchet: OK (first-party missing-required-frontmatter=${classMembers.length}; ` +
+      `${mirrorMembers.length} mirror records across ${mirrorCheck.paths.length} quarantined skills; ` +
+      `schema ${baseline.schema_version})`,
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-structural-ratchet.test.mjs
+++ b/scripts/check-structural-ratchet.test.mjs
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import { deepEqual, equal, match, ok } from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { checkMirrorDisposition, compare, validateBaseline } from './check-structural-ratchet.mjs';
+
+const digest = (members) => createHash('sha256').update(members.join('\n')).digest('hex');
+const baselineOf = (members = []) => ({
+  schema_version: '4.1.0',
+  classes: {
+    first_party_missing_required_frontmatter: {
+      count: members.length,
+      set_sha256: digest(members),
+      members,
+    },
+  },
+});
+const currentOf = (members = []) => ({
+  schema_version: '4.1.0',
+  first_party_missing_required_frontmatter: members,
+});
+
+test('the achieved zero first-party target passes', () => {
+  deepEqual(compare(baselineOf([]), currentOf([])), []);
+});
+
+test('growth and an equal-count swap fail', () => {
+  const growth = compare(baselineOf([]), currentOf(['a/SKILL.md::tags']));
+  equal(growth.length, 2);
+  match(growth[0], /count grew 0 → 1/);
+  const swap = compare(baselineOf(['a/SKILL.md::tags']), currentOf(['b/SKILL.md::tags']));
+  ok(swap.some((failure) => /zero target may not be raised/.test(failure)));
+  ok(swap.some((failure) => /swap is new debt/.test(failure)));
+});
+
+test('schema drift and a corrupt baseline fail closed', () => {
+  const baseline = baselineOf([]);
+  baseline.classes.first_party_missing_required_frontmatter.set_sha256 = '0'.repeat(64);
+  ok(validateBaseline(baseline).some((failure) => /set_sha256/.test(failure)));
+  ok(
+    compare(baselineOf([]), { ...currentOf([]), schema_version: '4.2.0' }).some((failure) =>
+      /schema version changed/.test(failure),
+    ),
+  );
+});
+
+test('removing the required class or current metric cannot disable the gate', () => {
+  const baseline = baselineOf([]);
+  delete baseline.classes.first_party_missing_required_frontmatter;
+  ok(validateBaseline(baseline).some((failure) => /missing required class/.test(failure)));
+  ok(
+    compare(baselineOf([]), { schema_version: '4.1.0' }).some((failure) =>
+      /current validator metrics must be an array/.test(failure),
+    ),
+  );
+});
+
+test('every mirror record resolves to one quarantined ledger row', () => {
+  const members = ['a/SKILL.md::tags', 'a/SKILL.md::version', 'b/SKILL.md::author'];
+  const ledger = {
+    artifacts: [
+      { path: 'a/SKILL.md', disposition: 'QUARANTINE' },
+      { path: 'b/SKILL.md', disposition: 'QUARANTINE' },
+    ],
+  };
+  deepEqual(checkMirrorDisposition(members, ledger), {
+    failures: [],
+    paths: ['a/SKILL.md', 'b/SKILL.md'],
+  });
+});
+
+test('missing and publishable mirror ledger rows fail', () => {
+  const result = checkMirrorDisposition(['a/SKILL.md::tags', 'b/SKILL.md::version'], {
+    artifacts: [{ path: 'a/SKILL.md', disposition: 'CERTIFY-PENDING-EVIDENCE' }],
+  });
+  equal(result.failures.length, 2);
+  match(result.failures[0], /must be QUARANTINE/);
+  match(result.failures[1], /absent from the disposition ledger/);
+});
+
+test('the live baseline carries count, set hash, and members with no waiver mechanism', () => {
+  const baseline = JSON.parse(
+    readFileSync(new URL('./structural-ratchet-baseline.json', import.meta.url), 'utf8'),
+  );
+  deepEqual(validateBaseline(baseline), []);
+  const source = readFileSync(new URL('./check-structural-ratchet.mjs', import.meta.url), 'utf8');
+  ok(!/allowlist\.txt|waiver.*\.txt|WAIVERS\s*=/.test(source));
+});

--- a/scripts/structural-ratchet-baseline.json
+++ b/scripts/structural-ratchet-baseline.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "E8 structural-ratchet baseline. Regenerate ONLY via `node scripts/check-structural-ratchet.mjs --write` in the PR that shrinks editable first-party debt. Mirror records are never edited; the gate requires their ledger disposition to remain QUARANTINE.",
+  "pinned_at": "2026-08-30",
+  "schema_version": "4.1.0",
+  "historical_reconciliation": {
+    "blueprint_base": "478aaf17731714fed9b1779284de6a5b3729ef6e",
+    "missing_required_frontmatter_records": 728,
+    "first_party_records": 1,
+    "mirror_records": 727
+  },
+  "classes": {
+    "first_party_missing_required_frontmatter": {
+      "count": 0,
+      "set_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "members": []
+    }
+  }
+}

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -5510,6 +5510,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--structural-metrics",
+        action="store_true",
+        help=(
+            "4.1.0 (E8.8): emit missing-required-frontmatter metrics as JSON and exit. "
+            "First-party and provenance-marked mirror records are reported separately so "
+            "the remediation ratchet can fail closed without editing upstream-owned files."
+        ),
+    )
+    parser.add_argument(
         "--standard",
         action="store_true",
         help="Use standard tier (Anthropic spec exactly: name + description required). This is the default.",
@@ -5906,6 +5915,38 @@ def main() -> int:
             "bare_bash": sorted(bare_bash),
             "tier2_tool_safety": sorted(tier2_tool_safety),
             "shell_substitution": sorted(shell_substitution),
+        }
+        print(_json.dumps(metrics, indent=1))
+        return 0
+
+    if args.structural_metrics:
+
+        def _is_mirror(path: Path) -> bool:
+            probe = path.parent
+            while probe != repo_root and probe != probe.parent:
+                if (probe / ".source.json").exists():
+                    return True
+                probe = probe.parent
+            return False
+
+        missing_pattern = re.compile(r"^\[frontmatter\] Missing required field: '([^']+)' \(marketplace\)$")
+        first_party: List[str] = []
+        mirrors: List[str] = []
+        for skill_path in find_skill_files(repo_root):
+            rel = str(skill_path.relative_to(repo_root))
+            result = validate_skill(skill_path, TIER_MARKETPLACE)
+            for error in result.get("errors", []):
+                match = missing_pattern.match(error)
+                if not match:
+                    continue
+                member = f"{rel}::{match.group(1)}"
+                (mirrors if _is_mirror(skill_path) else first_party).append(member)
+        import json as _json
+
+        metrics = {
+            "schema_version": SCHEMA_VERSION,
+            "first_party_missing_required_frontmatter": sorted(first_party),
+            "mirror_missing_required_frontmatter": sorted(mirrors),
         }
         print(_json.dumps(metrics, indent=1))
         return 0


### PR DESCRIPTION
## Summary
- reconcile the historical 728 frontmatter findings as 1 editable first-party record plus 727 mirror-owned records
- pin editable first-party missing-required-frontmatter debt at zero with a no-growth/no-substitution ratchet
- require every remaining mirror finding to resolve to a QUARANTINE ledger entry
- preserve the Blueprint 727 stop rule: never edit .source.json descendants directly

## Evidence
- Bead: claude-5e0c.8
- reviewed commit: 16c6b9536d94afa790fc32dd4198f46f19d2cb75
- reviewed tree: b3f91a18b847d306b2cebbef51f2127ba91a3116
- current result: 0 editable first-party findings; 580 mirror findings across 265 quarantined skills
- red proof: adding one first-party defect fails with the exact newcomer path
- baseline write refusal: nonzero first-party debt cannot be blessed

## Validation
- pnpm run verify
- pnpm run format:check
- pnpm lint
- 7/7 structural-ratchet tests
- 55/55 validator frontmatter tests
- 40/40 measurement tests plus scorecard drift PASS
- independent exact-tree review: PASS

## Rollback
Revert this single commit. No plugin payloads or mirror-owned skill files are changed.