### PR TITLE
fix(ci): clean temporary fixture trees

### DIFF
--- a/scripts/generate-saas-tutorial-lattice.test.mjs
+++ b/scripts/generate-saas-tutorial-lattice.test.mjs
@@ -22,8 +22,9 @@ function skill(name, body = 'Operational guidance.') {
   return `---\nname: ${name}\ndescription: Fixture skill for deterministic audit testing.\n---\n\n# ${name}\n\n${body}\n`;
 }
 
-function fixture() {
+function fixture(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'saas-lattice-'));
+  t.after(() => fs.rmSync(root, { force: true, recursive: true }));
   execFileSync('git', ['init', '-q'], { cwd: root });
   const plugins = [
     {
@@ -129,8 +130,8 @@ test('matches only explicit pack-prefix and terminal-family pairs', () => {
   assert.equal(tutorialFamily('langchain-py-pack', 'langchain-otel-observability'), null);
 });
 
-test('builds a catalog-scoped denominator and deterministic queue', () => {
-  const root = fixture();
+test('builds a catalog-scoped denominator and deterministic queue', (t) => {
+  const root = fixture(t);
   const report = buildReport({ root });
   assert.deepEqual(report.summary, {
     active_saas_packs: 2,
@@ -157,8 +158,8 @@ test('builds a catalog-scoped denominator and deterministic queue', () => {
   assert.match(renderMarkdown(report), /matching skill name proves structural repetition only/);
 });
 
-test('refuses a filesystem skill absent from the canonical corpus', () => {
-  const root = fixture();
+test('refuses a filesystem skill absent from the canonical corpus', (t) => {
+  const root = fixture(t);
   write(
     root,
     'plugins/saas-packs/alpha-pack/skills/alpha-debug-bundle/SKILL.md',
@@ -170,8 +171,8 @@ test('refuses a filesystem skill absent from the canonical corpus', () => {
   );
 });
 
-test('refuses catalog component counts that disagree with the canonical corpus', () => {
-  const root = fixture();
+test('refuses catalog component counts that disagree with the canonical corpus', (t) => {
+  const root = fixture(t);
   const catalogPath = path.join(root, '.claude-plugin/marketplace.extended.json');
   const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
   catalog.plugins[0].components.skills = 99;
@@ -179,8 +180,8 @@ test('refuses catalog component counts that disagree with the canonical corpus',
   assert.throws(() => buildReport({ root }), /alpha-pack declares 99 skills but resolves 2/);
 });
 
-test('pack and candidate hashes cover complete tracked subtrees without cross-pack drift', () => {
-  const root = fixture();
+test('pack and candidate hashes cover complete tracked subtrees without cross-pack drift', (t) => {
+  const root = fixture(t);
   const before = buildReport({ root });
   write(
     root,
@@ -208,8 +209,8 @@ test('pack and candidate hashes cover complete tracked subtrees without cross-pa
   assert.equal(candidateAlpha.candidate_set_sha256, noncandidateAlpha.candidate_set_sha256);
 });
 
-test('refuses public names that differ from their skill directory', () => {
-  const root = fixture();
+test('refuses public names that differ from their skill directory', (t) => {
+  const root = fixture(t);
   write(
     root,
     'plugins/saas-packs/alpha-pack/skills/alpha-hello-world/SKILL.md',
@@ -218,8 +219,8 @@ test('refuses public names that differ from their skill directory', () => {
   assert.throws(() => buildReport({ root }), /public name.*differs from directory/);
 });
 
-test('refuses a nested mirror boundary hidden below a first-party pack', () => {
-  const root = fixture();
+test('refuses a nested mirror boundary hidden below a first-party pack', (t) => {
+  const root = fixture(t);
   write(
     root,
     'plugins/saas-packs/alpha-pack/skills/alpha-hello-world/.source.json',
@@ -228,8 +229,8 @@ test('refuses a nested mirror boundary hidden below a first-party pack', () => {
   assert.throws(() => buildReport({ root }), /crosses a nested provenance boundary/);
 });
 
-test('refuses a tracked pack input replaced by a worktree symlink', () => {
-  const root = fixture();
+test('refuses a tracked pack input replaced by a worktree symlink', (t) => {
+  const root = fixture(t);
   const reference = path.join(
     root,
     'plugins/saas-packs/alpha-pack/skills/alpha-real-operator/references/operator-guide.md',
@@ -241,14 +242,14 @@ test('refuses a tracked pack input replaced by a worktree symlink', () => {
   assert.throws(() => buildReport({ root }), /tracked pack input crosses a symlink/);
 });
 
-test('refuses curated rows whose indexed mirror is missing from the worktree', () => {
-  const root = fixture();
+test('refuses curated rows whose indexed mirror is missing from the worktree', (t) => {
+  const root = fixture(t);
   fs.unlinkSync(path.join(root, 'skills/.curated/alpha-hello-world/SKILL.md'));
   assert.throws(() => buildReport({ root }), /mirror is unreadable/);
 });
 
-test('refuses a curated row whose canonical source is absent', () => {
-  const root = fixture();
+test('refuses a curated row whose canonical source is absent', (t) => {
+  const root = fixture(t);
   const manifestPath = path.join(root, 'skills/.curated/MANIFEST.json');
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   manifest.skills[0].source_path = 'plugins/saas-packs/alpha-pack/skills/does-not-exist';
@@ -256,8 +257,8 @@ test('refuses a curated row whose canonical source is absent', () => {
   assert.throws(() => buildReport({ root }), /has no tracked canonical source/);
 });
 
-test('refuses duplicate and traversal-shaped curated names', () => {
-  const root = fixture();
+test('refuses duplicate and traversal-shaped curated names', (t) => {
+  const root = fixture(t);
   const manifestPath = path.join(root, 'skills/.curated/MANIFEST.json');
   const duplicate = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   duplicate.count = 2;
@@ -280,8 +281,8 @@ test('refuses duplicate and traversal-shaped curated names', () => {
   assert.throws(() => buildReport({ root }), /curated manifest membership|invalid or duplicate/);
 });
 
-test('confines output paths and refuses output symlinks', () => {
-  const root = fixture();
+test('confines output paths and refuses output symlinks', (t) => {
+  const root = fixture(t);
   fs.mkdirSync(path.join(root, 'freshie'), { recursive: true });
   fs.mkdirSync(path.join(root, '000-docs'), { recursive: true });
   assert.throws(
@@ -297,8 +298,8 @@ test('confines output paths and refuses output symlinks', () => {
   );
 });
 
-test('check mode rejects input and staged-output divergence', () => {
-  const root = fixture();
+test('check mode rejects input and staged-output divergence', (t) => {
+  const root = fixture(t);
   fs.mkdirSync(path.join(root, 'freshie'), { recursive: true });
   fs.mkdirSync(path.join(root, '000-docs'), { recursive: true });
   main(['--root', root]);
@@ -315,8 +316,8 @@ test('check mode rejects input and staged-output divergence', () => {
   assert.throws(() => main(['--root', root, '--check']), /generated content drift/);
 });
 
-test('check mode refuses an input mutation after its initial parity check', () => {
-  const root = fixture();
+test('check mode refuses an input mutation after its initial parity check', (t) => {
+  const root = fixture(t);
   fs.mkdirSync(path.join(root, 'freshie'), { recursive: true });
   fs.mkdirSync(path.join(root, '000-docs'), { recursive: true });
   main(['--root', root]);

--- a/scripts/measure-epic-1-scorecard.test.mjs
+++ b/scripts/measure-epic-1-scorecard.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
@@ -32,8 +32,9 @@ function canonicalJson(value) {
   return JSON.stringify(value);
 }
 
-function fixture() {
+function fixture(t) {
   const root = mkdtempSync(join(tmpdir(), 'epic-1-scorecard-'));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
   const doltCommit = 'a'.repeat(32);
   const gradesCsv = 'skill_path,grade,score\none,A,90\ntwo,B,80\n';
   const gradesHash = createHash('sha256').update(gradesCsv).digest('hex');
@@ -238,8 +239,8 @@ function input(fixtureValue) {
   };
 }
 
-test('emits the exact extended numbered row set in deterministic order and shape', () => {
-  const rows = buildExtendedScorecardRows(input(fixture()));
+test('emits the exact extended numbered row set in deterministic order and shape', (t) => {
+  const rows = buildExtendedScorecardRows(input(fixture(t)));
   assert.deepEqual(Object.keys(rows).map(Number), EXPECTED_ROWS);
   for (const number of EXPECTED_ROWS) {
     assert.deepEqual(Object.keys(rows[number]).slice(0, 6), [
@@ -252,13 +253,13 @@ test('emits the exact extended numbered row set in deterministic order and shape
     ]);
     assert.equal(rows[number].reproduce, `pnpm run measure:e1 --row=${number} --stdout`);
   }
-  const again = buildExtendedScorecardRows(input(fixture()));
+  const again = buildExtendedScorecardRows(input(fixture(t)));
   const firstWithoutRootSpecificData = JSON.stringify(rows);
   assert.equal(JSON.stringify(again), firstWithoutRootSpecificData);
 });
 
-test('discovers additional generated artifacts and README count writers dynamically', () => {
-  const base = fixture();
+test('discovers additional generated artifacts and README count writers dynamically', (t) => {
+  const base = fixture(t);
   let rows = buildExtendedScorecardRows(input(base));
   assert.deepEqual(
     rows[22].values.artifacts.map((entry) => entry.path),
@@ -284,8 +285,8 @@ test('discovers additional generated artifacts and README count writers dynamica
   ]);
 });
 
-test('requires call-bound production evidence and excludes measurement instrumentation', () => {
-  const base = fixture();
+test('requires call-bound production evidence and excludes measurement instrumentation', (t) => {
+  const base = fixture(t);
   put(
     base.root,
     'scripts/measure-epic-1-scorecard.mjs',
@@ -322,8 +323,8 @@ test('requires call-bound production evidence and excludes measurement instrumen
   assert.deepEqual(rows[25].values.writers, ['scripts/readme-metrics.mjs']);
 });
 
-test('writer discovery matches exact basenames instead of catalog suffixes', () => {
-  const base = fixture();
+test('writer discovery matches exact basenames instead of catalog suffixes', (t) => {
+  const base = fixture(t);
   put(base.root, 'marketplace/src/data/catalog.json', '{}');
   put(base.root, 'marketplace/src/data/skills-catalog.json', '{}');
   put(
@@ -348,8 +349,8 @@ test('writer discovery matches exact basenames instead of catalog suffixes', () 
   );
 });
 
-test('counts only producer-integrated workflow checks as artifact drift gates', () => {
-  const base = fixture();
+test('counts only producer-integrated workflow checks as artifact drift gates', (t) => {
+  const base = fixture(t);
   put(
     base.root,
     'scripts/consumer-check.mjs',
@@ -385,8 +386,8 @@ test('counts only producer-integrated workflow checks as artifact drift gates', 
   assert.equal(row.status, 'measured');
 });
 
-test('normalizes absolute validator paths into the tracked Git cohort', () => {
-  const base = fixture();
+test('normalizes absolute validator paths into the tracked Git cohort', (t) => {
+  const base = fixture(t);
   const values = input(base);
   values.skillRows = values.skillRows.map((entry) => ({
     ...entry,
@@ -397,8 +398,8 @@ test('normalizes absolute validator paths into the tracked Git cohort', () => {
   assert.deepEqual(row.values.grade_distribution, { A: 1, B: 1, C: 0, D: 0, F: 0 });
 });
 
-test('measures the merged provenance boundary, ci-required needs, and STANDARDS authority table', () => {
-  const base = fixture();
+test('measures the merged provenance boundary, ci-required needs, and STANDARDS authority table', (t) => {
+  const base = fixture(t);
   put(
     base.root,
     '.github/workflows/cli-publish.yml',
@@ -415,8 +416,8 @@ test('measures the merged provenance boundary, ci-required needs, and STANDARDS 
   assert.deepEqual(rows[43].values.authority_links, ['000-docs/canonical.md']);
 });
 
-test('fails closed on malformed ci-required needs', () => {
-  const base = fixture();
+test('fails closed on malformed ci-required needs', (t) => {
+  const base = fixture(t);
   put(
     base.root,
     '.github/workflows/validate-plugins.yml',
@@ -428,8 +429,8 @@ test('fails closed on malformed ci-required needs', () => {
   assert.equal(row.reason_code, 'MALFORMED_CI_REQUIRED_NEEDS');
 });
 
-test('link instrumentation stays excluded while domain instrumentation cannot bypass policy', () => {
-  const base = fixture();
+test('link instrumentation stays excluded while domain instrumentation cannot bypass policy', (t) => {
+  const base = fixture(t);
   put(
     base.root,
     '000-docs/742-RA-DATA-epic-1-scorecard.json',
@@ -467,8 +468,8 @@ test('link instrumentation stays excluded while domain instrumentation cannot by
   assert.equal(rows[21].source.includes('scripts/measure-epic-1-scorecard.test.mjs'), true);
 });
 
-test('unresolved rows fail closed with null values rather than fabricated zeroes', () => {
-  const rows = buildExtendedScorecardRows(input(fixture()));
+test('unresolved rows fail closed with null values rather than fabricated zeroes', (t) => {
+  const rows = buildExtendedScorecardRows(input(fixture(t)));
   for (const number of [7, 8, 9, 15, 16, 17, 18, 19, 23, 29, 49, 50, 51, 60, 61, 62]) {
     assert.equal(rows[number].values, null, `row ${number}`);
     assert.match(rows[number].reason_code, /^[A-Z][A-Z0-9_]+$/);
@@ -476,8 +477,8 @@ test('unresolved rows fail closed with null values rather than fabricated zeroes
   }
 });
 
-test('Epic 9 pin and shadow rows require retained matching boundary evidence', () => {
-  let base = fixture();
+test('Epic 9 pin and shadow rows require retained matching boundary evidence', (t) => {
+  let base = fixture(t);
   let rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[38].status, 'target_met');
   assert.equal(rows[38].values.registry_matches_pins, true);
@@ -487,7 +488,7 @@ test('Epic 9 pin and shadow rows require retained matching boundary evidence', (
   assert.equal(rows[39].status, 'target_met');
   assert.equal(rows[39].values.report.lanes['authoring/v2'].existing_pass_kernel_fail, 0);
 
-  base = fixture();
+  base = fixture(t);
   const evidencePath = '000-docs/810-RA-DATA-epic-9-boundary-evidence.json';
   const evidence = JSON.parse(readFileSync(join(base.root, evidencePath), 'utf8'));
   evidence.package_registry.packages['@intentsolutions/core'].version = '2.0.0';
@@ -502,8 +503,8 @@ test('Epic 9 pin and shadow rows require retained matching boundary evidence', (
   assert.equal(rows[39].status, 'stale_evidence');
 });
 
-test('Freshie exit rows use tracked receipts and fail closed on planted drift', () => {
-  let base = fixture();
+test('Freshie exit rows use tracked receipts and fail closed on planted drift', (t) => {
+  let base = fixture(t);
   let rows = buildExtendedScorecardRows(input(base));
   for (const number of [52, 53, 54, 58]) assert.equal(rows[number].status, 'target_met');
   assert.equal(rows[55].status, 'target_met');
@@ -519,7 +520,7 @@ test('Freshie exit rows use tracked receipts and fail closed on planted drift', 
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[52].status, 'partial');
 
-  base = fixture();
+  base = fixture(t);
   const histogramPath = 'freshie/grade-histogram.json';
   let histogram = JSON.parse(readFileSync(join(base.root, histogramPath), 'utf8'));
   histogram.dolt_commit = 'b'.repeat(32);
@@ -527,19 +528,19 @@ test('Freshie exit rows use tracked receipts and fail closed on planted drift', 
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[53].status, 'partial');
 
-  base = fixture();
+  base = fixture(t);
   histogram = JSON.parse(readFileSync(join(base.root, histogramPath), 'utf8'));
   histogram.grades = { A: 2, B: 0 };
   put(base.root, histogramPath, JSON.stringify(histogram));
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[53].status, 'partial');
 
-  base = fixture();
+  base = fixture(t);
   put(base.root, 'freshie/grades.csv', 'skill_path,grade,score\none,B,90\ntwo,A,80\n');
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[53].status, 'partial');
 
-  base = fixture();
+  base = fixture(t);
   const proofPath = 'freshie/reports/legacy-forge-proofs-demotion.json';
   const proof = JSON.parse(readFileSync(join(base.root, proofPath), 'utf8'));
   proof.records.push({
@@ -554,7 +555,7 @@ test('Freshie exit rows use tracked receipts and fail closed on planted drift', 
   assert.equal(rows[54].status, 'not_reproducible');
   assert.equal(rows[55].status, 'not_reproducible');
 
-  base = fixture();
+  base = fixture(t);
   const workflowPath = '.github/workflows/validate-plugins.yml';
   const workflow = readFileSync(join(base.root, workflowPath), 'utf8').replace(
     '      - test\n',
@@ -564,7 +565,7 @@ test('Freshie exit rows use tracked receipts and fail closed on planted drift', 
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[58].status, 'partial');
 
-  base = fixture();
+  base = fixture(t);
   put(
     base.root,
     'tests/test_freshie_hermetic_cycle.py',
@@ -593,7 +594,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[58].status, 'partial');
 
-  base = fixture();
+  base = fixture(t);
   const skippedTest = readFileSync(
     join(base.root, 'tests/test_freshie_hermetic_cycle.py'),
     'utf8',
@@ -606,7 +607,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.full_cycle, false);
 
-  base = fixture();
+  base = fixture(t);
   const aliasedMutation = readFileSync(
     join(base.root, 'tests/test_freshie_hermetic_cycle.py'),
     'utf8',
@@ -619,7 +620,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.full_cycle, false);
 
-  base = fixture();
+  base = fixture(t);
   const replacedMethod = readFileSync(
     join(base.root, 'tests/test_freshie_hermetic_cycle.py'),
     'utf8',
@@ -632,7 +633,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.full_cycle, false);
 
-  base = fixture();
+  base = fixture(t);
   const lifecycleSkip = readFileSync(
     join(base.root, 'tests/test_freshie_hermetic_cycle.py'),
     'utf8',
@@ -645,7 +646,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.full_cycle, false);
 
-  base = fixture();
+  base = fixture(t);
   const generatorTest = readFileSync(
     join(base.root, 'tests/test_freshie_hermetic_cycle.py'),
     'utf8',
@@ -658,7 +659,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.full_cycle, false);
 
-  base = fixture();
+  base = fixture(t);
   const unsafeWorkflow = readFileSync(join(base.root, workflowPath), 'utf8').replace(
     '"$dolt_extract/dolt-linux-amd64/bin/dolt"',
     '/tmp/unverified/dolt',
@@ -668,7 +669,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.pinned_dolt, false);
 
-  base = fixture();
+  base = fixture(t);
   const aliasedOverwrite = readFileSync(join(base.root, workflowPath), 'utf8').replace(
     '      - name: Run Freshie hermetic publication cycle\n',
     '      - name: Overwrite Dolt through an alias\n        if: matrix.test-type == \'python-tests\'\n        env:\n          DOLT_DEST: /usr/local/bin/dolt\n        run: sudo /usr/bin/install -m 0755 /tmp/unverified/dolt "$DOLT_DEST"\n      - name: Run Freshie hermetic publication cycle\n',
@@ -678,7 +679,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.pinned_dolt, false);
 
-  base = fixture();
+  base = fixture(t);
   const separateStepOverwrite = readFileSync(join(base.root, workflowPath), 'utf8').replace(
     '      - name: Run Freshie hermetic publication cycle\n',
     "      - name: Overwrite Dolt after verification\n        if: matrix.test-type == 'python-tests'\n        run: sudo /usr/bin/install -m 0755 /tmp/unverified/dolt /usr/local/bin/dolt\n      - name: Run Freshie hermetic publication cycle\n",
@@ -688,7 +689,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.pinned_dolt, false);
 
-  base = fixture();
+  base = fixture(t);
   const alternateOverwriteWorkflow = readFileSync(join(base.root, workflowPath), 'utf8').replace(
     '          test "$installed_dolt_version" = "$dolt_version"\n',
     '          test "$installed_dolt_version" = "$dolt_version"\n          sudo /usr/bin/install -m 0755 /tmp/unverified/dolt /usr/local/bin/dolt\n',
@@ -698,7 +699,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.pinned_dolt, false);
 
-  base = fixture();
+  base = fixture(t);
   const overwrittenWorkflow = readFileSync(join(base.root, workflowPath), 'utf8').replace(
     '          test "$installed_dolt_version" = "$dolt_version"\n',
     '          test "$installed_dolt_version" = "$dolt_version"\n          sudo install -m 0755 /tmp/unverified/dolt /usr/local/bin/dolt\n',
@@ -708,7 +709,7 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.equal(rows[58].status, 'partial');
   assert.equal(rows[58].values.pinned_dolt, false);
 
-  base = fixture();
+  base = fixture(t);
   const emptyGrades = 'skill_path,grade,score\n';
   const emptyHash = createHash('sha256').update(emptyGrades).digest('hex');
   put(base.root, 'freshie/grades.csv', emptyGrades);
@@ -730,15 +731,15 @@ class HermeticFreshieCycleTests(unittest.TestCase):
   assert.notEqual(rows[52].status, 'target_met');
   assert.notEqual(rows[53].status, 'target_met');
 
-  base = fixture();
+  base = fixture(t);
   put(base.root, runPath, '{not json');
   rows = buildExtendedScorecardRows(input(base));
   assert.equal(rows[52].status, 'not_reproducible');
   assert.equal(rows[52].values, null);
 });
 
-test('legacy forge-proof evidence remains bound to its source when a newer run is empty', () => {
-  const base = fixture();
+test('legacy forge-proof evidence remains bound to its source when a newer run is empty', (t) => {
+  const base = fixture(t);
   const run9Path = 'freshie/reports/run-delta-9.json';
   const run10Path = 'freshie/reports/run-delta-10.json';
   const run10 = JSON.parse(readFileSync(join(base.root, run9Path), 'utf8'));
@@ -778,8 +779,8 @@ test('legacy forge-proof evidence remains bound to its source when a newer run i
   assert.equal(rows[55].status, 'not_reproducible');
 });
 
-test('measures privileged workflow action pins and exposes mutable references', () => {
-  const base = fixture();
+test('measures privileged workflow action pins and exposes mutable references', (t) => {
+  const base = fixture(t);
   let row = buildExtendedScorecardRows(input(base))[36];
   assert.equal(row.status, 'measured');
   assert.deepEqual(row.values.mutable_uses, []);
@@ -794,8 +795,8 @@ test('measures privileged workflow action pins and exposes mutable references', 
   assert.deepEqual(row.values.mutable_uses, ['.github/workflows/emit-evidence.yml:6']);
 });
 
-test('measurements follow fixture inputs and do not preserve historical blueprint numbers', () => {
-  const base = fixture();
+test('measurements follow fixture inputs and do not preserve historical blueprint numbers', (t) => {
+  const base = fixture(t);
   const first = buildExtendedScorecardRows(input(base));
   assert.equal(first[5].values.rows, 2);
   assert.equal(first[28].values.provenance_marked_mirrors, 1);
@@ -823,8 +824,8 @@ test('measurements follow fixture inputs and do not preserve historical blueprin
   }
 });
 
-test('rejects path traversal and ignores untracked validator rows', () => {
-  const base = fixture();
+test('rejects path traversal and ignores untracked validator rows', (t) => {
+  const base = fixture(t);
   const values = input(base);
   values.skillRows.push({ errors: 0, grade: 'A', path: 'plugins/untracked/SKILL.md', score: 100 });
   assert.equal(buildExtendedScorecardRows(values)[5].values.rows, 2);
@@ -834,8 +835,8 @@ test('rejects path traversal and ignores untracked validator rows', () => {
   );
 });
 
-test('scorecard corpus counts reject a supplied SKILL.md symlink', () => {
-  const base = fixture();
+test('scorecard corpus counts reject a supplied SKILL.md symlink', (t) => {
+  const base = fixture(t);
   const linked = 'plugins/local/skills/linked/SKILL.md';
   mkdirSync(dirname(join(base.root, linked)), { recursive: true });
   symlinkSync(join(base.root, 'plugins/local/skills/two/SKILL.md'), join(base.root, linked));

--- a/scripts/measure-epic-1.test.mjs
+++ b/scripts/measure-epic-1.test.mjs
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
@@ -16,6 +24,12 @@ import {
   trackedPaths,
   withIndexSnapshot,
 } from './measure-epic-1.mjs';
+
+function temporaryFixtureRoot(t, prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  return root;
+}
 
 function put(root, path, contents = '') {
   const target = join(root, path);
@@ -37,8 +51,8 @@ function evidence(rows = 2) {
   };
 }
 
-function fixture() {
-  const root = mkdtempSync(join(tmpdir(), 'epic-1-measurement-'));
+function fixture(t) {
+  const root = temporaryFixtureRoot(t, 'epic-1-measurement-');
   const files = {
     '.gitignore': 'plugins/mirror/\n',
     '.claude-plugin/marketplace.extended.json': JSON.stringify({
@@ -105,8 +119,8 @@ def _is_binary(path: Path):
   return root;
 }
 
-test('buildReport names cohorts and derives every governed row from tracked fixture evidence', () => {
-  const root = fixture();
+test('buildReport names cohorts and derives every governed row from tracked fixture evidence', (t) => {
+  const root = fixture(t);
   const report = buildReport(root, evidence());
   assert.deepEqual(
     Object.keys(report.rows),
@@ -143,8 +157,8 @@ test('buildReport names cohorts and derives every governed row from tracked fixt
   });
 });
 
-test('refuses a planted second README metrics writer even when it is indexed', () => {
-  const root = fixture();
+test('refuses a planted second README metrics writer even when it is indexed', (t) => {
+  const root = fixture(t);
   put(
     root,
     'packages/planted-readme-metrics/writer.mjs',
@@ -209,8 +223,8 @@ test('validator parsers fail closed on malformed evidence and missing summaries'
   );
 });
 
-test('Git-index snapshots exclude untracked and unstaged working-tree contamination', () => {
-  const root = fixture();
+test('Git-index snapshots exclude untracked and unstaged working-tree contamination', (t) => {
+  const root = fixture(t);
   const before = withIndexSnapshot(root, ({ paths, root: snapshot }) =>
     buildReport(snapshot, evidence(), paths),
   );
@@ -230,8 +244,8 @@ test('Git-index snapshots exclude untracked and unstaged working-tree contaminat
   assert.deepEqual(after, before);
 });
 
-test('Git-index snapshots measure staged bytes and ignore a later unstaged edit', () => {
-  const root = fixture();
+test('Git-index snapshots measure staged bytes and ignore a later unstaged edit', (t) => {
+  const root = fixture(t);
   put(root, 'sources.yaml', 'sources:\n  - name: beta\n');
   execFileSync('git', ['add', 'sources.yaml'], { cwd: root });
   put(root, 'sources.yaml', 'sources:\n  - name: contaminated\n');
@@ -243,8 +257,8 @@ test('Git-index snapshots measure staged bytes and ignore a later unstaged edit'
   });
 });
 
-test('Git-index snapshots expose the staged artifact rather than a matching worktree replacement', () => {
-  const root = fixture();
+test('Git-index snapshots expose the staged artifact rather than a matching worktree replacement', (t) => {
+  const root = fixture(t);
   put(root, '000-docs/742-RA-DATA-epic-1-scorecard.json', '{"state":"stale"}\n');
   execFileSync('git', ['add', '000-docs/742-RA-DATA-epic-1-scorecard.json'], { cwd: root });
   put(root, '000-docs/742-RA-DATA-epic-1-scorecard.json', '{"state":"working-copy"}\n');
@@ -256,9 +270,9 @@ test('Git-index snapshots expose the staged artifact rather than a matching work
   });
 });
 
-test('every executable measurement input must match its indexed bytes', () => {
-  const worktree = mkdtempSync(join(tmpdir(), 'epic-1-worktree-inputs-'));
-  const snapshot = mkdtempSync(join(tmpdir(), 'epic-1-snapshot-inputs-'));
+test('every executable measurement input must match its indexed bytes', (t) => {
+  const worktree = temporaryFixtureRoot(t, 'epic-1-worktree-inputs-');
+  const snapshot = temporaryFixtureRoot(t, 'epic-1-snapshot-inputs-');
   const path = 'scripts/imported-measurement.mjs';
   put(worktree, path, 'export const value = 1;\n');
   put(snapshot, path, 'export const value = 1;\n');
@@ -297,25 +311,25 @@ test('signature registry accepts genuine bytes, exposes counterfeits, and refuse
   );
 });
 
-test('Git, catalog, source, and detector contradictions fail closed', () => {
-  const empty = mkdtempSync(join(tmpdir(), 'epic-1-empty-'));
+test('Git, catalog, source, and detector contradictions fail closed', (t) => {
+  const empty = temporaryFixtureRoot(t, 'epic-1-empty-');
   execFileSync('git', ['init', '-q'], { cwd: empty });
   assert.throws(() => trackedPaths(empty), /inventory is empty/);
 
-  const duplicateSource = fixture();
+  const duplicateSource = fixture(t);
   put(duplicateSource, 'sources.yaml', 'sources:\n  - name: alpha\n  - name: alpha\n');
   const duplicateReport = buildReport(duplicateSource, evidence());
   assert.equal(duplicateReport.rows[27].status, 'undefined');
   assert.equal(duplicateReport.rows[27].values, null);
 
-  const unknownDetector = fixture();
+  const unknownDetector = fixture(t);
   put(unknownDetector, 'freshie/scripts/promote-to-curated.py', 'return False\n');
   assert.throws(
     () => buildReport(unknownDetector, evidence()),
     /unknown promotion binary-detector shape/,
   );
 
-  const oldDetector = fixture();
+  const oldDetector = fixture(t);
   put(
     oldDetector,
     'freshie/scripts/promote-to-curated.py',
@@ -349,4 +363,39 @@ test('stable output excludes runtime metadata and byte comparison catches one-va
   const cycle = {};
   cycle.self = cycle;
   assert.throws(() => stableJson(cycle), /cycle in output/);
+});
+
+test('temporary fixture cleanup runs after a real test failure', (t) => {
+  const proofRoot = mkdtempSync(join(tmpdir(), 'epic-1-cleanup-proof-'));
+  t.after(() => rmSync(proofRoot, { force: true, recursive: true }));
+  const probePath = join(proofRoot, 'failure-probe.test.mjs');
+  writeFileSync(
+    probePath,
+    `import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+${temporaryFixtureRoot.toString()}
+
+test('intentional failure', (t) => {
+  temporaryFixtureRoot(t, 'epic-1-failure-probe-');
+  assert.fail('intentional cleanup probe failure');
+});
+`,
+  );
+  const childEnvironment = {
+    ...process.env,
+    NODE_DISABLE_COMPILE_CACHE: '1',
+    TMPDIR: proofRoot,
+  };
+  delete childEnvironment.NODE_TEST_CONTEXT;
+  const child = spawnSync(process.execPath, ['--test', probePath], {
+    encoding: 'utf8',
+    env: childEnvironment,
+  });
+
+  assert.equal(child.status, 1, child.stderr || child.stdout);
+  assert.deepEqual(readdirSync(proofRoot), ['failure-probe.test.mjs']);
 });

--- a/scripts/normalize-retired-domain-projections.test.mjs
+++ b/scripts/normalize-retired-domain-projections.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
@@ -8,8 +8,9 @@ import test from 'node:test';
 import { DEAD_DOMAIN, LIVE_DOMAIN } from './dead-domain-policy.mjs';
 import { normalizeRetiredDomainProjections } from './normalize-retired-domain-projections.mjs';
 
-function fixture() {
+function fixture(t) {
   const root = mkdtempSync(join(tmpdir(), 'retired-domain-projections-'));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
   execFileSync('git', ['init', '-q'], { cwd: root });
   return root;
 }
@@ -21,8 +22,8 @@ function put(root, path, value) {
   execFileSync('git', ['add', '--', path], { cwd: root });
 }
 
-test('normalizes only registered generated JSON containing the retired domain', () => {
-  const root = fixture();
+test('normalizes only registered generated JSON containing the retired domain', (t) => {
+  const root = fixture(t);
   const generated = [
     '000-docs/742-RA-DATA-epic-1-scorecard.json',
     'marketplace/src/content/plugins/example.json',
@@ -58,8 +59,8 @@ test('normalizes only registered generated JSON containing the retired domain', 
   assert.match(readFileSync(join(root, mirror), 'utf8'), new RegExp(DEAD_DOMAIN));
 });
 
-test('refuses a symlinked generated projection without modifying its target', () => {
-  const root = fixture();
+test('refuses a symlinked generated projection without modifying its target', (t) => {
+  const root = fixture(t);
   const target = join(root, 'outside.json');
   const projection = 'marketplace/src/data/catalog.json';
   writeFileSync(target, JSON.stringify({ url: `https://${DEAD_DOMAIN}` }));


### PR DESCRIPTION
## Summary

- register every temporary fixture root in the four affected suites with per-test cleanup
- cover all seven prefixes created by those suites without shared cleanup state
- add a child-process regression proving cleanup still runs after a real test failure

## Verification

- 46/46 focused tests pass in an isolated TMPDIR with zero matching roots left behind
- pnpm run measure:e1:check passes: 42/42 tests and deterministic scorecard comparison OK
- ESLint, Prettier, and git diff --check pass
- independent Luna/high exact-diff re-review: PASS after concurrency and failure-path corrections
- MiniMax reviewed the byte-identical predecessor tree on #1456 and returned LGTM; exact-head review will rerun here

## Safety and scope

- byte-identical tree to #1456 head 03adbd89b5d9c0f3f6450a589e8cc89a0e75424a; rebuilt without force-push solely to replace the invalid commit scope tests with registered scope ci
- no dependency, product, generated catalog, or release changes
- existing historical temporary directories are handled under the separately approved no-loss repository sweep
- tracked by Bead claude-vggd.3.1
- do not merge without owner approval of the final exact head SHA

Supersedes #1456.