### PR TITLE
fix(ci): align emit-evidence core lockfile

### DIFF
--- a/ci/emit-evidence/package.json
+++ b/ci/emit-evidence/package.json
@@ -5,6 +5,6 @@
   "description": "CI-only signed-evidence emitter for the intent-eval-dashboard reports hub (repo row key: ccp). Not a workspace package, never published; installed standalone in .github/workflows/emit-evidence.yml via `pnpm install --ignore-workspace`.",
   "type": "module",
   "dependencies": {
-    "@intentsolutions/core": "0.9.0"
+    "@intentsolutions/core": "0.10.0"
   }
 }

--- a/ci/emit-evidence/pnpm-lock.yaml
+++ b/ci/emit-evidence/pnpm-lock.yaml
@@ -9,13 +9,13 @@ importers:
   .:
     dependencies:
       '@intentsolutions/core':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 0.10.0
+        version: 0.10.0
 
 packages:
 
-  '@intentsolutions/core@0.9.0':
-    resolution: {integrity: sha512-XGF3rR/FFgRz1qkiXMEXLijmPX3/9layH9e2wqykMitkl2gX/JREpS6ilRXB1tVnkdcHnDdfAxWstpW/UoGKsA==}
+  '@intentsolutions/core@0.10.0':
+    resolution: {integrity: sha512-6IF/A5qqrUdA/L4HB6YLd2/7+T3fA/1gY7rX1izkIhrx1E5+4XL/O3MIXvJafobQztPnm6ItYHbHLV1EpLnYOg==}
     engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
 
   zod@4.4.3:
@@ -23,7 +23,7 @@ packages:
 
 snapshots:
 
-  '@intentsolutions/core@0.9.0':
+  '@intentsolutions/core@0.10.0':
     dependencies:
       zod: 4.4.3
 


### PR DESCRIPTION
## Summary

Rebuilds #1324 from current main and updates the isolated emit-evidence package plus its standalone lockfile from `@intentsolutions/core` 0.9.0 to 0.10.0.

## Trust-boundary review

- npm registry signature and SLSA provenance verified
- downloaded tarball digest matches the lockfile integrity
- emitter-consumed EvidenceBundle and GateResult validators and schemas are byte-identical between 0.9.0 and 0.10.0
- 0.10.0 changes are additive SkillVersion signing-state support and do not activate a new path in this consumer

## Validation

- frozen standalone install: PASS
- emitter self-check: PASS
- focused tests: 6/6 PASS
- repository build, typecheck, lint, and root ESLint: PASS
- Prettier and git diff check: PASS

Tracks Beads issue `claude-0ffs`. Supersedes #1324.