### PR TITLE
fix(governance): satisfy funding portal length limit

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -51,7 +51,7 @@
         "guid": "security-sustainability-2026",
         "status": "active",
         "name": "Security and maintainer sustainability",
-        "description": "$15,000 for 300 hours of protected maintainer time at $50 per hour over 6 to 9 months, covering vulnerability remediation, dependency hygiene, secure releases, incident response, and contributor review; $5,000 for a focused independent security review and threat model, with an independent reviewer selected through a documented conflict-aware process; $3,000 for CI, testing, artifact, and observability infrastructure; and $2,000 for contributor bounties, security documentation, and community response.",
+        "description": "$15,000 for 300 protected maintainer hours at $50 per hour over 6 to 9 months, covering vulnerability remediation, dependency hygiene, secure releases, incident response, and contributor review; $5,000 for an independent security review and threat model, with the reviewer selected through a documented conflict-aware process; $3,000 for CI, testing, artifact, and observability infrastructure; and $2,000 for contributor bounties, security documentation, and community response.",
         "amount": 25000,
         "currency": "USD",
         "frequency": "one-time",


### PR DESCRIPTION
## Summary

- shorten the FLOSS/fund plan description from 505 to 479 characters
- preserve the approved $25,000 budget and security scope
- satisfy the portal validator limit that is enforced by the submission service but absent from the published JSON Schema

## Evidence

- `python3 -m json.tool funding.json`
- Prettier check
- `git diff --check`
- staged gitleaks scan
- added-line Unicode dash audit
- FLOSS/fund `POST /api/validate` returned HTTP 200 for this manifest

## Context

The first submission attempt was rejected with HTTP 400 because `plans[security-sustainability-2026].description` exceeded 500 characters. No application was created.

Bead: `claude-8w79`