### PR TITLE
fix(freshie): normalize scanner repository paths

### DIFF
--- a/freshie/scripts/rebuild-inventory.py
+++ b/freshie/scripts/rebuild-inventory.py
@@ -169,11 +169,22 @@ def file_size(path: Path) -> int:
 
 
 def rel(path: Path) -> str:
-    """Return repo-relative string path."""
+    """Return a canonical repository-relative path or refuse the input.
+
+    Freshie rows are durable and publicly exported to Dolt, so recording an
+    absolute checkout path would make identical trees differ by machine or
+    worktree name.  Resolving both sides also prevents a symlink inside the
+    checkout from smuggling an outside path into the inventory.
+    """
+    resolved_root = REPO_ROOT.resolve()
+    resolved_path = path.resolve()
     try:
-        return str(path.relative_to(REPO_ROOT))
-    except ValueError:
-        return str(path)
+        return resolved_path.relative_to(resolved_root).as_posix()
+    except ValueError as exc:
+        raise ValueError(
+            f"refusing path outside repository root: {resolved_path} "
+            f"(repository root: {resolved_root})"
+        ) from exc
 
 
 def git_commit_hash() -> str:
@@ -1324,8 +1335,11 @@ def scan_commands_agents(
         lines = text.splitlines()
         wc = word_count(text)
 
-        # Derive pack and plugin names from path
-        parts = cmd_path.parts
+        # Derive every durable identity from the repository-relative path.
+        # Absolute Path.parts includes the checkout prefix and previously
+        # leaked it into command_files.plugin_path.
+        command_rel = Path(rel(cmd_path))
+        parts = command_rel.parts
         try:
             plugins_idx = parts.index("plugins")
             pack = parts[plugins_idx + 1]
@@ -1334,7 +1348,7 @@ def scan_commands_agents(
             # plugin is the dir that contains the commands/ subdir
             cmd_idx = next(i for i, p in enumerate(parts) if p == "commands")
             plugin = parts[cmd_idx - 1]
-            plugin_path = str(Path(*parts[:cmd_idx]))
+            plugin_path = Path(*parts[:cmd_idx]).as_posix()
         except (ValueError, StopIteration, IndexError):
             pack = "unknown"
             plugin = "unknown"
@@ -1343,7 +1357,7 @@ def scan_commands_agents(
         cmd_batch.append(
             (
                 run_id,
-                rel(cmd_path),
+                command_rel.as_posix(),
                 plugin_path,
                 pack,
                 plugin,
@@ -1369,7 +1383,8 @@ def scan_commands_agents(
         lines = text.splitlines()
         wc = word_count(text)
 
-        parts = agent_path.parts
+        agent_rel = Path(rel(agent_path))
+        parts = agent_rel.parts
         try:
             plugins_idx = parts.index("plugins")
             pack = parts[plugins_idx + 1]
@@ -1377,7 +1392,7 @@ def scan_commands_agents(
                 pack = parts[plugins_idx + 2]
             agents_idx = next(i for i, p in enumerate(parts) if p == "agents")
             plugin = parts[agents_idx - 1]
-            plugin_path = str(Path(*parts[:agents_idx]))
+            plugin_path = Path(*parts[:agents_idx]).as_posix()
         except (ValueError, StopIteration, IndexError):
             pack = "unknown"
             plugin = "unknown"
@@ -1389,7 +1404,7 @@ def scan_commands_agents(
         agent_batch.append(
             (
                 run_id,
-                rel(agent_path),
+                agent_rel.as_posix(),
                 plugin_path,
                 pack,
                 plugin,
@@ -1445,7 +1460,8 @@ DOC_SKIP_PATTERNS = frozenset({"node_modules", "dist", "__pycache__", ".git", "f
 def infer_doc_type(path: Path) -> tuple[str, str, str]:
     """Return (doc_type, apparent_subject, subject_type)."""
     name_lower = path.name.lower()
-    parent = path.parent.name
+    relative_path = Path(rel(path))
+    parent = "repository" if relative_path.parent == Path(".") else relative_path.parent.name
 
     if name_lower == "readme.md":
         return "readme", parent, "plugin" if (path.parent.parent / ".claude-plugin").exists() else "directory"

--- a/tests/test_freshie_hermetic_cycle.py
+++ b/tests/test_freshie_hermetic_cycle.py
@@ -57,6 +57,21 @@ class HermeticFreshieCycleTests(unittest.TestCase):
         source = self._graded_fixture_source()
         self.skill.parent.parent.mkdir(parents=True)
         shutil.copytree(source.parent, self.skill.parent)
+        (self.root / "README.md").write_text("# Fixture repository\n", encoding="utf-8")
+        (self.root / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+        command = self.root / "plugins" / "testing" / "example" / "commands" / "check.md"
+        command.parent.mkdir(parents=True)
+        command.write_text(
+            "---\n"
+            "name: fixture-command\n"
+            "description: Exercise portable Freshie paths.\n"
+            "---\n\n"
+            "# Fixture command\n",
+            encoding="utf-8",
+        )
+        agent = self.root / "plugins" / "testing" / "example" / "agents" / "claim-verifier.md"
+        agent.parent.mkdir(parents=True)
+        shutil.copyfile(ROOT / ".claude" / "agents" / "claim-verifier.md", agent)
         self.resolver = Path(self.tmp.name) / "resolver.mjs"
         self.resolver.write_text(
             "#!/usr/bin/env node\n"
@@ -116,6 +131,105 @@ class HermeticFreshieCycleTests(unittest.TestCase):
             time.sleep(0.1)
         self.fail(f"dolt sql-server did not bind port {port}")
 
+    def _portable_inventory_rows(self, db: Path) -> dict[str, list[tuple]]:
+        with sqlite3.connect(db) as conn:
+            return {
+                "commands": conn.execute(
+                    "SELECT path, plugin_path, pack_name, plugin_name "
+                    "FROM command_files WHERE run_id=1 ORDER BY path"
+                ).fetchall(),
+                "agents": conn.execute(
+                    "SELECT path, plugin_path, pack_name, plugin_name "
+                    "FROM agent_files WHERE run_id=1 ORDER BY path"
+                ).fetchall(),
+                "root_docs": conn.execute(
+                    "SELECT path, doc_type, apparent_subject, subject_type "
+                    "FROM docs WHERE run_id=1 AND path IN ('README.md', 'CHANGELOG.md') "
+                    "ORDER BY path"
+                ).fetchall(),
+            }
+
+    def test_inventory_paths_are_identical_across_differently_named_clean_checkouts(self):
+        first_db = Path(self.tmp.name) / "first.sqlite"
+        second_db = Path(self.tmp.name) / "second.sqlite"
+        second_root = Path(self.tmp.name) / "temporary-retired-product-name-worktree"
+        self._run(["git", "clone", "-q", str(self.root), str(second_root)])
+
+        self._run(
+            [
+                sys.executable,
+                str(REBUILD),
+                "--repo-root",
+                str(self.root),
+                "--db",
+                str(first_db),
+                "--run-id",
+                "1",
+            ]
+        )
+        self._run(
+            [
+                sys.executable,
+                str(REBUILD),
+                "--repo-root",
+                str(second_root),
+                "--db",
+                str(second_db),
+                "--run-id",
+                "1",
+            ]
+        )
+
+        first_rows = self._portable_inventory_rows(first_db)
+        second_rows = self._portable_inventory_rows(second_db)
+        self.assertEqual(first_rows, second_rows)
+        self.assertEqual(
+            first_rows["commands"],
+            [("plugins/testing/example/commands/check.md", "plugins/testing/example", "testing", "example")],
+        )
+        self.assertEqual(
+            first_rows["agents"],
+            [
+                (
+                    "plugins/testing/example/agents/claim-verifier.md",
+                    "plugins/testing/example",
+                    "testing",
+                    "example",
+                )
+            ],
+        )
+        self.assertEqual(
+            first_rows["root_docs"],
+            [
+                ("CHANGELOG.md", "changelog", "repository", "plugin"),
+                ("README.md", "readme", "repository", "directory"),
+            ],
+        )
+        serialized = json.dumps(first_rows) + json.dumps(second_rows)
+        self.assertNotIn(str(self.root), serialized)
+        self.assertNotIn(str(second_root), serialized)
+
+    def test_scanner_refuses_a_symlinked_file_outside_the_repository(self):
+        outside = Path(self.tmp.name) / "outside-command.md"
+        outside.write_text("# Outside\n", encoding="utf-8")
+        leaked = self.root / "plugins" / "testing" / "example" / "commands" / "outside.md"
+        leaked.symlink_to(outside)
+
+        refusal = self._run(
+            [
+                sys.executable,
+                str(REBUILD),
+                "--repo-root",
+                str(self.root),
+                "--db",
+                str(Path(self.tmp.name) / "refused.sqlite"),
+                "--run-id",
+                "1",
+            ],
+            expected=1,
+        )
+        self.assertIn("refusing path outside repository root", refusal.stderr)
+
     def test_full_cycle_uses_only_scratch_state_and_refuses_live_server(self):
         self._run([sys.executable, str(REBUILD), "--repo-root", str(self.root), "--db", str(self.db), "--run-id", "1"])
         self._run(
@@ -152,6 +266,53 @@ class HermeticFreshieCycleTests(unittest.TestCase):
                 "--no-push",
             ]
         )
+
+        command_export = self._run(
+            [
+                "dolt",
+                "sql",
+                "-r",
+                "csv",
+                "-q",
+                "SELECT path, plugin_path FROM command_files WHERE run_id=1",
+            ],
+            cwd=self.dolt_dir,
+        ).stdout
+        agent_export = self._run(
+            [
+                "dolt",
+                "sql",
+                "-r",
+                "csv",
+                "-q",
+                "SELECT path, plugin_path FROM agent_files WHERE run_id=1",
+            ],
+            cwd=self.dolt_dir,
+        ).stdout
+        root_doc_export = self._run(
+            [
+                "dolt",
+                "sql",
+                "-r",
+                "csv",
+                "-q",
+                "SELECT path, apparent_subject FROM docs "
+                "WHERE run_id=1 AND path IN ('README.md', 'CHANGELOG.md') ORDER BY path",
+            ],
+            cwd=self.dolt_dir,
+        ).stdout
+        exported = command_export + agent_export + root_doc_export
+        self.assertIn(
+            "plugins/testing/example/commands/check.md,plugins/testing/example",
+            command_export,
+        )
+        self.assertIn(
+            "plugins/testing/example/agents/claim-verifier.md,plugins/testing/example",
+            agent_export,
+        )
+        self.assertIn("README.md,repository", root_doc_export)
+        self.assertIn("CHANGELOG.md,repository", root_doc_export)
+        self.assertNotIn(str(self.root), exported)
 
         self.assertTrue((self.out / "grades.csv").is_file())
         self.assertTrue((self.out / "reports" / "run-delta-1.json").is_file())


### PR DESCRIPTION
## Summary

- normalize Freshie scanner identities to resolved repository-relative paths
- derive command/agent plugin paths without leaking checkout prefixes
- make root README/CHANGELOG subjects stable across worktrees
- fail closed when a scanned path resolves outside the repository

## Evidence

- `python3 -m unittest tests.test_freshie_hermetic_cycle -v` — 3/3
- `python3 -m unittest tests.test_dolt_sync -v` — 60/60
- `python3 -m py_compile freshie/scripts/rebuild-inventory.py tests/test_freshie_hermetic_cycle.py`
- `git diff --check e486a1c1db..HEAD`

The hermetic test runs two differently named clean checkouts and a scratch SQLite-to-Dolt cycle. No real Freshie run, tracked export, Dolt tag, or production data is changed.

Bead: `claude-5e0c.36`
