### PR TITLE
fix(governance): reject nested identity decoys

### DIFF
--- a/scripts/check-identity-compatibility.mjs
+++ b/scripts/check-identity-compatibility.mjs
@@ -118,7 +118,10 @@ function buildProgramFunction(source) {
 function directCallsIn(node, receiver, method) {
   const calls = [];
   const visit = (current) => {
-    if (current !== node && ts.isFunctionLike(current)) return;
+    // Calls inside any nested function are not part of buildProgram's executed
+    // registration flow. This includes a function-like node passed as the root
+    // (for example, a variable initializer containing a decoy function).
+    if (ts.isFunctionLike(current)) return;
     if (
       ts.isCallExpression(current) &&
       ts.isPropertyAccessExpression(current.expression) &&

--- a/scripts/check-identity-compatibility.test.mjs
+++ b/scripts/check-identity-compatibility.test.mjs
@@ -149,6 +149,25 @@ test('the ccpi program identity and portable skills family remain registered', (
   assert.match(spoofViolations, /tons skills/);
 });
 
+test('unreachable nested functions cannot satisfy the program identity contract', () => {
+  const nestedFunctionSpoof = snapshot({
+    cliProgramSource: [
+      'export function buildProgram() {',
+      '  const program = new Command();',
+      "  function decoyName() { program.name('ccpi'); }",
+      '  const skills = function decoyCommand() {',
+      "    return program.command('skills');",
+      '  };',
+      '  return program;',
+      '}',
+    ].join('\n'),
+  });
+
+  const violations = checkIdentityCompatibility(nestedFunctionSpoof).join('\n');
+  assert.match(violations, /ccpi program identity/);
+  assert.match(violations, /tons skills/);
+});
+
 test('live redirect verifier follows every legacy route to the canonical destination', async () => {
   const seen = [];
   const results = await checkLiveRedirects(async (url) => {


### PR DESCRIPTION
## Summary

Immediate follow-up to merged #1455. The AST identity checker correctly ignored nested functions during recursive descent, but still accepted a function-like node when that node was supplied as the traversal root from a variable initializer. An unreachable decoy function could therefore satisfy the canonical `program.command` check.

This two-file patch makes every function-like subtree fail closed, including a function-like root, and adds the exact nested-function regression for both the `ccpi` name and `skills` command requirements.

## Verification

- exact head `848ba5cbe1fbc3232a5fdb49c42c5a4592726635`
- frozen root install
- identity suite: 12/12
- Prettier and ESLint
- audit-harness verification
- diff whitespace check

No dependencies, generated artifacts, workflow policy, release state, or branch protection are changed. This is tracked under `claude-vggd.1` as the settlement fix for #1455. Merge remains gated on fresh hosted required checks and reviewer reconciliation. The advisory PR-time CodeQL workflow intentionally scopes itself to `packages/**` and `marketplace/src/**`, so this `scripts/**`-only follow-up does not trigger CodeQL; the normal main-push CodeQL lane remains unchanged.

The second commit is intentionally empty: it triggers a fresh pull-request event after correcting the PR title from an unregistered scope to `fix(governance): …`, so `commit-scope-check` evaluates the corrected event payload rather than a stale rerun payload.


