### PR TITLE
fix(marketplace-site): fail closed on partial stats refresh

### DIFF
--- a/.github/workflows/update-npm-stats.yml
+++ b/.github/workflows/update-npm-stats.yml
@@ -56,6 +56,20 @@ jobs:
         with:
           node-version: 20
 
+      # fetch-npm-stats imports the repository-pinned Prettier dependency to
+      # keep its JSON and README outputs consistent. The generator fails closed
+      # if formatting cannot run, so prepare that dependency before spending
+      # ~30 minutes on the rate-limited npm crawl. --ignore-scripts avoids
+      # executing package lifecycle hooks in this data-only automation lane.
+      - name: Enable repository-pinned pnpm
+        run: corepack enable
+
+      - name: Install stats generator dependencies
+        run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo" --ignore-scripts
+
+      - name: Verify stats publication contract
+        run: node --test scripts/fetch-npm-stats.test.mjs
+
       # E1.10 advisory pass BEFORE fetching: reports how stale main's tracked
       # copies are (surfaces automation-PR merge lag) without failing the run
       # that is about to fix it.

--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 347,
         "raw_tracked_plugin_skill_files": 3075,
-        "tracked_files": 23771
+        "tracked_files": 23773
       }
     },
     "2": {
@@ -1919,7 +1919,7 @@
         "invalid_patterns": 0,
         "invisible_files": 23,
         "target_invisible_files": 0,
-        "tracked_files": 23771
+        "tracked_files": 23773
       }
     },
     "47": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate:published-count-cohorts": "node --test scripts/check-published-count-cohorts.test.mjs && node scripts/check-published-count-cohorts.mjs",
     "validate:jrig-db-boundary": "node --test scripts/check-jrig-db-boundary.test.mjs && node scripts/check-jrig-db-boundary.mjs",
     "validate:changelog-coverage": "node --test scripts/check-changelog-coverage.test.mjs && node scripts/check-changelog-coverage.mjs",
-    "validate:stats-freshness": "node --test scripts/check-stats-freshness.test.mjs && node scripts/check-stats-freshness.mjs --report",
+    "validate:stats-freshness": "node --test scripts/check-stats-freshness.test.mjs scripts/fetch-npm-stats.test.mjs && node scripts/check-stats-freshness.mjs --report",
     "validate:sources-lock-parity": "node --test scripts/check-sources-lock-parity.test.mjs && node scripts/check-sources-lock-parity.mjs",
     "validate:mirror-licenses": "node scripts/check-mirror-licenses.mjs",
     "validate:privileged-action-pins": "node --test scripts/check-privileged-action-pins.test.mjs && node scripts/check-privileged-action-pins.mjs",

--- a/scripts/fetch-npm-stats.mjs
+++ b/scripts/fetch-npm-stats.mjs
@@ -27,8 +27,12 @@
 
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
+import prettier from 'prettier';
+
+const THIS_FILE = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(THIS_FILE), '..');
 const OUT_JSON = join(ROOT, 'marketplace', 'src', 'data', 'npm-stats.json');
 const README = join(ROOT, 'README.md');
 
@@ -299,7 +303,7 @@ function fmt(n) {
   return Number(n || 0).toLocaleString('en-US');
 }
 
-function buildReadmeBlock(agg) {
+export function buildReadmeBlock(agg) {
   const lines = [
     START_SENTINEL,
     '',
@@ -334,8 +338,7 @@ function buildReadmeBlock(agg) {
   return lines.join('\n');
 }
 
-function updateReadme(block) {
-  const readme = readFileSync(README, 'utf-8');
+export function spliceReadmeStats(readme, block) {
   const s = readme.indexOf(START_SENTINEL);
   const e = readme.indexOf(END_SENTINEL);
   if (s === -1 || e === -1) {
@@ -344,6 +347,24 @@ function updateReadme(block) {
     );
   }
   return readme.slice(0, s) + block + readme.slice(e + END_SENTINEL.length);
+}
+
+export async function prepareStatsArtifacts(
+  agg,
+  {
+    readme = readFileSync(README, 'utf-8'),
+    formatter = prettier,
+    prettierOptions = {},
+    filepath = README,
+  } = {},
+) {
+  const jsonOutput = JSON.stringify(agg, null, 2) + '\n';
+  const spliced = spliceReadmeStats(readme, buildReadmeBlock(agg));
+  const readmeOutput = await formatter.format(spliced, {
+    ...prettierOptions,
+    filepath,
+  });
+  return { jsonOutput, readmeOutput };
 }
 
 async function main() {
@@ -434,27 +455,26 @@ async function main() {
   if (dryRun) {
     console.log('\n(--dry-run: no files written)');
   } else {
-    // 5. Write JSON + README block
-    writeFileSync(OUT_JSON, JSON.stringify(agg, null, 2) + '\n');
+    // 5. Prepare BOTH generated artifacts before writing either one. Prettier
+    // is a required dependency, not an optional enhancement: publishing fresh
+    // JSON while silently retaining a stale README makes the public surfaces
+    // contradict one another. Any import/config/format failure reaches the
+    // top-level catch and turns the automation run red.
+    const options = (await prettier.resolveConfig(README)) || {};
+    const currentReadme = readFileSync(README, 'utf-8');
+    const { jsonOutput, readmeOutput: updatedReadme } = await prepareStatsArtifacts(agg, {
+      readme: currentReadme,
+      prettierOptions: options,
+    });
+
+    writeFileSync(OUT_JSON, jsonOutput);
     console.log(`\nWrote ${OUT_JSON}`);
 
-    try {
-      // Pipe the spliced README through the repo's Prettier config so the
-      // daily bot commit satisfies format-check and the TOC byte-compare —
-      // the same contract generate-readme-toc.mjs honors (issue #657 class).
-      const prettier = (await import('prettier')).default;
-      const spliced = updateReadme(buildReadmeBlock(agg));
-      const options = (await prettier.resolveConfig(README)) || {};
-      const updated = await prettier.format(spliced, { ...options, filepath: README });
-      const current = readFileSync(README, 'utf-8');
-      if (updated !== current) {
-        writeFileSync(README, updated);
-        console.log('Updated README NPM-STATS block');
-      } else {
-        console.log('README NPM-STATS block already current');
-      }
-    } catch (err) {
-      console.warn(`⚠ README update skipped: ${err.message}`);
+    if (updatedReadme !== currentReadme) {
+      writeFileSync(README, updatedReadme);
+      console.log('Updated README NPM-STATS block');
+    } else {
+      console.log('README NPM-STATS block already current');
     }
   }
 
@@ -469,7 +489,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error('fetch-npm-stats failed:', err);
-  process.exit(1);
-});
+if (process.argv[1] && resolve(process.argv[1]) === THIS_FILE) {
+  main().catch((err) => {
+    console.error('fetch-npm-stats failed:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/fetch-npm-stats.test.mjs
+++ b/scripts/fetch-npm-stats.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import prettier from 'prettier';
+
+import { buildReadmeBlock, prepareStatsArtifacts, spliceReadmeStats } from './fetch-npm-stats.mjs';
+
+const SAMPLE = {
+  generatedAt: '2026-09-02T03:47:05.535Z',
+  max_age_hours: 72,
+  publishedCount: 394,
+  establishedCount: 394,
+  candidateCount: 423,
+  totalDay: 641,
+  totalWeek: 3272,
+  totalMonth: 11794,
+  establishedDay: 641,
+  establishedWeek: 3272,
+  establishedMonth: 11794,
+  top: [
+    {
+      name: '@intentsolutionsio/openrouter-pack',
+      status: 'published',
+      lastDay: 21,
+      lastWeek: 100,
+      lastMonth: 400,
+      createdAt: 1,
+      latestVersion: '1.0.0',
+    },
+  ],
+  telemetry: {
+    candidates: 423,
+    probed: 423,
+    published: 394,
+    unpublished: 27,
+    foreign: 2,
+    rateLimited: 0,
+    errors: 0,
+  },
+};
+
+const README_FIXTURE = [
+  '# Marketplace',
+  '',
+  '<!-- NPM-STATS:START — do not edit; daily cron updates this -->',
+  'stale stats',
+  '<!-- NPM-STATS:END -->',
+  '',
+  'Footer',
+  '',
+].join('\n');
+
+test('prepared JSON and README describe the same exact snapshot', async () => {
+  const { jsonOutput, readmeOutput } = await prepareStatsArtifacts(SAMPLE, {
+    readme: README_FIXTURE,
+    prettierOptions: { proseWrap: 'preserve' },
+    filepath: 'README.md',
+  });
+
+  assert.deepEqual(JSON.parse(jsonOutput), SAMPLE);
+  assert.match(readmeOutput, /Across \*\*394 published packages\*\*/);
+  assert.match(readmeOutput, /\| Last 24 hours\s+\|\s+641 \|\s+641 \|/);
+  assert.match(readmeOutput, /\| Last 7 days\s+\|\s+3,272 \|\s+3,272 \|/);
+  assert.match(readmeOutput, /\| Last 30 days\s+\|\s+11,794 \|\s+11,794 \|/);
+  assert.match(readmeOutput, /Last refreshed 2026-09-02T03:47:05\.535Z/);
+  assert.doesNotMatch(readmeOutput, /stale stats/);
+});
+
+test('missing README sentinels fail instead of producing a partial snapshot', async () => {
+  await assert.rejects(
+    prepareStatsArtifacts(SAMPLE, { readme: '# No generated block\n' }),
+    /missing NPM-STATS sentinels/,
+  );
+});
+
+test('formatter failures propagate instead of silently skipping the README', async () => {
+  const failingFormatter = {
+    async format() {
+      throw new Error('formatter unavailable');
+    },
+  };
+
+  await assert.rejects(
+    prepareStatsArtifacts(SAMPLE, {
+      readme: README_FIXTURE,
+      formatter: failingFormatter,
+    }),
+    /formatter unavailable/,
+  );
+});
+
+test('the rendered block can only replace its bounded README region', () => {
+  const block = buildReadmeBlock(SAMPLE);
+  const updated = spliceReadmeStats(README_FIXTURE, block);
+
+  assert.ok(updated.startsWith('# Marketplace\n\n'));
+  assert.ok(updated.endsWith('\n\nFooter\n'));
+});

--- a/tests/ci/test_npm_stats_refresh_contract.py
+++ b/tests/ci/test_npm_stats_refresh_contract.py
@@ -1,0 +1,40 @@
+"""Regression checks for the daily npm-stats publication contract.
+
+The generator owns two public surfaces: ``npm-stats.json`` and the README
+``NPM-STATS`` block. A 2026-09-02 run updated the JSON but caught a missing
+Prettier import and silently skipped the README, producing a green workflow and
+a self-contradictory PR. These checks pin dependency setup, fail-closed error
+handling, and prepare-before-write ordering.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "update-npm-stats.yml"
+GENERATOR = REPO_ROOT / "scripts" / "fetch-npm-stats.mjs"
+
+
+def test_workflow_installs_generator_dependencies_before_fetching() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    corepack = workflow.index("run: corepack enable")
+    install = workflow.index(
+        'run: pnpm install --frozen-lockfile --filter "claude-code-plugins-monorepo" --ignore-scripts'
+    )
+    fetch = workflow.index("run: node scripts/fetch-npm-stats.mjs")
+
+    assert corepack < install < fetch
+
+
+def test_readme_formatting_is_required_and_precedes_artifact_writes() -> None:
+    generator = GENERATOR.read_text(encoding="utf-8")
+
+    assert "import prettier from 'prettier';" in generator
+    assert "README update skipped" not in generator
+
+    format_readme = generator.index("const readmeOutput = await formatter.format")
+    write_json = generator.index("writeFileSync(OUT_JSON, jsonOutput)")
+    write_readme = generator.index("writeFileSync(README, updatedReadme)")
+
+    assert format_readme < write_json < write_readme


### PR DESCRIPTION
## What changed

- installs the repository-pinned Prettier dependency before the daily npm crawl
- prepares fresh JSON and formatted README output before writing either artifact
- propagates formatter, config, and sentinel failures instead of warning and continuing
- behavior-tests exact JSON-to-README parity and failure paths
- regenerates the canonical Epic 1 scorecard for the two added test files

## Why

PR #1414 exposed a fail-open path: fresh JSON was committed while the README NPM-STATS block remained stale because Prettier was unavailable. The automation run stayed green and the PR body incorrectly claimed both surfaces were refreshed.

## Verification

- validate:stats-freshness: 11/11 tests plus freshness check
- tests/ci: 49/49
- Epic 1 measurement: 40/40 plus deterministic byte check
- actionlint, ESLint, Prettier, Ruff, strict Unicode, and diff check pass
- independent exact-SHA review: APPROVE db983a4b6e72f6582eb94a13394f1097f79f8fda

Tracks Beads bug claude-0ffs.2. This PR must merge before rerunning and merging #1414.