### PR TITLE
fix(docs-governance): refresh scorecard after blog publish

### DIFF
--- a/000-docs/742-RA-DATA-epic-1-scorecard.json
+++ b/000-docs/742-RA-DATA-epic-1-scorecard.json
@@ -42,7 +42,7 @@
       "values": {
         "plugin_agent_files": 352,
         "raw_tracked_plugin_skill_files": 3031,
-        "tracked_files": 23948
+        "tracked_files": 23949
       }
     },
     "2": {
@@ -1946,7 +1946,7 @@
         "invalid_patterns": 0,
         "invisible_files": 23,
         "target_invisible_files": 0,
-        "tracked_files": 23948
+        "tracked_files": 23949
       }
     },
     "47": {


### PR DESCRIPTION
## Summary

- repairs the Epic-1 scorecard drift introduced when direct main commit `fb5a4e2517ac28b62906e89db868a5407a522672` added one tracked blog file
- regenerates the scorecard through the canonical `pnpm run measure:e1` producer
- changes only the two governed `tracked_files` values from 23,948 to 23,949
- leaves the published blog content unchanged

Beads: `claude-vggd.2.1`

Exact candidate head: `96a06a139ade18c93bb20a17038be271c1f42d61`

## Evidence

Pre-repair on current main:

```text
epic-1-measurement: DRIFT (000-docs/742-RA-DATA-epic-1-scorecard.json)
```

Post-repair:

- scorecard regression suite: 41/41 pass
- exact staged-byte scorecard check: pass
- audit-harness hash verification: pass
- Prettier and `git diff --check`: pass
- frozen install uses audit-harness 1.4.0 and patched js-yaml 4.3.2
- pre-commit checks: pass

The net diff is one generated file, 2 insertions and 2 deletions. No branch-protection bypass, release, publication, or #1452 merge is included. Waiting for exact-head CI and reviewer reconciliation.