### PR TITLE
fix(external-sync): select the complete UIZZE plugin package

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -1213,7 +1213,7 @@ sources:
   - name: uizze
     description: STOP UI SLOP. Ground Claude Code in 800,000+ real web and iOS screens, a product-specific design contract, required states, and a hard finish gate.
     repo: uizze/uizze
-    source_path: .
+    source_path: plugins/claude-directory
     target_path: plugins/design/uizze
     author:
       name: UIZZE
@@ -1230,10 +1230,10 @@ sources:
       - anti-slop
     include:
       - '/.claude-plugin/plugin.json'
-      - '/.claude-plugin/marketplace.json'
-      - '/skills/anti-ui-slop/SKILL.md'
+      - '/skills/anti-ui-slop/**'
       - '/README.md'
       - '/LICENSE'
+      - '/SECURITY.md'
     exclude:
       - '/.git/**'
       - '**/node_modules/**'


### PR DESCRIPTION
## Problem

The UIZZE source currently selects only five files from the monorepo root. The checked-in skill still asks agents to run scripts/context.mjs and load playbooks that are absent from the mirror. The README describes retired MCP capabilities and points to paths that are not included.

## Proposed source correction

Use the maintained plugins/claude-directory package and select the complete anti-ui-slop directory, including its playbooks, reference policy, licenses, notices, and checksums. The package README is self-contained and uses canonical absolute links. The separate optional MCP now exposes only find_ui_references and find_ui_materials.

This PR changes source selection only. It does not alter sources.lock.json, bypass quarantine, or claim the mirrored files have already been refreshed. After reviewing the upstream diff, a maintainer can run the existing targeted sync/relock flow to regenerate the mirror. The complete source is visible at https://github.com/uizze/uizze/tree/main/plugins/claude-directory.

Affiliation: I maintain UIZZE.

## Verification

- git diff --check passes.
- The existing sync engine was run with --source=uizze --dry-run --strict. It resolves the intended upstream package and reports 14 added, 3 changed, and 1 removed file against the old lock. It exits nonzero because quarantine correctly requires a maintainer's reviewed relock; no source lock or mirror files changed.
- The attempted sync-marketplace command could not finish in the sparse checkout because its Prettier dependency is absent. Its intermediate generated catalog change was discarded; no generated artifacts are in this PR.
- No validator, publication gate, or trust policy is weakened.

## Current CI findings

The source-lock unit corpus, skill-conform, secret scan, and generated-content checks pass. The supply-chain gate explicitly requests human review for a source-list change without refreshed mirror contents (`sources-change-unscanned`), consistent with the intentionally pending relock above. The doc-governance job reports drift in `000-docs/742-RA-DATA-epic-1-scorecard.json`; this PR does not change that scorecard. Both checks remain visible rather than waived.
