### PR TITLE
fix(ci): prescreen skill-less MCP plugins structurally

### DIFF
--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -113,22 +113,32 @@ jobs:
           jq -r '.[].filename' /tmp/pr-files.json > /tmp/pr-files.txt
           echo "All changed files (count=$(wc -l < /tmp/pr-files.txt | tr -d ' ')):" >&2
           head -50 /tmp/pr-files.txt >&2
+          PLUGIN_LINES=$(jq '[.[] | select(
+            (.filename | startswith("plugins/")) or
+            ((.previous_filename // "") | startswith("plugins/"))
+          )] | length' /tmp/pr-files.json)
           SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
-          if [ ! -f "$SCOPE_SCRIPT" ]; then
+          if [ "$PLUGIN_LINES" = "0" ]; then
+            # Bootstrap-safe: a governance-only PR cannot execute its new helper,
+            # and it has no plugin data that needs scoping.
+            : > /tmp/no-plugin-changes
+            : > /tmp/changed-plugins.txt
+            : > /tmp/deleted-plugins.txt
+          elif [ ! -f "$SCOPE_SCRIPT" ]; then
             echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
             exit 1
+          else
+            python3 "$SCOPE_SCRIPT" discover \
+              --files-json /tmp/pr-files.json \
+              --pr-root pr \
+              --base-root base \
+              --changed-output /tmp/changed-plugins.txt \
+              --deleted-output /tmp/deleted-plugins.txt
           fi
-          python3 "$SCOPE_SCRIPT" discover \
-            --files-json /tmp/pr-files.json \
-            --pr-root pr \
-            --base-root base \
-            --changed-output /tmp/changed-plugins.txt \
-            --deleted-output /tmp/deleted-plugins.txt
           echo "Changed (non-deleted) plugin dirs:" >&2
           cat /tmp/changed-plugins.txt >&2
           echo "Deleted plugin dirs:" >&2
           cat /tmp/deleted-plugins.txt >&2
-          PLUGIN_LINES=$(jq '[.[] | select(.filename | startswith("plugins/"))] | length' /tmp/pr-files.json)
           CHANGED_DIRS=$(wc -l < /tmp/changed-plugins.txt | tr -d ' ')
           DELETED_DIRS=$(wc -l < /tmp/deleted-plugins.txt | tr -d ' ')
           : > /tmp/diff-step-signals.txt
@@ -147,19 +157,28 @@ jobs:
           CI: 'true'
         run: |
           set -euo pipefail
-          VALIDATOR_EXIT=0
-          # Execute immutable base-authored validator + resolver code. The PR
-          # checkout is supplied only as the data root; no pr/scripts bytes run.
-          python3 base/scripts/validate-skills-schema.py --marketplace --json --repo-root pr \
-            > /tmp/validator-results.json 2>/tmp/validator.log || VALIDATOR_EXIT=$?
-          echo "Validator exit: $VALIDATOR_EXIT" >&2
-          if [ "$VALIDATOR_EXIT" -ne 0 ]; then
-            echo "prescreen-internal-error: validator exited $VALIDATOR_EXIT (see validator.log)" \
-              >> /tmp/diff-step-signals.txt
-          fi
-          echo "Validator stderr/info:" >&2
-          tail -50 /tmp/validator.log >&2 || true
-          python3 - <<'PY'
+          if [ -f /tmp/no-plugin-changes ]; then
+            # The prescreen owns plugin changes only. Produce its complete
+            # neutral artifact set without executing PR-authored helper code.
+            : > /tmp/validator.log
+            printf '[]\n' > /tmp/validator-parsed.json
+            printf '[]\n' > /tmp/filtered-results.json
+            : > /tmp/structure-signals.txt
+            echo "No plugin paths changed; validator and structural supplement skipped." >&2
+          else
+            VALIDATOR_EXIT=0
+            # Execute immutable base-authored validator + resolver code. The PR
+            # checkout is supplied only as the data root; no pr/scripts bytes run.
+            python3 base/scripts/validate-skills-schema.py --marketplace --json --repo-root pr \
+              > /tmp/validator-results.json 2>/tmp/validator.log || VALIDATOR_EXIT=$?
+            echo "Validator exit: $VALIDATOR_EXIT" >&2
+            if [ "$VALIDATOR_EXIT" -ne 0 ]; then
+              echo "prescreen-internal-error: validator exited $VALIDATOR_EXIT (see validator.log)" \
+                >> /tmp/diff-step-signals.txt
+            fi
+            echo "Validator stderr/info:" >&2
+            tail -50 /tmp/validator.log >&2 || true
+            python3 - <<'PY'
           import json, pathlib
           raw = pathlib.Path('/tmp/validator-results.json').read_text()
           try:
@@ -174,17 +193,18 @@ jobs:
           pathlib.Path('/tmp/validator-parsed.json').write_text(json.dumps(all_results))
           print(f"validator total: {len(all_results)}")
           PY
-          SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
-          if [ ! -f "$SCOPE_SCRIPT" ]; then
-            echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
-            exit 1
+            SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
+            if [ ! -f "$SCOPE_SCRIPT" ]; then
+              echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
+              exit 1
+            fi
+            python3 "$SCOPE_SCRIPT" supplement \
+              --validator-results /tmp/validator-parsed.json \
+              --changed-input /tmp/changed-plugins.txt \
+              --pr-root pr \
+              --results-output /tmp/filtered-results.json \
+              --signals-output /tmp/structure-signals.txt
           fi
-          python3 "$SCOPE_SCRIPT" supplement \
-            --validator-results /tmp/validator-parsed.json \
-            --changed-input /tmp/changed-plugins.txt \
-            --pr-root pr \
-            --results-output /tmp/filtered-results.json \
-            --signals-output /tmp/structure-signals.txt
           cat /tmp/structure-signals.txt >> /tmp/diff-step-signals.txt
           echo "validator filtered/supplemented count: $(jq length /tmp/filtered-results.json)" >&2
 
@@ -192,15 +212,19 @@ jobs:
         id: signals
         run: |
           set -euo pipefail
-          SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
-          if [ ! -f "$SCOPE_SCRIPT" ]; then
-            echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
-            exit 1
+          if [ -f /tmp/no-plugin-changes ]; then
+            : > /tmp/hard-blocks.txt
+          else
+            SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
+            if [ ! -f "$SCOPE_SCRIPT" ]; then
+              echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
+              exit 1
+            fi
+            python3 "$SCOPE_SCRIPT" check-deletions \
+              --deleted-input /tmp/deleted-plugins.txt \
+              --pr-root pr \
+              --signals-output /tmp/hard-blocks.txt
           fi
-          python3 "$SCOPE_SCRIPT" check-deletions \
-            --deleted-input /tmp/deleted-plugins.txt \
-            --pr-root pr \
-            --signals-output /tmp/hard-blocks.txt
           echo "Detected hard-block signals:" >&2
           cat /tmp/hard-blocks.txt >&2 || true
 

--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -58,12 +58,21 @@ jobs:
 
       - name: Resolve PR number
         id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           if [ -n "${{ github.event.pull_request.number }}" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
           else
-            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            PR_NUMBER="${{ inputs.pr_number }}"
           fi
+          gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" > /tmp/pr-meta.json
+          {
+            echo "number=$PR_NUMBER"
+            echo "head_sha=$(jq -r '.head.sha' /tmp/pr-meta.json)"
+            echo "base_sha=$(jq -r '.base.sha' /tmp/pr-meta.json)"
+          } >> "$GITHUB_OUTPUT"
 
       # Check out BASE (main) for the validator + classifier scripts. The PR
       # HEAD is checked out separately into ./pr. Both are fork-context
@@ -71,14 +80,14 @@ jobs:
       - name: Checkout base (validator source)
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ steps.pr.outputs.base_sha }}
           persist-credentials: false
           path: base
 
       - name: Checkout PR HEAD into ./pr
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ steps.pr.outputs.head_sha }}
           persist-credentials: false
           fetch-depth: 0
           path: pr
@@ -98,20 +107,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/files" \
-            > /tmp/pr-files.json
+          gh api --paginate --slurp \
+            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/files?per_page=100" \
+            | jq 'add' > /tmp/pr-files.json
           jq -r '.[].filename' /tmp/pr-files.json > /tmp/pr-files.txt
           echo "All changed files (count=$(wc -l < /tmp/pr-files.txt | tr -d ' ')):" >&2
           head -50 /tmp/pr-files.txt >&2
-          jq -r '.[] | select(.status != "removed") | .filename' /tmp/pr-files.json \
-            | { grep '^plugins/' || true; } \
-            | awk -F/ '{print $1"/"$2"/"$3}' \
-            | sort -u > /tmp/changed-plugins.txt
-          jq -r '.[] | select(.status == "removed") | .filename' /tmp/pr-files.json \
-            | { grep '^plugins/' || true; } \
-            | awk -F/ '{print $1"/"$2"/"$3}' \
-            | sort -u > /tmp/deleted-plugins.txt
+          SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
+          if [ ! -f "$SCOPE_SCRIPT" ]; then
+            echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
+            exit 1
+          fi
+          python3 "$SCOPE_SCRIPT" discover \
+            --files-json /tmp/pr-files.json \
+            --pr-root pr \
+            --base-root base \
+            --changed-output /tmp/changed-plugins.txt \
+            --deleted-output /tmp/deleted-plugins.txt
           echo "Changed (non-deleted) plugin dirs:" >&2
           cat /tmp/changed-plugins.txt >&2
           echo "Deleted plugin dirs:" >&2
@@ -120,8 +132,10 @@ jobs:
           CHANGED_DIRS=$(wc -l < /tmp/changed-plugins.txt | tr -d ' ')
           DELETED_DIRS=$(wc -l < /tmp/deleted-plugins.txt | tr -d ' ')
           : > /tmp/diff-step-signals.txt
-          if [ "$PLUGIN_LINES" -gt 0 ] && [ "$CHANGED_DIRS" = "0" ]; then
+          if [ "$PLUGIN_LINES" -gt 0 ] && [ "$CHANGED_DIRS" = "0" ] && [ "$DELETED_DIRS" -gt 0 ]; then
             echo "All $PLUGIN_LINES changed plugin file(s) are removals; grading is intentionally skipped and deletion integrity is checked separately." >&2
+          elif [ "$PLUGIN_LINES" -gt 0 ] && [ "$CHANGED_DIRS" = "0" ] && [ "$DELETED_DIRS" = "0" ]; then
+            echo "Plugin category support files changed, but no plugin directory is in scope." >&2
           fi
           {
             echo "count=$((CHANGED_DIRS + DELETED_DIRS))"
@@ -129,18 +143,20 @@ jobs:
 
       - name: Run validator against PR tree (full --json sweep)
         id: validate
-        working-directory: pr
         env:
           CI: 'true'
         run: |
           set -euo pipefail
-          install -m 0644 ../base/scripts/validate-skills-schema.py \
-            ./scripts/.prescreen-validator.py
           VALIDATOR_EXIT=0
-          python3 scripts/.prescreen-validator.py --marketplace --json \
+          # Execute immutable base-authored validator + resolver code. The PR
+          # checkout is supplied only as the data root; no pr/scripts bytes run.
+          python3 base/scripts/validate-skills-schema.py --marketplace --json --repo-root pr \
             > /tmp/validator-results.json 2>/tmp/validator.log || VALIDATOR_EXIT=$?
-          rm -f ./scripts/.prescreen-validator.py
           echo "Validator exit: $VALIDATOR_EXIT" >&2
+          if [ "$VALIDATOR_EXIT" -ne 0 ]; then
+            echo "prescreen-internal-error: validator exited $VALIDATOR_EXIT (see validator.log)" \
+              >> /tmp/diff-step-signals.txt
+          fi
           echo "Validator stderr/info:" >&2
           tail -50 /tmp/validator.log >&2 || true
           python3 - <<'PY'
@@ -150,63 +166,41 @@ jobs:
               all_results = json.loads(raw or '[]')
           except json.JSONDecodeError:
               all_results = []
-          changed_lines = pathlib.Path('/tmp/changed-plugins.txt').read_text().splitlines()
-          changed = [c.strip() for c in changed_lines if c.strip()]
           if not all_results:
               with pathlib.Path('/tmp/diff-step-signals.txt').open('a') as fh:
                   fh.write('prescreen-internal-error: validator sweep produced 0 results '
                            '(crash or truncated output; see /tmp/validator.log)\n')
               print('::error::pr-prescreen internal: validator produced no results — failing closed')
-          if not changed:
-              filtered = []
-          else:
-              filtered = [r for r in all_results
-                          if any((c + '/') in r.get('path', '') for c in changed)]
-          for r in filtered:
-              p = r.get('path', '')
-              idx = p.find('/plugins/')
-              if idx >= 0:
-                  r['path'] = p[idx + 1:]
-          pathlib.Path('/tmp/filtered-results.json').write_text(json.dumps(filtered))
-          print(f"validator total: {len(all_results)}, filtered to PR: {len(filtered)}")
+          pathlib.Path('/tmp/validator-parsed.json').write_text(json.dumps(all_results))
+          print(f"validator total: {len(all_results)}")
           PY
+          SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
+          if [ ! -f "$SCOPE_SCRIPT" ]; then
+            echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
+            exit 1
+          fi
+          python3 "$SCOPE_SCRIPT" supplement \
+            --validator-results /tmp/validator-parsed.json \
+            --changed-input /tmp/changed-plugins.txt \
+            --pr-root pr \
+            --results-output /tmp/filtered-results.json \
+            --signals-output /tmp/structure-signals.txt
+          cat /tmp/structure-signals.txt >> /tmp/diff-step-signals.txt
+          echo "validator filtered/supplemented count: $(jq length /tmp/filtered-results.json)" >&2
 
       - name: Detect structural hard-block signals
         id: signals
-        working-directory: pr
         run: |
           set -euo pipefail
-          : > /tmp/hard-blocks.txt
-          if [ -s /tmp/changed-plugins.txt ]; then
-            while read -r plug; do
-              [ -z "$plug" ] && continue
-              if [ -f .claude-plugin/marketplace.extended.json ]; then
-                if ! grep -q "\"$plug\"\|/$(basename "$plug")\"" .claude-plugin/marketplace.extended.json; then
-                  echo "Missing catalog entry for $plug in marketplace.extended.json" >> /tmp/hard-blocks.txt
-                fi
-              fi
-              if [ -d "$plug" ]; then
-                if [ -z "$(find "$plug" -type f \( -name 'SKILL.md' -o -name 'plugin.json' \) -print -quit)" ]; then
-                  echo "Plugin dir $plug has no SKILL.md or plugin.json" >> /tmp/hard-blocks.txt
-                fi
-              fi
-            done < /tmp/changed-plugins.txt
+          SCOPE_SCRIPT=base/scripts/pr-prescreen/scope.py
+          if [ ! -f "$SCOPE_SCRIPT" ]; then
+            echo "prescreen-internal-error: immutable base scope helper is unavailable" >&2
+            exit 1
           fi
-          if [ -s /tmp/deleted-plugins.txt ]; then
-            while read -r plug; do
-              [ -z "$plug" ] && continue
-              # A directory absent from the PR checkout is a full plugin
-              # removal. Its structural invariant is the inverse of an added
-              # plugin: it must no longer be listed in the catalog. Partial
-              # file removals keep their directory and remain covered by the
-              # normal validator/catalog lanes.
-              if [ ! -d "$plug" ] && [ -f .claude-plugin/marketplace.extended.json ]; then
-                if grep -q "\"$plug\"\|/$(basename "$plug")\"" .claude-plugin/marketplace.extended.json; then
-                  echo "Deleted plugin $plug still has a catalog entry in marketplace.extended.json" >> /tmp/hard-blocks.txt
-                fi
-              fi
-            done < /tmp/deleted-plugins.txt
-          fi
+          python3 "$SCOPE_SCRIPT" check-deletions \
+            --deleted-input /tmp/deleted-plugins.txt \
+            --pr-root pr \
+            --signals-output /tmp/hard-blocks.txt
           echo "Detected hard-block signals:" >&2
           cat /tmp/hard-blocks.txt >&2 || true
 
@@ -230,8 +224,6 @@ jobs:
       # head SHA, author, title) so the privileged job doesn't need to
       # re-query the GitHub API.
       - name: Bundle artifacts for respond job
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/prescreen-bundle
@@ -240,9 +232,9 @@ jobs:
           cat > /tmp/prescreen-bundle/meta.json <<EOF
           {
             "pr_number": "${{ steps.pr.outputs.number }}",
-            "head_sha": "${{ github.event.pull_request.head.sha }}",
-            "author": "${{ github.event.pull_request.user.login }}",
-            "title": $(jq -Rsa . <<<"$PR_TITLE"),
+            "head_sha": "${{ steps.pr.outputs.head_sha }}",
+            "author": $(jq '.user.login' /tmp/pr-meta.json),
+            "title": $(jq '.title' /tmp/pr-meta.json),
             "diff_count": "${{ steps.diff.outputs.count }}"
           }
           EOF

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3075,
-        "tracked_files": 23748
+        "tracked_files": 23750
       }
     },
     "2": {
@@ -1739,7 +1739,11 @@
       "dimension": "Marketplace-tier validator runs that block a merge",
       "limitations": ["static workflow analysis does not execute GitHub expression control flow"],
       "reproduce": "pnpm run measure:e1 --row=40 --stdout",
-      "source": [".github/workflows/minimax-review.yml", ".github/workflows/promote-curated.yml"],
+      "source": [
+        ".github/workflows/minimax-review.yml",
+        ".github/workflows/pr-prescreen.yml",
+        ".github/workflows/promote-curated.yml"
+      ],
       "status": "partial",
       "values": {
         "blocking_candidates": 0,
@@ -1748,6 +1752,11 @@
             "blocking_candidate": false,
             "line": 247,
             "path": ".github/workflows/minimax-review.yml"
+          },
+          {
+            "blocking_candidate": false,
+            "line": 172,
+            "path": ".github/workflows/pr-prescreen.yml"
           },
           {
             "blocking_candidate": false,
@@ -1910,7 +1919,7 @@
         "invalid_patterns": 0,
         "invisible_files": 22,
         "target_invisible_files": 0,
-        "tracked_files": 23748
+        "tracked_files": 23750
       }
     },
     "47": {

--- a/scripts/pr-prescreen/classify.py
+++ b/scripts/pr-prescreen/classify.py
@@ -113,7 +113,9 @@ def _summarize(verdict: str, results: list[dict], blockers: list[str], warnings:
     # Null-safe: validator can emit "score": null on partial results.
     scores = [int(r["score"]) for r in results if r.get("score") is not None]
     avg = (sum(scores) / len(scores)) if scores else 0
-    parts = [f"{verdict}: {n} skill(s) inspected"]
+    # Results can represent skill grades or structural records for valid
+    # skill-less plugins (for example, an MCP-only plugin).
+    parts = [f"{verdict}: {n} component(s) inspected"]
     if scores:
         parts.append(f"avg score {avg:.0f}/100")
     if blockers:

--- a/scripts/pr-prescreen/scope.py
+++ b/scripts/pr-prescreen/scope.py
@@ -183,17 +183,14 @@ def load_catalog_roots(checkout: Path, *, required: bool = False) -> set[str]:
         source = _normalize_catalog_source(entry.get("source"))
         if source is None:
             raise ValueError(
-                f"{_CATALOG_PATH} plugins[{index}].source must be an exact "
-                "plugins/<category>/<plugin> path"
+                f"{_CATALOG_PATH} plugins[{index}].source must be an exact plugins/<category>/<plugin> path"
             )
         roots.add(source)
     return roots
 
 
 def _catalog_or_marker_root(checkout: Path, relative: str, catalog_roots: set[str]) -> bool:
-    return _real_directory(checkout, relative) and (
-        relative in catalog_roots or _plugin_has_marker(checkout, relative)
-    )
+    return _real_directory(checkout, relative) and (relative in catalog_roots or _plugin_has_marker(checkout, relative))
 
 
 def discover_plugin_dirs(
@@ -288,9 +285,7 @@ def _regular_contained_file(plugin_dir: Path, path: Path) -> bool:
         if stat.S_ISLNK(metadata.st_mode):
             return False
         final = index == len(relative.parts) - 1
-        if (final and not stat.S_ISREG(metadata.st_mode)) or (
-            not final and not stat.S_ISDIR(metadata.st_mode)
-        ):
+        if (final and not stat.S_ISREG(metadata.st_mode)) or (not final and not stat.S_ISDIR(metadata.st_mode)):
             return False
     try:
         return path.resolve().is_relative_to(plugin_dir.resolve())
@@ -326,11 +321,7 @@ def _canonical_manifest_errors(path: Path, manifest: dict[str, Any]) -> list[str
         return [str(exc)]
     errors = [str(value) for value in result.get("errors", []) + result.get("warnings", [])]
     name = manifest.get("name")
-    if (
-        not isinstance(name, str)
-        or not _KEBAB_NAME.fullmatch(name)
-        or len(name) > 64
-    ):
+    if not isinstance(name, str) or not _KEBAB_NAME.fullmatch(name) or len(name) > 64:
         errors.append("Field 'name' must be a non-empty kebab-case name of at most 64 characters")
     return errors
 
@@ -360,23 +351,16 @@ def _validate_mcp_servers(servers: Any, label: str) -> list[str]:
             errors.append(f"{label} server {server_name!r} name must match its map key")
         transport = config.get("type")
         if transport not in {"stdio", "http", "streamable-http", "sse", "ws"}:
-            errors.append(
-                f"{label} server {server_name!r} type must be one of "
-                "stdio, http, streamable-http, sse, ws"
-            )
+            errors.append(f"{label} server {server_name!r} type must be one of stdio, http, streamable-http, sse, ws")
         command = config.get("command")
         if not isinstance(command, str) or not command.strip():
             errors.append(f"{label} server {server_name!r} command must be a non-empty string")
         if transport in {"http", "streamable-http", "sse", "ws"}:
             if not isinstance(config.get("url"), str) or not config["url"].strip():
-                errors.append(
-                    f"{label} server {server_name!r} type {transport!r} requires a non-empty url"
-                )
+                errors.append(f"{label} server {server_name!r} type {transport!r} requires a non-empty url")
         if not isinstance(config.get("args"), list):
             errors.append(f"{label} server {server_name!r} args must be an array")
-        elif not all(
-            isinstance(value, str) for value in config["args"]
-        ):
+        elif not all(isinstance(value, str) for value in config["args"]):
             errors.append(f"{label} server {server_name!r} args entries must be strings")
         if not isinstance(config.get("env"), dict):
             errors.append(f"{label} server {server_name!r} env must be an object")
@@ -452,9 +436,7 @@ _HOOK_EVENTS = {
 }
 
 
-def _validate_hooks(
-    document: Any, label: str, *, require_marketplace_fields: bool = True
-) -> list[str]:
+def _validate_hooks(document: Any, label: str, *, require_marketplace_fields: bool = True) -> list[str]:
     """Validate the canonical event → matcher-group → handler shape."""
 
     if not isinstance(document, dict) or not isinstance(document.get("hooks"), dict):
@@ -528,9 +510,7 @@ def validate_plugin_structure(plugin_dir: Path, relative: str, *, has_skills: bo
     for component_dir in (".claude-plugin", "hooks", "skills", "agents", "commands"):
         candidate = plugin_dir / component_dir
         if candidate.is_symlink():
-            errors.append(
-                f"{relative}/{component_dir} must be a contained directory with no symlink components"
-            )
+            errors.append(f"{relative}/{component_dir} must be a contained directory with no symlink components")
     manifest_path = plugin_dir / ".claude-plugin" / "plugin.json"
     manifest: dict[str, Any] | None = None
     if _lexists(manifest_path):
@@ -554,9 +534,7 @@ def validate_plugin_structure(plugin_dir: Path, relative: str, *, has_skills: bo
     if manifest is not None and "mcpServers" in manifest:
         declaration = manifest["mcpServers"]
         if isinstance(declaration, dict):
-            errors.extend(
-                _validate_mcp_servers(declaration, f"{relative}/.claude-plugin/plugin.json mcpServers")
-            )
+            errors.extend(_validate_mcp_servers(declaration, f"{relative}/.claude-plugin/plugin.json mcpServers"))
         elif isinstance(declaration, (str, list)):
             references = [declaration] if isinstance(declaration, str) else declaration
             for reference in references:
@@ -624,9 +602,7 @@ def validate_plugin_structure(plugin_dir: Path, relative: str, *, has_skills: bo
             if not _regular_contained_file(plugin_dir, path):
                 errors.append(f"{label} must be a contained regular file with no symlink components")
                 continue
-            errors.extend(
-                f"{label}: {error}" for error in _canonical_component_errors(path, kind)
-            )
+            errors.extend(f"{label}: {error}" for error in _canonical_component_errors(path, kind))
 
     return errors
 
@@ -647,15 +623,10 @@ def supplement_results(
     for plugin in changed_dirs:
         plugin_dir = pr_root.joinpath(*PurePosixPath(plugin).parts)
         if plugin not in catalog_roots:
-            signals.append(
-                f"Missing exact catalog source './{plugin}' in {_CATALOG_PATH}"
-            )
-        has_skills = any(
-            _regular_contained_file(plugin_dir, path) for path in plugin_dir.rglob("SKILL.md")
-        )
+            signals.append(f"Missing exact catalog source './{plugin}' in {_CATALOG_PATH}")
+        has_skills = any(_regular_contained_file(plugin_dir, path) for path in plugin_dir.rglob("SKILL.md"))
         has_skill_result = any(
-            (plugin + "/") in str(result.get("path", ""))
-            and str(result.get("path", "")).endswith("SKILL.md")
+            (plugin + "/") in str(result.get("path", "")) and str(result.get("path", "")).endswith("SKILL.md")
             for result in filtered
         )
         errors = validate_plugin_structure(plugin_dir, plugin, has_skills=has_skills)
@@ -689,9 +660,7 @@ def supplement_results(
     return filtered, signals
 
 
-def validate_deleted_plugins(
-    deleted_dirs: list[str], *, pr_root: Path
-) -> list[str]:
+def validate_deleted_plugins(deleted_dirs: list[str], *, pr_root: Path) -> list[str]:
     """Validate full removals without following replacement symlinks."""
 
     catalog_roots = load_catalog_roots(pr_root, required=True)
@@ -705,15 +674,11 @@ def validate_deleted_plugins(
                 signals.append(f"Deleted plugin root {plugin} cannot be inspected: {exc}")
             else:
                 if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
-                    signals.append(
-                        f"Deleted plugin root {plugin} still exists as a symlink or non-directory"
-                    )
+                    signals.append(f"Deleted plugin root {plugin} still exists as a symlink or non-directory")
                 else:
                     signals.append(f"prescreen-internal-error: deleted plugin root {plugin} still exists")
         if plugin in catalog_roots:
-            signals.append(
-                f"Deleted plugin {plugin} still has exact catalog source './{plugin}'"
-            )
+            signals.append(f"Deleted plugin {plugin} still has exact catalog source './{plugin}'")
     return signals
 
 

--- a/scripts/pr-prescreen/scope.py
+++ b/scripts/pr-prescreen/scope.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+"""Resolve real plugin roots and supplement skill-only prescreen results.
+
+The marketplace contains category-level support files such as
+``plugins/mcp/destructive-policies.json``.  A path-prefix truncation cannot
+distinguish those files from ``plugins/<category>/<plugin>`` directories, so
+the prescreen must consult the checked-out trees before treating a prefix as
+a plugin.
+
+The skill validator also intentionally emits no record for a valid plugin
+that contains only MCP/hooks/runtime components.  For those plugins this
+module performs deterministic canonical structural checks and emits a neutral
+component record (no score or grade). Structural failures are returned as
+hard-block signals; they are never converted into a synthetic grade.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+_CATALOG_PATH = Path(".claude-plugin/marketplace.extended.json")
+_KEBAB_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+_STRICT_SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+_MCP_RESERVED_NAMES = {"skill", "claude", "anthropic", "mcp", "plugin", "agent"}
+_MCP_UNSAFE_DESCRIPTION = re.compile(r"<[^>]+>|\$\{|\$\(|`")
+
+
+def _safe_plugin_root(filename: str) -> str | None:
+    """Return the lexical ``plugins/<category>/<plugin>`` prefix.
+
+    A tracked file inside a plugin has at least four path components.  A
+    three-component path is a category-root support file, not a plugin tree.
+    Dot segments and absolute paths are rejected before any filesystem read.
+    """
+
+    path = PurePosixPath(filename)
+    parts = path.parts
+    if path.is_absolute() or len(parts) < 4 or parts[0] != "plugins":
+        return None
+    if any(part in ("", ".", "..") for part in parts):
+        return None
+    return "/".join(parts[:3])
+
+
+def _direct_plugin_root(
+    filename: str,
+    *,
+    pr_root: Path,
+    base_root: Path,
+    pr_catalog: set[str],
+    base_catalog: set[str],
+) -> str | None:
+    """Resolve a three-part Git entry only with plugin-specific authority.
+
+    Git represents a plugin-root symlink or non-directory replacement as the
+    root path itself. Exact catalog membership, a real marked plugin tree, or
+    a kebab-named symlink/non-directory establishes plugin scope. Ordinary
+    category support files such as ``destructive-policies.json`` do not.
+    """
+
+    path = PurePosixPath(filename)
+    if (
+        path.is_absolute()
+        or len(path.parts) != 3
+        or path.parts[0] != "plugins"
+        or any(part in ("", ".", "..") for part in path.parts)
+    ):
+        return None
+    relative = path.as_posix()
+    if relative in pr_catalog or relative in base_catalog:
+        return relative
+    if _scope_existing_root(pr_root, relative) or _scope_existing_root(base_root, relative):
+        return relative
+    if not _KEBAB_NAME.fullmatch(path.parts[2]):
+        return None
+    for checkout in (pr_root, base_root):
+        candidate = checkout.joinpath(*path.parts)
+        if not _lexists(candidate):
+            continue
+        try:
+            metadata = candidate.lstat()
+        except OSError:
+            return relative
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            return relative
+    return None
+
+
+def _real_directory(checkout: Path, relative: str) -> bool:
+    """True only for a non-symlink directory contained by ``checkout``."""
+
+    root = checkout.resolve()
+    candidate = root.joinpath(*PurePosixPath(relative).parts)
+    if candidate.is_symlink() or not candidate.is_dir():
+        return False
+    try:
+        return candidate.resolve().is_relative_to(root)
+    except (OSError, RuntimeError):
+        return False
+
+
+def _lexists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def _plugin_has_marker(checkout: Path, relative: str) -> bool:
+    """Return whether a directory has an actual plugin component marker.
+
+    This excludes category support trees (for example ``mcp/.greptile`` and
+    ``saas-packs/_templates``) without guessing from their names. Symlinked
+    markers intentionally count here so the structural lane can reject them
+    explicitly instead of silently dropping the plugin from scope.
+    """
+
+    root = checkout.joinpath(*PurePosixPath(relative).parts)
+    direct_markers = (
+        root / ".claude-plugin" / "plugin.json",
+        root / ".mcp.json",
+        root / "hooks" / "hooks.json",
+        root / "SKILL.md",
+    )
+    if any(_lexists(marker) for marker in direct_markers):
+        return True
+    if any((root / name).is_symlink() for name in (".claude-plugin", "hooks", "skills", "agents", "commands")):
+        return True
+    for component_dir, pattern in (("skills", "SKILL.md"), ("agents", "*.md"), ("commands", "*.md")):
+        directory = root / component_dir
+        if _lexists(directory) and any(directory.rglob(pattern)):
+            return True
+    return False
+
+
+def _scope_existing_root(checkout: Path, relative: str) -> bool:
+    return _real_directory(checkout, relative) and _plugin_has_marker(checkout, relative)
+
+
+def _normalize_catalog_source(source: Any) -> str | None:
+    if not isinstance(source, str):
+        return None
+    normalized = source[2:] if source.startswith("./") else source
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or len(path.parts) != 3 or path.parts[0] != "plugins":
+        return None
+    if any(part in ("", ".", "..") for part in path.parts):
+        return None
+    return path.as_posix()
+
+
+def load_catalog_roots(checkout: Path, *, required: bool = False) -> set[str]:
+    """Parse exact plugin sources from the canonical editable catalog."""
+
+    catalog_path = checkout / _CATALOG_PATH
+    if not _lexists(catalog_path):
+        if required:
+            raise ValueError(f"{_CATALOG_PATH} is missing")
+        return set()
+    if not _regular_contained_file(checkout, catalog_path):
+        raise ValueError(f"{_CATALOG_PATH} must be a contained regular file")
+    document, error = _load_object(catalog_path, str(_CATALOG_PATH))
+    if error:
+        raise ValueError(error)
+    plugins = document.get("plugins") if document is not None else None
+    if not isinstance(plugins, list):
+        raise ValueError(f"{_CATALOG_PATH} must contain a plugins array")
+    roots: set[str] = set()
+    for index, entry in enumerate(plugins):
+        if not isinstance(entry, dict):
+            raise ValueError(f"{_CATALOG_PATH} plugins[{index}] must be an object")
+        source = _normalize_catalog_source(entry.get("source"))
+        if source is None:
+            raise ValueError(
+                f"{_CATALOG_PATH} plugins[{index}].source must be an exact "
+                "plugins/<category>/<plugin> path"
+            )
+        roots.add(source)
+    return roots
+
+
+def _catalog_or_marker_root(checkout: Path, relative: str, catalog_roots: set[str]) -> bool:
+    return _real_directory(checkout, relative) and (
+        relative in catalog_roots or _plugin_has_marker(checkout, relative)
+    )
+
+
+def discover_plugin_dirs(
+    entries: list[dict[str, Any]], *, pr_root: Path, base_root: Path
+) -> tuple[list[str], list[str], int]:
+    """Return changed dirs, deletion-touched dirs, and plugin-file count."""
+
+    changed: set[str] = set()
+    deleted: set[str] = set()
+    plugin_file_count = 0
+    pr_catalog = load_catalog_roots(pr_root)
+    base_catalog = load_catalog_roots(base_root)
+
+    for entry in entries:
+        filename = entry.get("filename")
+        status = entry.get("status")
+        if not isinstance(filename, str) or not filename.startswith("plugins/"):
+            continue
+        plugin_file_count += 1
+        plugin_root = _safe_plugin_root(filename) or _direct_plugin_root(
+            filename,
+            pr_root=pr_root,
+            base_root=base_root,
+            pr_catalog=pr_catalog,
+            base_catalog=base_catalog,
+        )
+        if plugin_root is None:
+            continue
+        if status == "removed":
+            # A file deletion from a plugin that still exists in the PR is a
+            # plugin change, not a plugin deletion. Only a root absent from the
+            # PR tree belongs in the deletion-integrity lane.
+            if _catalog_or_marker_root(base_root, plugin_root, base_catalog):
+                if _real_directory(pr_root, plugin_root):
+                    changed.add(plugin_root)
+                else:
+                    deleted.add(plugin_root)
+            elif _catalog_or_marker_root(pr_root, plugin_root, pr_catalog):
+                changed.add(plugin_root)
+        elif _catalog_or_marker_root(pr_root, plugin_root, pr_catalog):
+            changed.add(plugin_root)
+        elif _lexists(pr_root.joinpath(*PurePosixPath(plugin_root).parts)) and not _real_directory(
+            pr_root, plugin_root
+        ):
+            # A plugin root added or replaced as a symlink/non-directory is
+            # suspicious, not an ordinary removal. The deletion lane reports
+            # the exact non-regular-root and stale-catalog violations.
+            deleted.add(plugin_root)
+
+        # GitHub exposes the old side of a rename as previous_filename. A
+        # cross-plugin rename must scope both roots: the new root as changed,
+        # and the old root as changed or deleted according to PR-tree reality.
+        previous = entry.get("previous_filename")
+        if status == "renamed" and isinstance(previous, str):
+            old_root = _safe_plugin_root(previous)
+            if old_root is not None and old_root != plugin_root:
+                if _catalog_or_marker_root(base_root, old_root, base_catalog):
+                    if _real_directory(pr_root, old_root):
+                        changed.add(old_root)
+                    else:
+                        deleted.add(old_root)
+                elif _catalog_or_marker_root(pr_root, old_root, pr_catalog):
+                    changed.add(old_root)
+
+    return sorted(changed), sorted(deleted), plugin_file_count
+
+
+def _load_object(path: Path, label: str) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{label} is not valid JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return None, f"{label} must contain a JSON object"
+    return parsed, None
+
+
+def _regular_contained_file(plugin_dir: Path, path: Path) -> bool:
+    """Require a regular file with no symlink in any path component."""
+
+    try:
+        relative = path.relative_to(plugin_dir)
+    except ValueError:
+        return False
+    current = plugin_dir
+    for index, segment in enumerate(relative.parts):
+        current /= segment
+        try:
+            metadata = current.lstat()
+        except OSError:
+            return False
+        if stat.S_ISLNK(metadata.st_mode):
+            return False
+        final = index == len(relative.parts) - 1
+        if (final and not stat.S_ISREG(metadata.st_mode)) or (
+            not final and not stat.S_ISDIR(metadata.st_mode)
+        ):
+            return False
+    try:
+        return path.resolve().is_relative_to(plugin_dir.resolve())
+    except (OSError, RuntimeError):
+        return False
+
+
+_VALIDATOR_MODULE: Any | None = None
+
+
+def _canonical_validator() -> Any:
+    """Load the immutable base-authored canonical component validator."""
+
+    global _VALIDATOR_MODULE  # noqa: PLW0603
+    if _VALIDATOR_MODULE is None:
+        validator_path = Path(__file__).resolve().parents[1] / "validate-skills-schema.py"
+        spec = importlib.util.spec_from_file_location("_prescreen_base_validator", validator_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"canonical component validator unavailable at {validator_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        _VALIDATOR_MODULE = module
+    return _VALIDATOR_MODULE
+
+
+def _canonical_manifest_errors(path: Path, manifest: dict[str, Any]) -> list[str]:
+    """Apply canonical manifest validation plus the strict marketplace name floor."""
+
+    try:
+        result = _canonical_validator().validate_plugin_json(path, strict=True)
+    except RuntimeError as exc:
+        return [str(exc)]
+    errors = [str(value) for value in result.get("errors", []) + result.get("warnings", [])]
+    name = manifest.get("name")
+    if (
+        not isinstance(name, str)
+        or not _KEBAB_NAME.fullmatch(name)
+        or len(name) > 64
+    ):
+        errors.append("Field 'name' must be a non-empty kebab-case name of at most 64 characters")
+    return errors
+
+
+def _validate_mcp_servers(servers: Any, label: str) -> list[str]:
+    """Mirror the pinned kernel v2 + marketplace MCP server contract."""
+
+    if not isinstance(servers, dict) or not servers:
+        return [f"{label} must declare a non-empty mcpServers object"]
+    errors: list[str] = []
+    for server_name, config in servers.items():
+        if (
+            not isinstance(server_name, str)
+            or not _KEBAB_NAME.fullmatch(server_name)
+            or len(server_name) > 64
+            or server_name in _MCP_RESERVED_NAMES
+            or "claude" in server_name.lower()
+            or "anthropic" in server_name.lower()
+        ):
+            errors.append(f"{label} contains an invalid kebab-case server name")
+            continue
+        if not isinstance(config, dict):
+            errors.append(f"{label} server {server_name!r} must be an object")
+            continue
+        explicit_name = config.get("name", server_name)
+        if explicit_name != server_name:
+            errors.append(f"{label} server {server_name!r} name must match its map key")
+        transport = config.get("type")
+        if transport not in {"stdio", "http", "streamable-http", "sse", "ws"}:
+            errors.append(
+                f"{label} server {server_name!r} type must be one of "
+                "stdio, http, streamable-http, sse, ws"
+            )
+        command = config.get("command")
+        if not isinstance(command, str) or not command.strip():
+            errors.append(f"{label} server {server_name!r} command must be a non-empty string")
+        if transport in {"http", "streamable-http", "sse", "ws"}:
+            if not isinstance(config.get("url"), str) or not config["url"].strip():
+                errors.append(
+                    f"{label} server {server_name!r} type {transport!r} requires a non-empty url"
+                )
+        if not isinstance(config.get("args"), list):
+            errors.append(f"{label} server {server_name!r} args must be an array")
+        elif not all(
+            isinstance(value, str) for value in config["args"]
+        ):
+            errors.append(f"{label} server {server_name!r} args entries must be strings")
+        if not isinstance(config.get("env"), dict):
+            errors.append(f"{label} server {server_name!r} env must be an object")
+        if "headers" in config and not isinstance(config["headers"], dict):
+            errors.append(f"{label} server {server_name!r} headers must be an object")
+        if "metadata" in config and not isinstance(config["metadata"], dict):
+            errors.append(f"{label} server {server_name!r} metadata must be an object")
+        description = config.get("description")
+        if not isinstance(description, str) or not description.strip():
+            errors.append(f"{label} server {server_name!r} description must be a non-empty string")
+        elif len(description) > 1024:
+            errors.append(f"{label} server {server_name!r} description exceeds 1024 characters")
+        elif _MCP_UNSAFE_DESCRIPTION.search(description):
+            errors.append(f"{label} server {server_name!r} description contains unsafe markup or substitution")
+        version = config.get("version")
+        if not isinstance(version, str) or not _STRICT_SEMVER.fullmatch(version):
+            errors.append(f"{label} server {server_name!r} version must be strict SemVer")
+        if not isinstance(config.get("enabled"), bool):
+            errors.append(f"{label} server {server_name!r} enabled must be boolean")
+        for deprecated in ("compatible-with", "when_to_use"):
+            if deprecated in config:
+                errors.append(f"{label} server {server_name!r} uses deprecated field {deprecated!r}")
+    return errors
+
+
+def _canonical_component_errors(path: Path, kind: str) -> list[str]:
+    """Return canonical fatal/errors for an agent or command data file."""
+
+    try:
+        validator = _canonical_validator()
+    except RuntimeError as exc:
+        return [str(exc)]
+    function = validator.validate_agent if kind == "agent" else validator.validate_command
+    result = function(path)
+    errors: list[str] = []
+    if result.get("fatal"):
+        errors.append(str(result["fatal"]))
+    errors.extend(str(value) for value in result.get("errors", []))
+    return errors
+
+
+_HOOK_EVENTS = {
+    "SessionStart",
+    "Setup",
+    "UserPromptSubmit",
+    "UserPromptExpansion",
+    "PreToolUse",
+    "PermissionRequest",
+    "PermissionDenied",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "PostToolBatch",
+    "Notification",
+    "MessageDisplay",
+    "SubagentStart",
+    "SubagentStop",
+    "TaskCreated",
+    "TaskCompleted",
+    "Stop",
+    "StopFailure",
+    "TeammateIdle",
+    "InstructionsLoaded",
+    "ConfigChange",
+    "CwdChanged",
+    "FileChanged",
+    "WorktreeCreate",
+    "WorktreeRemove",
+    "PreCompact",
+    "PostCompact",
+    "Elicitation",
+    "ElicitationResult",
+    "SessionEnd",
+}
+
+
+def _validate_hooks(
+    document: Any, label: str, *, require_marketplace_fields: bool = True
+) -> list[str]:
+    """Validate the canonical event → matcher-group → handler shape."""
+
+    if not isinstance(document, dict) or not isinstance(document.get("hooks"), dict):
+        return [f"{label} must contain a hooks object"]
+    errors: list[str] = []
+    hooks = document["hooks"]
+    if not hooks:
+        errors.append(f"{label} hooks object must not be empty")
+    for event, groups in hooks.items():
+        if event not in _HOOK_EVENTS:
+            errors.append(f"{label} uses unsupported hook event {event!r}")
+            continue
+        if not isinstance(groups, list) or not groups:
+            errors.append(f"{label} event {event!r} must contain a non-empty array")
+            continue
+        for group_index, group in enumerate(groups):
+            group_label = f"{label} event {event!r} group {group_index}"
+            if not isinstance(group, dict):
+                errors.append(f"{group_label} must be an object")
+                continue
+            matcher = group.get("matcher")
+            if require_marketplace_fields and (not isinstance(matcher, str) or not matcher):
+                errors.append(f"{group_label} matcher must be a non-empty string")
+            elif matcher is not None and not isinstance(matcher, str):
+                errors.append(f"{group_label} matcher must be a string when present")
+            handlers = group.get("hooks")
+            if not isinstance(handlers, list) or not handlers:
+                errors.append(f"{group_label} hooks must be a non-empty array")
+                continue
+            for handler_index, handler in enumerate(handlers):
+                handler_label = f"{group_label} handler {handler_index}"
+                if not isinstance(handler, dict):
+                    errors.append(f"{handler_label} must be an object")
+                    continue
+                kind = handler.get("type")
+                required_field = {
+                    "command": "command",
+                    "http": "url",
+                    "mcp_tool": "toolName",
+                    "prompt": "prompt",
+                    "agent": "prompt",
+                }.get(kind)
+                if required_field is None:
+                    errors.append(f"{handler_label} has unsupported type {kind!r}")
+                elif not isinstance(handler.get(required_field), str) or not handler[required_field].strip():
+                    errors.append(f"{handler_label} requires a non-empty {required_field}")
+                if require_marketplace_fields:
+                    if not isinstance(handler.get("description"), str) or not handler["description"].strip():
+                        errors.append(f"{handler_label} requires a non-empty description")
+                    if not isinstance(handler.get("enabled"), bool):
+                        errors.append(f"{handler_label} enabled must be boolean")
+                    timeout = handler.get("timeout")
+                    if isinstance(timeout, bool) or not isinstance(timeout, int) or timeout < 0:
+                        errors.append(f"{handler_label} timeout must be a non-negative integer")
+                    if not isinstance(handler.get("blocking"), bool):
+                        errors.append(f"{handler_label} blocking must be boolean")
+    return errors
+
+
+def _load_regular_object(plugin_dir: Path, path: Path, label: str) -> tuple[dict[str, Any] | None, list[str]]:
+    if not _regular_contained_file(plugin_dir, path):
+        return None, [f"{label} must be a contained regular file with no symlink components"]
+    document, error = _load_object(path, label)
+    return document, [error] if error else []
+
+
+def validate_plugin_structure(plugin_dir: Path, relative: str, *, has_skills: bool) -> list[str]:
+    """Validate every structural artifact with canonical fail-closed rules."""
+
+    errors: list[str] = []
+    for component_dir in (".claude-plugin", "hooks", "skills", "agents", "commands"):
+        candidate = plugin_dir / component_dir
+        if candidate.is_symlink():
+            errors.append(
+                f"{relative}/{component_dir} must be a contained directory with no symlink components"
+            )
+    manifest_path = plugin_dir / ".claude-plugin" / "plugin.json"
+    manifest: dict[str, Any] | None = None
+    if _lexists(manifest_path):
+        manifest, load_errors = _load_regular_object(
+            plugin_dir, manifest_path, f"{relative}/.claude-plugin/plugin.json"
+        )
+        errors.extend(load_errors)
+        if manifest is not None:
+            errors.extend(
+                f"{relative}/.claude-plugin/plugin.json: {error}"
+                for error in _canonical_manifest_errors(manifest_path, manifest)
+            )
+    elif not has_skills:
+        errors.append(f"Plugin dir {relative} has no SKILL.md or canonical .claude-plugin/plugin.json")
+
+    mcp_documents: list[tuple[Path, str]] = []
+    mcp_path = plugin_dir / ".mcp.json"
+    if _lexists(mcp_path):
+        mcp_documents.append((mcp_path, f"{relative}/.mcp.json"))
+
+    if manifest is not None and "mcpServers" in manifest:
+        declaration = manifest["mcpServers"]
+        if isinstance(declaration, dict):
+            errors.extend(
+                _validate_mcp_servers(declaration, f"{relative}/.claude-plugin/plugin.json mcpServers")
+            )
+        elif isinstance(declaration, (str, list)):
+            references = [declaration] if isinstance(declaration, str) else declaration
+            for reference in references:
+                if not isinstance(reference, str):
+                    errors.append(f"{relative} mcpServers references must be strings")
+                    continue
+                ref_path = PurePosixPath(reference)
+                if ref_path.is_absolute() or ".." in ref_path.parts:
+                    errors.append(f"{relative} mcpServers reference escapes plugin: {reference}")
+                    continue
+                mcp_documents.append((plugin_dir.joinpath(*ref_path.parts), f"{relative}/{reference}"))
+
+    hook_documents: list[tuple[Path, str]] = []
+    if manifest is not None and "hooks" in manifest:
+        declaration = manifest["hooks"]
+        if isinstance(declaration, dict):
+            errors.extend(
+                _validate_hooks(
+                    {"hooks": declaration},
+                    f"{relative}/.claude-plugin/plugin.json hooks",
+                    require_marketplace_fields=False,
+                )
+            )
+        elif isinstance(declaration, (str, list)):
+            references = [declaration] if isinstance(declaration, str) else declaration
+            for reference in references:
+                if not isinstance(reference, str):
+                    errors.append(f"{relative} hooks references must be strings")
+                    continue
+                ref_path = PurePosixPath(reference)
+                if ref_path.is_absolute() or ".." in ref_path.parts:
+                    errors.append(f"{relative} hooks reference escapes plugin: {reference}")
+                    continue
+                hook_documents.append((plugin_dir.joinpath(*ref_path.parts), f"{relative}/{reference}"))
+
+    seen_mcp: set[Path] = set()
+    for path, label in mcp_documents:
+        if path in seen_mcp:
+            continue
+        seen_mcp.add(path)
+        document, load_errors = _load_regular_object(plugin_dir, path, label)
+        errors.extend(load_errors)
+        if document is not None:
+            errors.extend(_validate_mcp_servers(document.get("mcpServers", document), label))
+
+    hooks_path = plugin_dir / "hooks" / "hooks.json"
+    if _lexists(hooks_path):
+        hook_documents.append((hooks_path, f"{relative}/hooks/hooks.json"))
+    seen_hooks: set[Path] = set()
+    for path, label in hook_documents:
+        if path in seen_hooks:
+            continue
+        seen_hooks.add(path)
+        hooks, load_errors = _load_regular_object(plugin_dir, path, label)
+        errors.extend(load_errors)
+        if hooks is not None:
+            errors.extend(_validate_hooks(hooks, label))
+
+    for component_dir, kind in (("agents", "agent"), ("commands", "command")):
+        directory = plugin_dir / component_dir
+        if not _lexists(directory) or directory.is_symlink() or not directory.is_dir():
+            continue
+        for path in directory.rglob("*.md"):
+            label = f"{relative}/{path.relative_to(plugin_dir).as_posix()}"
+            if not _regular_contained_file(plugin_dir, path):
+                errors.append(f"{label} must be a contained regular file with no symlink components")
+                continue
+            errors.extend(
+                f"{label}: {error}" for error in _canonical_component_errors(path, kind)
+            )
+
+    return errors
+
+
+def supplement_results(
+    all_results: list[dict[str, Any]], changed_dirs: list[str], *, pr_root: Path
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Filter skill results and add neutral structural records for plugins."""
+
+    filtered = [
+        result
+        for result in all_results
+        if any((plugin + "/") in str(result.get("path", "")) for plugin in changed_dirs)
+    ]
+    signals: list[str] = []
+    catalog_roots = load_catalog_roots(pr_root, required=True)
+
+    for plugin in changed_dirs:
+        plugin_dir = pr_root.joinpath(*PurePosixPath(plugin).parts)
+        if plugin not in catalog_roots:
+            signals.append(
+                f"Missing exact catalog source './{plugin}' in {_CATALOG_PATH}"
+            )
+        has_skills = any(
+            _regular_contained_file(plugin_dir, path) for path in plugin_dir.rglob("SKILL.md")
+        )
+        has_skill_result = any(
+            (plugin + "/") in str(result.get("path", ""))
+            and str(result.get("path", "")).endswith("SKILL.md")
+            for result in filtered
+        )
+        errors = validate_plugin_structure(plugin_dir, plugin, has_skills=has_skills)
+        if errors:
+            signals.extend(errors)
+            continue
+        if has_skills and not has_skill_result:
+            # A changed skill-bearing plugin with no validator record is an
+            # internal failure, not a candidate for structural-only PASS.
+            signals.append(f"prescreen-internal-error: validator produced no result for {plugin}")
+            continue
+        filtered.append(
+            {
+                "path": plugin,
+                "score": None,
+                "grade": None,
+                "errors": 0,
+                "warnings": 0,
+                "error_messages": [],
+                "warning_messages": [],
+                "component_type": "plugin-structure",
+            }
+        )
+
+    for result in filtered:
+        path = str(result.get("path", ""))
+        marker = "/plugins/"
+        if marker in path:
+            result["path"] = path[path.index(marker) + 1 :]
+
+    return filtered, signals
+
+
+def validate_deleted_plugins(
+    deleted_dirs: list[str], *, pr_root: Path
+) -> list[str]:
+    """Validate full removals without following replacement symlinks."""
+
+    catalog_roots = load_catalog_roots(pr_root, required=True)
+    signals: list[str] = []
+    for plugin in deleted_dirs:
+        candidate = pr_root.joinpath(*PurePosixPath(plugin).parts)
+        if _lexists(candidate):
+            try:
+                metadata = candidate.lstat()
+            except OSError as exc:
+                signals.append(f"Deleted plugin root {plugin} cannot be inspected: {exc}")
+            else:
+                if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                    signals.append(
+                        f"Deleted plugin root {plugin} still exists as a symlink or non-directory"
+                    )
+                else:
+                    signals.append(f"prescreen-internal-error: deleted plugin root {plugin} still exists")
+        if plugin in catalog_roots:
+            signals.append(
+                f"Deleted plugin {plugin} still has exact catalog source './{plugin}'"
+            )
+    return signals
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_lines(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _write_lines(path: Path, values: list[str]) -> None:
+    path.write_text("".join(f"{value}\n" for value in values), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    discover = subparsers.add_parser("discover")
+    discover.add_argument("--files-json", type=Path, required=True)
+    discover.add_argument("--pr-root", type=Path, required=True)
+    discover.add_argument("--base-root", type=Path, required=True)
+    discover.add_argument("--changed-output", type=Path, required=True)
+    discover.add_argument("--deleted-output", type=Path, required=True)
+
+    supplement = subparsers.add_parser("supplement")
+    supplement.add_argument("--validator-results", type=Path, required=True)
+    supplement.add_argument("--changed-input", type=Path, required=True)
+    supplement.add_argument("--pr-root", type=Path, required=True)
+    supplement.add_argument("--results-output", type=Path, required=True)
+    supplement.add_argument("--signals-output", type=Path, required=True)
+
+    deletions = subparsers.add_parser("check-deletions")
+    deletions.add_argument("--deleted-input", type=Path, required=True)
+    deletions.add_argument("--pr-root", type=Path, required=True)
+    deletions.add_argument("--signals-output", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "discover":
+            entries = _read_json(args.files_json)
+            if not isinstance(entries, list):
+                raise ValueError("--files-json must contain a JSON array")
+            changed, deleted, plugin_files = discover_plugin_dirs(
+                entries, pr_root=args.pr_root, base_root=args.base_root
+            )
+            _write_lines(args.changed_output, changed)
+            _write_lines(args.deleted_output, deleted)
+            print(json.dumps({"changed": len(changed), "deleted": len(deleted), "plugin_files": plugin_files}))
+        elif args.command == "supplement":
+            results = _read_json(args.validator_results)
+            if not isinstance(results, list):
+                raise ValueError("--validator-results must contain a JSON array")
+            filtered, signals = supplement_results(results, _read_lines(args.changed_input), pr_root=args.pr_root)
+            args.results_output.write_text(json.dumps(filtered), encoding="utf-8")
+            _write_lines(args.signals_output, signals)
+            print(json.dumps({"filtered": len(filtered), "signals": len(signals)}))
+        else:
+            signals = validate_deleted_plugins(_read_lines(args.deleted_input), pr_root=args.pr_root)
+            _write_lines(args.signals_output, signals)
+            print(json.dumps({"deleted_signals": len(signals)}))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"prescreen scope error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr-prescreen/test_classify.py
+++ b/scripts/pr-prescreen/test_classify.py
@@ -103,6 +103,20 @@ class ClassifyTests(unittest.TestCase):
         out = classify([_r("a", 90, "A"), _r("b", 80, "B")])
         self.assertIn("85", out["summary"])
 
+    def test_summary_names_structural_plugin_record_as_component(self):
+        record = {
+            "path": "plugins/mcp/a2a",
+            "score": None,
+            "grade": None,
+            "errors": 0,
+            "warnings": 0,
+            "component_type": "plugin-structure",
+        }
+        out = classify([record])
+        self.assertEqual(out["verdict"], "PASS")
+        self.assertIn("1 component(s) inspected", out["summary"])
+        self.assertNotIn("avg score", out["summary"])
+
     def test_main_reads_stdin(self):
         payload = json.dumps([_r("plugins/x/SKILL.md", 95, "A")])
         with patch("sys.stdin", StringIO(payload)), patch("sys.stdout", new_callable=StringIO) as out:

--- a/scripts/pr-prescreen/test_scope.py
+++ b/scripts/pr-prescreen/test_scope.py
@@ -1,0 +1,549 @@
+"""Hostile regression tests for PR prescreen plugin scoping."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).with_name("scope.py")
+_SPEC = importlib.util.spec_from_file_location("_pr_prescreen_scope", _SCRIPT)
+_SCOPE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SCOPE
+_SPEC.loader.exec_module(_SCOPE)
+
+
+def _manifest(plugin: Path, value: dict | None = None) -> Path:
+    path = plugin / ".claude-plugin" / "plugin.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value or {"name": plugin.name}), encoding="utf-8")
+    return path
+
+
+def _mcp(plugin: Path, value: dict | None = None) -> Path:
+    path = plugin / ".mcp.json"
+    path.write_text(
+        json.dumps(
+            value
+            or {
+                "mcpServers": {
+                    plugin.name: {
+                        "name": plugin.name,
+                        "type": "stdio",
+                        "command": "node",
+                        "args": [],
+                        "env": {},
+                        "description": "A canonical test MCP server",
+                        "version": "1.0.0",
+                        "enabled": True,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _catalog(root: Path, sources: list[str]) -> Path:
+    path = root / ".claude-plugin/marketplace.extended.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"plugins": [{"source": f"./{source}"} for source in sources]}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _supplement(
+    results: list[dict], changed_dirs: list[str], *, pr_root: Path
+) -> tuple[list[dict], list[str]]:
+    _catalog(pr_root, changed_dirs)
+    return _SCOPE.supplement_results(results, changed_dirs, pr_root=pr_root)
+
+
+class ScopeTests(unittest.TestCase):
+    def test_workflow_uses_only_immutable_base_tooling(self) -> None:
+        workflow = (_SCRIPT.parents[2] / ".github/workflows/pr-prescreen.yml").read_text()
+        self.assertIn('"$SCOPE_SCRIPT" discover', workflow)
+        self.assertIn('"$SCOPE_SCRIPT" supplement', workflow)
+        self.assertIn("python3 base/scripts/validate-skills-schema.py --marketplace --json --repo-root pr", workflow)
+        self.assertNotIn("SCOPE_SCRIPT=pr/", workflow)
+        self.assertNotIn(".prescreen-validator.py", workflow)
+        self.assertNotIn("install -m 0644", workflow)
+
+    def test_workflow_resolves_dispatch_head_base_and_all_file_pages(self) -> None:
+        workflow = (_SCRIPT.parents[2] / ".github/workflows/pr-prescreen.yml").read_text()
+        self.assertIn("gh api \"repos/${{ github.repository }}/pulls/$PR_NUMBER\"", workflow)
+        self.assertIn("ref: ${{ steps.pr.outputs.head_sha }}", workflow)
+        self.assertIn("ref: ${{ steps.pr.outputs.base_sha }}", workflow)
+        self.assertIn("gh api --paginate --slurp", workflow)
+        self.assertIn("| jq 'add' > /tmp/pr-files.json", workflow)
+        self.assertIn('if [ "$VALIDATOR_EXIT" -ne 0 ]', workflow)
+        self.assertIn('"$SCOPE_SCRIPT" check-deletions', workflow)
+        self.assertNotIn("grep -q", workflow)
+
+    def test_category_support_file_is_not_a_plugin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "pr/plugins/mcp").mkdir(parents=True)
+            (root / "base/plugins/mcp").mkdir(parents=True)
+            (root / "pr/plugins/mcp/destructive-policies.json").write_text("{}")
+            changed, deleted, count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/mcp/destructive-policies.json", "status": "modified"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual((changed, deleted, count), ([], [], 1))
+
+    def test_new_cataloged_plugin_root_symlink_is_scoped_for_hard_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "outside"
+            target.mkdir()
+            candidate = root / "pr/plugins/mcp/evil"
+            candidate.parent.mkdir(parents=True)
+            candidate.symlink_to(target, target_is_directory=True)
+            _catalog(root / "pr", ["plugins/mcp/evil"])
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/mcp/evil", "status": "added"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+            signals = _SCOPE.validate_deleted_plugins(deleted, pr_root=root / "pr")
+        self.assertEqual(changed, [])
+        self.assertEqual(deleted, ["plugins/mcp/evil"])
+        self.assertTrue(any("symlink or non-directory" in signal for signal in signals))
+        self.assertTrue(any("still has exact catalog source" in signal for signal in signals))
+
+    def test_three_part_regular_cataloged_plugin_root_is_changed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _manifest(root / "pr/plugins/mcp/regular-plugin")
+            _catalog(root / "pr", ["plugins/mcp/regular-plugin"])
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/mcp/regular-plugin", "status": "added"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/mcp/regular-plugin"])
+        self.assertEqual(deleted, [])
+
+    def test_real_support_directories_are_excluded_by_missing_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            entries = []
+            for relative in (
+                "plugins/mcp/.greptile/config.json",
+                "plugins/saas-packs/scripts/generate-skill-db.py",
+                "plugins/saas-packs/_templates/slots/S01.md.j2",
+            ):
+                path = root / "pr" / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("support")
+                entries.append({"filename": relative, "status": "modified"})
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                entries, pr_root=root / "pr", base_root=root / "base"
+            )
+        self.assertEqual(changed, [])
+        self.assertEqual(deleted, [])
+
+    def test_cataloged_axiom_without_root_marker_is_scoped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "pr/plugins/skill-enhancers/axiom"
+            (plugin / "plugins/axiom/skills").mkdir(parents=True)
+            (plugin / "plugins/axiom/skills/example.md").write_text("nested component")
+            _catalog(root / "pr", ["plugins/skill-enhancers/axiom"])
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/skill-enhancers/axiom/README.md", "status": "modified"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/skill-enhancers/axiom"])
+        self.assertEqual(deleted, [])
+
+    def test_same_basename_catalog_source_does_not_spoof_exact_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/mcp/shared-name"
+            _manifest(plugin)
+            _mcp(plugin)
+            _catalog(root, ["plugins/security/shared-name"])
+            results, signals = _SCOPE.supplement_results(
+                [], ["plugins/mcp/shared-name"], pr_root=root
+            )
+        self.assertEqual(len(results), 1)
+        self.assertTrue(any("Missing exact catalog source" in signal for signal in signals))
+
+    def test_real_mcp_plugin_and_support_file_yield_only_plugin_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "pr/plugins/mcp/a2a-client"
+            _manifest(plugin)
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [
+                    {"filename": "plugins/mcp/a2a-client/src/index.ts", "status": "added"},
+                    {"filename": "plugins/mcp/destructive-policies.json", "status": "modified"},
+                ],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/mcp/a2a-client"])
+        self.assertEqual(deleted, [])
+
+    def test_partial_deletion_inside_existing_plugin_remains_changed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _manifest(root / "pr/plugins/mcp/a2a-client")
+            _manifest(root / "base/plugins/mcp/a2a-client")
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/mcp/a2a-client/old.ts", "status": "removed"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/mcp/a2a-client"])
+        self.assertEqual(deleted, [])
+
+    def test_deleted_manifest_with_remaining_plugin_root_is_not_full_deletion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "pr/plugins/mcp/a2a-client"
+            plugin.mkdir(parents=True)
+            (plugin / "README.md").write_text("still here")
+            _manifest(root / "base/plugins/mcp/a2a-client")
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{
+                    "filename": "plugins/mcp/a2a-client/.claude-plugin/plugin.json",
+                    "status": "removed",
+                }],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/mcp/a2a-client"])
+        self.assertEqual(deleted, [])
+
+    def test_fully_absent_plugin_is_deleted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "pr").mkdir()
+            _manifest(root / "base/plugins/mcp/old-plugin")
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/mcp/old-plugin/README.md", "status": "removed"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, [])
+        self.assertEqual(deleted, ["plugins/mcp/old-plugin"])
+
+    def test_base_plugin_replaced_by_symlink_enters_deletion_integrity_lane(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _manifest(root / "base/plugins/mcp/old-plugin")
+            _catalog(root / "base", ["plugins/mcp/old-plugin"])
+            target = root / "outside"
+            target.mkdir()
+            candidate = root / "pr/plugins/mcp/old-plugin"
+            candidate.parent.mkdir(parents=True)
+            candidate.symlink_to(target, target_is_directory=True)
+            _catalog(root / "pr", ["plugins/mcp/old-plugin"])
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{"filename": "plugins/mcp/old-plugin/README.md", "status": "modified"}],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, [])
+        self.assertEqual(deleted, ["plugins/mcp/old-plugin"])
+
+    def test_cross_plugin_rename_scopes_new_and_deleted_old_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _manifest(root / "pr/plugins/mcp/new-plugin")
+            _manifest(root / "base/plugins/mcp/old-plugin")
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{
+                    "filename": "plugins/mcp/new-plugin/src/index.ts",
+                    "previous_filename": "plugins/mcp/old-plugin/src/index.ts",
+                    "status": "renamed",
+                }],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/mcp/new-plugin"])
+        self.assertEqual(deleted, ["plugins/mcp/old-plugin"])
+
+    def test_cross_plugin_rename_scopes_old_root_when_it_still_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _manifest(root / "pr/plugins/mcp/new-plugin")
+            _manifest(root / "pr/plugins/mcp/old-plugin")
+            _manifest(root / "base/plugins/mcp/old-plugin")
+            changed, deleted, _count = _SCOPE.discover_plugin_dirs(
+                [{
+                    "filename": "plugins/mcp/new-plugin/src/index.ts",
+                    "previous_filename": "plugins/mcp/old-plugin/src/index.ts",
+                    "status": "renamed",
+                }],
+                pr_root=root / "pr",
+                base_root=root / "base",
+            )
+        self.assertEqual(changed, ["plugins/mcp/new-plugin", "plugins/mcp/old-plugin"])
+        self.assertEqual(deleted, [])
+
+    def test_valid_non_skill_mcp_plugin_gets_neutral_structural_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/mcp/a2a-client"
+            _manifest(plugin)
+            _mcp(plugin)
+            results, signals = _supplement(
+                [], ["plugins/mcp/a2a-client"], pr_root=root
+            )
+        self.assertEqual(signals, [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["grade"])
+        self.assertIsNone(results[0]["score"])
+        self.assertEqual(results[0]["component_type"], "plugin-structure")
+
+    def test_manifest_name_contract_fails_for_skill_and_non_skill_plugins(self) -> None:
+        for name, with_skill in (("", False), ("Bad Name", False), ("", True), ("Bad Name", True)):
+            with self.subTest(name=name, with_skill=with_skill), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                plugin = root / "plugins/mcp/name-contract"
+                _manifest(plugin, {"name": name})
+                validator_results: list[dict] = []
+                if with_skill:
+                    skill = plugin / "skills/check/SKILL.md"
+                    skill.parent.mkdir(parents=True)
+                    skill.write_text("---\nname: check\ndescription: Valid test skill description\n---\n")
+                    validator_results.append(
+                        {"path": str(skill), "score": 95, "grade": "A", "errors": 0, "warnings": 0}
+                    )
+                results, signals = _supplement(
+                    validator_results, ["plugins/mcp/name-contract"], pr_root=root
+                )
+            self.assertTrue(any("non-empty kebab-case" in signal for signal in signals))
+
+    def test_mcp_marketplace_required_fields_fail_closed(self) -> None:
+        canonical = {
+            "name": "server",
+            "type": "stdio",
+            "command": "node",
+            "args": [],
+            "env": {},
+            "description": "Canonical MCP server",
+            "version": "1.0.0",
+            "enabled": True,
+        }
+        for field in ("type", "command", "args", "env", "description", "version", "enabled"):
+            with self.subTest(field=field):
+                config = dict(canonical)
+                del config[field]
+                errors = _SCOPE._validate_mcp_servers({"server": config}, "test MCP")
+                self.assertTrue(any(field in error for error in errors), errors)
+        self.assertTrue(
+            _SCOPE._validate_mcp_servers(
+                {"Bad Name": canonical}, "test MCP"
+            )
+        )
+        invalid_version = dict(canonical, version="1.0")
+        self.assertTrue(
+            any(
+                "strict SemVer" in error
+                for error in _SCOPE._validate_mcp_servers({"server": invalid_version}, "test MCP")
+            )
+        )
+        for mutation, expected in (
+            ({"description": "${SECRET}"}, "unsafe"),
+            ({"description": "x" * 1025}, "1024"),
+            ({"version": "1.0.0-01"}, "SemVer"),
+            ({"metadata": []}, "metadata"),
+            ({"when_to_use": "legacy"}, "deprecated"),
+        ):
+            with self.subTest(mutation=mutation):
+                errors = _SCOPE._validate_mcp_servers(
+                    {"server": dict(canonical, **mutation)}, "test MCP"
+                )
+                self.assertTrue(any(expected in error for error in errors), errors)
+
+    def test_invalid_manifest_version_type_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/mcp/broken-version"
+            _manifest(plugin, {"name": "broken-version", "version": 7})
+            results, signals = _supplement(
+                [], ["plugins/mcp/broken-version"], pr_root=root
+            )
+        self.assertEqual(results, [])
+        self.assertTrue(any("Field 'version' must be string" in signal for signal in signals))
+
+    def test_inline_http_mcp_without_url_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/mcp/broken-inline"
+            _manifest(plugin, {
+                "name": "broken-inline",
+                "mcpServers": {
+                    "remote": {
+                        "name": "remote",
+                        "type": "http",
+                        "command": "node",
+                        "args": [],
+                        "env": {},
+                        "description": "Remote MCP server",
+                        "version": "1.0.0",
+                        "enabled": True,
+                    }
+                },
+            })
+            results, signals = _supplement(
+                [], ["plugins/mcp/broken-inline"], pr_root=root
+            )
+        self.assertEqual(results, [])
+        self.assertTrue(any("requires a non-empty url" in signal for signal in signals))
+
+    def test_malformed_hooks_shape_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/mcp/broken-hooks"
+            _manifest(plugin)
+            hooks = plugin / "hooks/hooks.json"
+            hooks.parent.mkdir()
+            hooks.write_text(json.dumps({"hooks": {"PreToolUse": []}}))
+            results, signals = _supplement(
+                [], ["plugins/mcp/broken-hooks"], pr_root=root
+            )
+        self.assertEqual(results, [])
+        self.assertTrue(any("must contain a non-empty array" in signal for signal in signals))
+
+    def test_malformed_agent_and_command_fail_closed_without_skills(self) -> None:
+        for component in ("agents", "commands"):
+            with self.subTest(component=component), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                plugin = root / "plugins/mcp/broken-component"
+                _manifest(plugin)
+                _mcp(plugin)
+                artifact = plugin / component / "broken.md"
+                artifact.parent.mkdir(parents=True)
+                artifact.write_text("No frontmatter here")
+                results, signals = _supplement(
+                    [], ["plugins/mcp/broken-component"], pr_root=root
+                )
+            self.assertEqual(results, [])
+            self.assertTrue(any("No frontmatter found" in signal for signal in signals))
+
+    def test_deleted_root_symlink_and_stale_exact_catalog_both_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "outside"
+            target.mkdir()
+            candidate = root / "plugins/mcp/old-plugin"
+            candidate.parent.mkdir(parents=True)
+            candidate.symlink_to(target, target_is_directory=True)
+            _catalog(root, ["plugins/mcp/old-plugin"])
+            signals = _SCOPE.validate_deleted_plugins(
+                ["plugins/mcp/old-plugin"], pr_root=root
+            )
+        self.assertTrue(any("symlink or non-directory" in signal for signal in signals))
+        self.assertTrue(any("still has exact catalog source" in signal for signal in signals))
+
+    def test_malformed_inline_hooks_shape_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/mcp/broken-inline-hooks"
+            _manifest(plugin, {
+                "name": "broken-inline-hooks",
+                "hooks": {"PreToolUse": [{"hooks": "not-an-array"}]},
+            })
+            results, signals = _supplement(
+                [], ["plugins/mcp/broken-inline-hooks"], pr_root=root
+            )
+        self.assertEqual(results, [])
+        self.assertTrue(any("hooks must be a non-empty array" in signal for signal in signals))
+
+    def test_nested_symlink_artifacts_fail_closed(self) -> None:
+        for case in ("manifest", "mcp", "hooks"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                plugin = root / "plugins/mcp/symlinked"
+                outside = root / "outside"
+                outside.mkdir()
+                if case == "manifest":
+                    target = outside / "plugin.json"
+                    target.write_text(json.dumps({"name": "symlinked"}))
+                    link = plugin / ".claude-plugin/plugin.json"
+                    link.parent.mkdir(parents=True)
+                    link.symlink_to(target)
+                else:
+                    _manifest(plugin)
+                    if case == "mcp":
+                        target = outside / ".mcp.json"
+                        target.write_text(json.dumps({"mcpServers": {"x": {"command": "node"}}}))
+                        (plugin / ".mcp.json").symlink_to(target)
+                    else:
+                        target = outside / "hooks.json"
+                        target.write_text(json.dumps({"hooks": {}}))
+                        (plugin / "hooks").symlink_to(outside, target_is_directory=True)
+                results, signals = _supplement(
+                    [], ["plugins/mcp/symlinked"], pr_root=root
+                )
+                self.assertEqual(results, [])
+                self.assertTrue(any("no symlink components" in signal for signal in signals))
+
+    def test_dangling_manifest_parent_symlink_on_skill_plugin_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/security/symlinked"
+            skill = plugin / "skills/check/SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("---\nname: check\n---\n")
+            (plugin / ".claude-plugin").symlink_to(root / "missing", target_is_directory=True)
+            validator_result = {
+                "path": str(skill), "score": 95, "grade": "A", "errors": 0, "warnings": 0,
+            }
+            results, signals = _supplement(
+                [validator_result], ["plugins/security/symlinked"], pr_root=root
+            )
+        self.assertEqual(len(results), 1)
+        self.assertTrue(any(".claude-plugin" in signal and "no symlink" in signal for signal in signals))
+
+    def test_a_skill_result_does_not_hide_invalid_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/security/example"
+            _manifest(plugin, {"name": "example", "version": 4})
+            skill = plugin / "skills/check/SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("---\nname: check\ndescription: example\n---\n")
+            validator_result = {
+                "path": str(skill), "score": 95, "grade": "A", "errors": 0, "warnings": 0,
+            }
+            results, signals = _supplement(
+                [validator_result], ["plugins/security/example"], pr_root=root
+            )
+        self.assertEqual(len(results), 1)
+        self.assertTrue(any("Field 'version' must be string" in signal for signal in signals))
+
+    def test_skill_bearing_plugin_without_validator_result_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin = root / "plugins/security/example"
+            _manifest(plugin)
+            skill = plugin / "skills/check/SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("---\nname: check\n---\n")
+            results, signals = _supplement(
+                [], ["plugins/security/example"], pr_root=root
+            )
+        self.assertEqual(results, [])
+        self.assertEqual(signals, [
+            "prescreen-internal-error: validator produced no result for plugins/security/example"
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr-prescreen/test_scope.py
+++ b/scripts/pr-prescreen/test_scope.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+import yaml
 
 
 _SCRIPT = Path(__file__).with_name("scope.py")
@@ -59,11 +63,15 @@ def _catalog(root: Path, sources: list[str]) -> Path:
     return path
 
 
-def _supplement(
-    results: list[dict], changed_dirs: list[str], *, pr_root: Path
-) -> tuple[list[dict], list[str]]:
+def _supplement(results: list[dict], changed_dirs: list[str], *, pr_root: Path) -> tuple[list[dict], list[str]]:
     _catalog(pr_root, changed_dirs)
     return _SCOPE.supplement_results(results, changed_dirs, pr_root=pr_root)
+
+
+def _workflow_step(name: str) -> str:
+    workflow_path = _SCRIPT.parents[2] / ".github/workflows/pr-prescreen.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+    return next(step["run"] for step in workflow["jobs"]["validate"]["steps"] if step.get("name") == name)
 
 
 class ScopeTests(unittest.TestCase):
@@ -72,13 +80,20 @@ class ScopeTests(unittest.TestCase):
         self.assertIn('"$SCOPE_SCRIPT" discover', workflow)
         self.assertIn('"$SCOPE_SCRIPT" supplement', workflow)
         self.assertIn("python3 base/scripts/validate-skills-schema.py --marketplace --json --repo-root pr", workflow)
+        self.assertIn('if [ "$PLUGIN_LINES" = "0" ]', workflow)
+        self.assertIn('((.previous_filename // "") | startswith("plugins/"))', workflow)
+        self.assertEqual(workflow.count("/tmp/no-plugin-changes"), 3)
+        self.assertIn("printf '[]\\n' > /tmp/filtered-results.json", workflow)
+        self.assertIn(": > /tmp/structure-signals.txt", workflow)
+        self.assertIn(": > /tmp/hard-blocks.txt", workflow)
+        self.assertIn("immutable base scope helper is unavailable", workflow)
         self.assertNotIn("SCOPE_SCRIPT=pr/", workflow)
         self.assertNotIn(".prescreen-validator.py", workflow)
         self.assertNotIn("install -m 0644", workflow)
 
     def test_workflow_resolves_dispatch_head_base_and_all_file_pages(self) -> None:
         workflow = (_SCRIPT.parents[2] / ".github/workflows/pr-prescreen.yml").read_text()
-        self.assertIn("gh api \"repos/${{ github.repository }}/pulls/$PR_NUMBER\"", workflow)
+        self.assertIn('gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER"', workflow)
         self.assertIn("ref: ${{ steps.pr.outputs.head_sha }}", workflow)
         self.assertIn("ref: ${{ steps.pr.outputs.base_sha }}", workflow)
         self.assertIn("gh api --paginate --slurp", workflow)
@@ -86,6 +101,94 @@ class ScopeTests(unittest.TestCase):
         self.assertIn('if [ "$VALIDATOR_EXIT" -ne 0 ]', workflow)
         self.assertIn('"$SCOPE_SCRIPT" check-deletions', workflow)
         self.assertNotIn("grep -q", workflow)
+
+    def test_workflow_zero_plugin_bootstrap_produces_complete_artifacts_without_base_helper(self) -> None:
+        artifact_paths = [
+            Path("/tmp/no-plugin-changes"),
+            Path("/tmp/validator.log"),
+            Path("/tmp/validator-parsed.json"),
+            Path("/tmp/filtered-results.json"),
+            Path("/tmp/structure-signals.txt"),
+            Path("/tmp/diff-step-signals.txt"),
+            Path("/tmp/hard-blocks.txt"),
+        ]
+        try:
+            for path in artifact_paths:
+                path.unlink(missing_ok=True)
+            Path("/tmp/no-plugin-changes").touch()
+            Path("/tmp/diff-step-signals.txt").touch()
+            with tempfile.TemporaryDirectory() as tmp:
+                for name in (
+                    "Run validator against PR tree (full --json sweep)",
+                    "Detect structural hard-block signals",
+                ):
+                    result = subprocess.run(
+                        ["bash", "-c", _workflow_step(name)],
+                        cwd=tmp,
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(Path("/tmp/filtered-results.json").read_text()), [])
+            self.assertEqual(Path("/tmp/structure-signals.txt").read_text(), "")
+            self.assertEqual(Path("/tmp/hard-blocks.txt").read_text(), "")
+        finally:
+            for path in artifact_paths:
+                path.unlink(missing_ok=True)
+
+    def test_workflow_rename_out_of_plugins_invokes_immutable_scope_helper(self) -> None:
+        artifact_paths = [
+            Path("/tmp/no-plugin-changes"),
+            Path("/tmp/pr-files.json"),
+            Path("/tmp/pr-files.txt"),
+            Path("/tmp/changed-plugins.txt"),
+            Path("/tmp/deleted-plugins.txt"),
+            Path("/tmp/diff-step-signals.txt"),
+        ]
+        try:
+            for path in artifact_paths:
+                path.unlink(missing_ok=True)
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                bin_dir = root / "bin"
+                bin_dir.mkdir()
+                gh = bin_dir / "gh"
+                gh.write_text(
+                    "#!/bin/sh\n"
+                    'printf \'%s\\n\' \'[[{"filename":"000-docs/moved.json",'
+                    '"previous_filename":"plugins/mcp/a2a-client/.claude-plugin/plugin.json",'
+                    '"status":"renamed"}]]\'\n'
+                )
+                gh.chmod(0o755)
+                helper = root / "base/scripts/pr-prescreen/scope.py"
+                helper.parent.mkdir(parents=True)
+                helper.write_text(
+                    "import pathlib, sys\n"
+                    "args = sys.argv\n"
+                    "for flag in ('--changed-output', '--deleted-output'):\n"
+                    "    pathlib.Path(args[args.index(flag) + 1]).touch()\n"
+                    "pathlib.Path('scope-invoked').touch()\n"
+                )
+                (root / "pr").mkdir()
+                script = _workflow_step("Compute changed plugin paths")
+                script = script.replace("${{ github.repository }}", "owner/repo")
+                script = script.replace("${{ steps.pr.outputs.number }}", "1")
+                github_output = root / "github-output"
+                result = subprocess.run(
+                    ["bash", "-c", script],
+                    cwd=root,
+                    env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", "GITHUB_OUTPUT": str(github_output)},
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertTrue((root / "scope-invoked").is_file())
+                self.assertFalse(Path("/tmp/no-plugin-changes").exists())
+        finally:
+            for path in artifact_paths:
+                path.unlink(missing_ok=True)
 
     def test_category_support_file_is_not_a_plugin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -174,9 +277,7 @@ class ScopeTests(unittest.TestCase):
             _manifest(plugin)
             _mcp(plugin)
             _catalog(root, ["plugins/security/shared-name"])
-            results, signals = _SCOPE.supplement_results(
-                [], ["plugins/mcp/shared-name"], pr_root=root
-            )
+            results, signals = _SCOPE.supplement_results([], ["plugins/mcp/shared-name"], pr_root=root)
         self.assertEqual(len(results), 1)
         self.assertTrue(any("Missing exact catalog source" in signal for signal in signals))
 
@@ -217,10 +318,12 @@ class ScopeTests(unittest.TestCase):
             (plugin / "README.md").write_text("still here")
             _manifest(root / "base/plugins/mcp/a2a-client")
             changed, deleted, _count = _SCOPE.discover_plugin_dirs(
-                [{
-                    "filename": "plugins/mcp/a2a-client/.claude-plugin/plugin.json",
-                    "status": "removed",
-                }],
+                [
+                    {
+                        "filename": "plugins/mcp/a2a-client/.claude-plugin/plugin.json",
+                        "status": "removed",
+                    }
+                ],
                 pr_root=root / "pr",
                 base_root=root / "base",
             )
@@ -265,11 +368,13 @@ class ScopeTests(unittest.TestCase):
             _manifest(root / "pr/plugins/mcp/new-plugin")
             _manifest(root / "base/plugins/mcp/old-plugin")
             changed, deleted, _count = _SCOPE.discover_plugin_dirs(
-                [{
-                    "filename": "plugins/mcp/new-plugin/src/index.ts",
-                    "previous_filename": "plugins/mcp/old-plugin/src/index.ts",
-                    "status": "renamed",
-                }],
+                [
+                    {
+                        "filename": "plugins/mcp/new-plugin/src/index.ts",
+                        "previous_filename": "plugins/mcp/old-plugin/src/index.ts",
+                        "status": "renamed",
+                    }
+                ],
                 pr_root=root / "pr",
                 base_root=root / "base",
             )
@@ -283,11 +388,13 @@ class ScopeTests(unittest.TestCase):
             _manifest(root / "pr/plugins/mcp/old-plugin")
             _manifest(root / "base/plugins/mcp/old-plugin")
             changed, deleted, _count = _SCOPE.discover_plugin_dirs(
-                [{
-                    "filename": "plugins/mcp/new-plugin/src/index.ts",
-                    "previous_filename": "plugins/mcp/old-plugin/src/index.ts",
-                    "status": "renamed",
-                }],
+                [
+                    {
+                        "filename": "plugins/mcp/new-plugin/src/index.ts",
+                        "previous_filename": "plugins/mcp/old-plugin/src/index.ts",
+                        "status": "renamed",
+                    }
+                ],
                 pr_root=root / "pr",
                 base_root=root / "base",
             )
@@ -300,9 +407,7 @@ class ScopeTests(unittest.TestCase):
             plugin = root / "plugins/mcp/a2a-client"
             _manifest(plugin)
             _mcp(plugin)
-            results, signals = _supplement(
-                [], ["plugins/mcp/a2a-client"], pr_root=root
-            )
+            results, signals = _supplement([], ["plugins/mcp/a2a-client"], pr_root=root)
         self.assertEqual(signals, [])
         self.assertEqual(len(results), 1)
         self.assertIsNone(results[0]["grade"])
@@ -323,9 +428,7 @@ class ScopeTests(unittest.TestCase):
                     validator_results.append(
                         {"path": str(skill), "score": 95, "grade": "A", "errors": 0, "warnings": 0}
                     )
-                results, signals = _supplement(
-                    validator_results, ["plugins/mcp/name-contract"], pr_root=root
-                )
+                results, signals = _supplement(validator_results, ["plugins/mcp/name-contract"], pr_root=root)
             self.assertTrue(any("non-empty kebab-case" in signal for signal in signals))
 
     def test_mcp_marketplace_required_fields_fail_closed(self) -> None:
@@ -345,11 +448,7 @@ class ScopeTests(unittest.TestCase):
                 del config[field]
                 errors = _SCOPE._validate_mcp_servers({"server": config}, "test MCP")
                 self.assertTrue(any(field in error for error in errors), errors)
-        self.assertTrue(
-            _SCOPE._validate_mcp_servers(
-                {"Bad Name": canonical}, "test MCP"
-            )
-        )
+        self.assertTrue(_SCOPE._validate_mcp_servers({"Bad Name": canonical}, "test MCP"))
         invalid_version = dict(canonical, version="1.0")
         self.assertTrue(
             any(
@@ -365,9 +464,7 @@ class ScopeTests(unittest.TestCase):
             ({"when_to_use": "legacy"}, "deprecated"),
         ):
             with self.subTest(mutation=mutation):
-                errors = _SCOPE._validate_mcp_servers(
-                    {"server": dict(canonical, **mutation)}, "test MCP"
-                )
+                errors = _SCOPE._validate_mcp_servers({"server": dict(canonical, **mutation)}, "test MCP")
                 self.assertTrue(any(expected in error for error in errors), errors)
 
     def test_invalid_manifest_version_type_fails_closed(self) -> None:
@@ -375,9 +472,7 @@ class ScopeTests(unittest.TestCase):
             root = Path(tmp)
             plugin = root / "plugins/mcp/broken-version"
             _manifest(plugin, {"name": "broken-version", "version": 7})
-            results, signals = _supplement(
-                [], ["plugins/mcp/broken-version"], pr_root=root
-            )
+            results, signals = _supplement([], ["plugins/mcp/broken-version"], pr_root=root)
         self.assertEqual(results, [])
         self.assertTrue(any("Field 'version' must be string" in signal for signal in signals))
 
@@ -385,24 +480,25 @@ class ScopeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             plugin = root / "plugins/mcp/broken-inline"
-            _manifest(plugin, {
-                "name": "broken-inline",
-                "mcpServers": {
-                    "remote": {
-                        "name": "remote",
-                        "type": "http",
-                        "command": "node",
-                        "args": [],
-                        "env": {},
-                        "description": "Remote MCP server",
-                        "version": "1.0.0",
-                        "enabled": True,
-                    }
+            _manifest(
+                plugin,
+                {
+                    "name": "broken-inline",
+                    "mcpServers": {
+                        "remote": {
+                            "name": "remote",
+                            "type": "http",
+                            "command": "node",
+                            "args": [],
+                            "env": {},
+                            "description": "Remote MCP server",
+                            "version": "1.0.0",
+                            "enabled": True,
+                        }
+                    },
                 },
-            })
-            results, signals = _supplement(
-                [], ["plugins/mcp/broken-inline"], pr_root=root
             )
+            results, signals = _supplement([], ["plugins/mcp/broken-inline"], pr_root=root)
         self.assertEqual(results, [])
         self.assertTrue(any("requires a non-empty url" in signal for signal in signals))
 
@@ -414,9 +510,7 @@ class ScopeTests(unittest.TestCase):
             hooks = plugin / "hooks/hooks.json"
             hooks.parent.mkdir()
             hooks.write_text(json.dumps({"hooks": {"PreToolUse": []}}))
-            results, signals = _supplement(
-                [], ["plugins/mcp/broken-hooks"], pr_root=root
-            )
+            results, signals = _supplement([], ["plugins/mcp/broken-hooks"], pr_root=root)
         self.assertEqual(results, [])
         self.assertTrue(any("must contain a non-empty array" in signal for signal in signals))
 
@@ -430,9 +524,7 @@ class ScopeTests(unittest.TestCase):
                 artifact = plugin / component / "broken.md"
                 artifact.parent.mkdir(parents=True)
                 artifact.write_text("No frontmatter here")
-                results, signals = _supplement(
-                    [], ["plugins/mcp/broken-component"], pr_root=root
-                )
+                results, signals = _supplement([], ["plugins/mcp/broken-component"], pr_root=root)
             self.assertEqual(results, [])
             self.assertTrue(any("No frontmatter found" in signal for signal in signals))
 
@@ -445,9 +537,7 @@ class ScopeTests(unittest.TestCase):
             candidate.parent.mkdir(parents=True)
             candidate.symlink_to(target, target_is_directory=True)
             _catalog(root, ["plugins/mcp/old-plugin"])
-            signals = _SCOPE.validate_deleted_plugins(
-                ["plugins/mcp/old-plugin"], pr_root=root
-            )
+            signals = _SCOPE.validate_deleted_plugins(["plugins/mcp/old-plugin"], pr_root=root)
         self.assertTrue(any("symlink or non-directory" in signal for signal in signals))
         self.assertTrue(any("still has exact catalog source" in signal for signal in signals))
 
@@ -455,13 +545,14 @@ class ScopeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             plugin = root / "plugins/mcp/broken-inline-hooks"
-            _manifest(plugin, {
-                "name": "broken-inline-hooks",
-                "hooks": {"PreToolUse": [{"hooks": "not-an-array"}]},
-            })
-            results, signals = _supplement(
-                [], ["plugins/mcp/broken-inline-hooks"], pr_root=root
+            _manifest(
+                plugin,
+                {
+                    "name": "broken-inline-hooks",
+                    "hooks": {"PreToolUse": [{"hooks": "not-an-array"}]},
+                },
             )
+            results, signals = _supplement([], ["plugins/mcp/broken-inline-hooks"], pr_root=root)
         self.assertEqual(results, [])
         self.assertTrue(any("hooks must be a non-empty array" in signal for signal in signals))
 
@@ -488,9 +579,7 @@ class ScopeTests(unittest.TestCase):
                         target = outside / "hooks.json"
                         target.write_text(json.dumps({"hooks": {}}))
                         (plugin / "hooks").symlink_to(outside, target_is_directory=True)
-                results, signals = _supplement(
-                    [], ["plugins/mcp/symlinked"], pr_root=root
-                )
+                results, signals = _supplement([], ["plugins/mcp/symlinked"], pr_root=root)
                 self.assertEqual(results, [])
                 self.assertTrue(any("no symlink components" in signal for signal in signals))
 
@@ -503,11 +592,13 @@ class ScopeTests(unittest.TestCase):
             skill.write_text("---\nname: check\n---\n")
             (plugin / ".claude-plugin").symlink_to(root / "missing", target_is_directory=True)
             validator_result = {
-                "path": str(skill), "score": 95, "grade": "A", "errors": 0, "warnings": 0,
+                "path": str(skill),
+                "score": 95,
+                "grade": "A",
+                "errors": 0,
+                "warnings": 0,
             }
-            results, signals = _supplement(
-                [validator_result], ["plugins/security/symlinked"], pr_root=root
-            )
+            results, signals = _supplement([validator_result], ["plugins/security/symlinked"], pr_root=root)
         self.assertEqual(len(results), 1)
         self.assertTrue(any(".claude-plugin" in signal and "no symlink" in signal for signal in signals))
 
@@ -520,11 +611,13 @@ class ScopeTests(unittest.TestCase):
             skill.parent.mkdir(parents=True)
             skill.write_text("---\nname: check\ndescription: example\n---\n")
             validator_result = {
-                "path": str(skill), "score": 95, "grade": "A", "errors": 0, "warnings": 0,
+                "path": str(skill),
+                "score": 95,
+                "grade": "A",
+                "errors": 0,
+                "warnings": 0,
             }
-            results, signals = _supplement(
-                [validator_result], ["plugins/security/example"], pr_root=root
-            )
+            results, signals = _supplement([validator_result], ["plugins/security/example"], pr_root=root)
         self.assertEqual(len(results), 1)
         self.assertTrue(any("Field 'version' must be string" in signal for signal in signals))
 
@@ -536,13 +629,11 @@ class ScopeTests(unittest.TestCase):
             skill = plugin / "skills/check/SKILL.md"
             skill.parent.mkdir(parents=True)
             skill.write_text("---\nname: check\n---\n")
-            results, signals = _supplement(
-                [], ["plugins/security/example"], pr_root=root
-            )
+            results, signals = _supplement([], ["plugins/security/example"], pr_root=root)
         self.assertEqual(results, [])
-        self.assertEqual(signals, [
-            "prescreen-internal-error: validator produced no result for plugins/security/example"
-        ])
+        self.assertEqual(
+            signals, ["prescreen-internal-error: validator produced no result for plugins/security/example"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fixes PR prescreen scoping for skill-less MCP plugins and category-level support files.
- Derives plugin authority from exact catalog sources and real PR/base trees instead of path truncation or basename matching.
- Runs immutable base-authored validators with the PR checkout treated as data only.
- Fails closed on partial deletion, cross-root rename, symlink/non-regular roots, malformed manifests/MCP/hooks/agents/commands, validator failures, incomplete pagination, and incorrect manual-dispatch SHAs.
- Emits a neutral structural component for a valid skill-less plugin; it never fabricates an A grade or score.

## Security rationale

PR #1412 exposed that `plugins/mcp/destructive-policies.json` was treated as a plugin root while the real skill-less A2A plugin received no validator row. Adversarial review then found deletion, rename, catalog-spoof, symlink, component-validation, pagination, and trust-boundary bypasses. This isolated repair closes that complete matrix before A2A is rebased.

## Verification

- Exact reviewed source commit: `3ee29d4ecd82fae8e52782fc485bf8ee3e6e0c9e`.
- Cherry-picked head: `6a37f913a965078b37cfb0d60f379a056a896e30`; all five changed blobs are byte-identical to the approved source commit.
- Independent adversarial review: **APPROVE**.
- Prescreen regression suite: 44/44 on the isolated branch; repair lane reported 56/56 including 28 hostile scope cases.
- `actionlint`, Prettier, Python compilation, diff checks, commit hooks, and TruffleHog pass.
- Exact A2A simulation produces the expected hard block for its legacy `transport` field; A2A will change to canonical `type` only after this governance PR lands.

Tracked by Beads `claude-0ffs.1`.
