### PR TITLE
fix(skill-creator): distinguish documented agent fields

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -6666,7 +6666,7 @@
       "name": "skill-creator",
       "source": "./plugins/skill-enhancers/skill-creator",
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "category": "skill-enhancers",
       "keywords": [
         "skill-creation",

--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -6666,7 +6666,7 @@
       "name": "skill-creator",
       "source": "./plugins/skill-enhancers/skill-creator",
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "category": "skill-enhancers",
       "keywords": [
         "skill-creation",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4983,7 +4983,7 @@
       "name": "skill-creator",
       "source": "./plugins/skill-enhancers/skill-creator",
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "category": "skill-enhancers",
       "keywords": [
         "skill-creation",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4983,7 +4983,7 @@
       "name": "skill-creator",
       "source": "./plugins/skill-enhancers/skill-creator",
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "category": "skill-enhancers",
       "keywords": [
         "skill-creation",

--- a/000-docs/813-RA-AUDT-saas-tutorial-lattice.md
+++ b/000-docs/813-RA-AUDT-saas-tutorial-lattice.md
@@ -24,8 +24,8 @@ A matching skill name proves structural repetition only. It does **not** prove t
 | Candidates admitted by explicit prefix aliases | 78 |
 | Suffix-only names excluded by prefix policy | 1 |
 
-- Catalog SHA-256: `67504940286db809fa6056405f42120211928ce5415dbe304fcf289666dca5c6`
-- Tracked inventory SHA-256: `cb02dbb86dcb24ca9d9be8e60b9016a7feaed8bcb50b2b86ca0395281451c47a`
+- Catalog SHA-256: `5a5ce6912987ab26207b31ac0b3c0c2ffc639928af1df7ee0aae1185a3adb716`
+- Tracked inventory SHA-256: `ba5cb84b110c6991c33621ea21b95de87f4bf3899dc34bf764f9bcfbf674d44f`
 
 The earlier 2,011-candidate census used 24 base families and literal pack-name stems. This version expands the family set with `advanced-troubleshooting`, `architecture-variants`, `known-pitfalls`, `load-scale`, `policy-guardrails`, and `reliability-patterns`, then applies versioned exact aliases for `anthropic-pack`, `claude-pack`, and `langchain-py-pack`. The current generated counts above are authoritative. Suffix-only near-matches such as `langchain-otel-observability` and the explicitly recorded content-specific Customer.io workflows remain excluded.
 

--- a/freshie/saas-tutorial-lattice.json
+++ b/freshie/saas-tutorial-lattice.json
@@ -4,10 +4,10 @@
   "semantics": "Family-name matches are review candidates, not automatic quality or retirement verdicts.",
   "sources": {
     "catalog": ".claude-plugin/marketplace.extended.json",
-    "catalog_sha256": "67504940286db809fa6056405f42120211928ce5415dbe304fcf289666dca5c6",
+    "catalog_sha256": "5a5ce6912987ab26207b31ac0b3c0c2ffc639928af1df7ee0aae1185a3adb716",
     "curated_manifest": "skills/.curated/MANIFEST.json",
     "curated_manifest_sha256": "b20a1cf091bb5ab8c149265c8b29ff18bfa41217bbddfa775292602204888a41",
-    "tracked_inventory_sha256": "cb02dbb86dcb24ca9d9be8e60b9016a7feaed8bcb50b2b86ca0395281451c47a"
+    "tracked_inventory_sha256": "ba5cb84b110c6991c33621ea21b95de87f4bf3899dc34bf764f9bcfbf674d44f"
   },
   "family_definition": [
     "advanced-troubleshooting",

--- a/marketplace/src/data/catalog.json
+++ b/marketplace/src/data/catalog.json
@@ -7126,7 +7126,7 @@
       "name": "skill-creator",
       "displayName": "skill creator",
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "category": "skill-enhancers",
       "keywords": [
         "skill-creation",

--- a/marketplace/src/data/catalog.json
+++ b/marketplace/src/data/catalog.json
@@ -7126,7 +7126,7 @@
       "name": "skill-creator",
       "displayName": "skill creator",
       "description": "Create and validate production-grade agent skills with 100-point marketplace grading. Supports creation workflows, eval-driven development, and auto-fix for spec compliance.",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "category": "skill-enhancers",
       "keywords": [
         "skill-creation",

--- a/marketplace/src/data/skills-index.json
+++ b/marketplace/src/data/skills-index.json
@@ -677,8 +677,8 @@
     {
       "slug": "agent-creator",
       "name": "agent-creator",
-      "description": "Create production-grade agent .md files aligned with the current Anthropic 17-field subagent schema. Also validates existing agents against the marketplace compliance rules. Use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. Trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". Make sure to use this skill whenever creating agents/*.md files for plugins or standalone use.",
-      "version": "5.22.0",
+      "description": "Create production-grade agent .md files aligned with the current Anthropic subagent contract. Also validates existing agents against the marketplace compliance rules. Use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. Trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". Make sure to use this skill whenever creating agents/*.md files for plugins or standalone use.",
+      "version": "5.22.1",
       "category": "skill-enhancers",
       "parentPlugin": "skill-creator",
       "requires_env": [],
@@ -34804,7 +34804,7 @@
     }
   ],
   "count": 2900,
-  "generatedAt": "2026-09-11T13:11:56.955Z",
+  "generatedAt": "2026-09-11T14:25:43.031Z",
   "categories": [
     "ai-agency",
     "ai-ml",

--- a/marketplace/src/data/skills-index.json
+++ b/marketplace/src/data/skills-index.json
@@ -34804,7 +34804,7 @@
     }
   ],
   "count": 2900,
-  "generatedAt": "2026-09-11T14:35:17.077Z",
+  "generatedAt": "2026-09-11T14:41:48.979Z",
   "categories": [
     "ai-agency",
     "ai-ml",

--- a/marketplace/src/data/skills-index.json
+++ b/marketplace/src/data/skills-index.json
@@ -678,7 +678,7 @@
       "slug": "agent-creator",
       "name": "agent-creator",
       "description": "Create production-grade agent .md files aligned with the current Anthropic subagent contract. Also validates existing agents against the marketplace compliance rules. Use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. Trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". Make sure to use this skill whenever creating agents/*.md files for plugins or standalone use.",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "category": "skill-enhancers",
       "parentPlugin": "skill-creator",
       "requires_env": [],
@@ -30378,7 +30378,7 @@
       "slug": "skill-creator",
       "name": "skill-creator",
       "description": "Create production-grade agent skills aligned with the 2026 AgentSkills.io spec and Anthropic best practices (2026). Also validates existing skills against the Intent Solutions 100-point rubric. Use when building, testing, validating, or optimizing Claude Code skills. Trigger with \"/skill-creator\", \"create a skill\", \"validate my skill\", or \"check skill quality\". Make sure to use this skill whenever creating a new skill, slash command, or agent capability.",
-      "version": "5.22.0",
+      "version": "5.23.0",
       "category": "skill-enhancers",
       "parentPlugin": "skill-creator",
       "requires_env": [],
@@ -34804,7 +34804,7 @@
     }
   ],
   "count": 2900,
-  "generatedAt": "2026-09-11T14:25:43.031Z",
+  "generatedAt": "2026-09-11T14:35:17.077Z",
   "categories": [
     "ai-agency",
     "ai-ml",

--- a/marketplace/src/data/unified-search-index.json
+++ b/marketplace/src/data/unified-search-index.json
@@ -9798,7 +9798,7 @@
         "email": "jeremy@intentsolutions.io"
       },
       "authorType": "official",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "isFeatured": true,
       "isNew": false,
       "badges": [],
@@ -16289,7 +16289,7 @@
         "Agent"
       ],
       "compatibleWith": [],
-      "version": "5.22.1",
+      "version": "5.23.0",
       "parentPlugin": {
         "name": "skill-creator",
         "category": "skill-enhancers"
@@ -71402,7 +71402,7 @@
         "AskUserQuestion"
       ],
       "compatibleWith": [],
-      "version": "5.22.0",
+      "version": "5.23.0",
       "parentPlugin": {
         "name": "skill-creator",
         "category": "skill-enhancers"

--- a/marketplace/src/data/unified-search-index.json
+++ b/marketplace/src/data/unified-search-index.json
@@ -9798,7 +9798,7 @@
         "email": "jeremy@intentsolutions.io"
       },
       "authorType": "official",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "isFeatured": true,
       "isNew": false,
       "badges": [],
@@ -16276,7 +16276,7 @@
       "id": "agent-creator",
       "slug": "agent-creator",
       "name": "agent-creator",
-      "description": "Create production-grade agent .md files aligned with the current Anthropic 17-field subagent schema. Also validates existing agents against the marketplace compliance rules. Use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. Trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". Make sure to use this skill whenever creating agents/*.md files for plugins or standalone use.",
+      "description": "Create production-grade agent .md files aligned with the current Anthropic subagent contract. Also validates existing agents against the marketplace compliance rules. Use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. Trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". Make sure to use this skill whenever creating agents/*.md files for plugins or standalone use.",
       "category": "skill-enhancers",
       "allowedTools": [
         "Read",
@@ -16289,12 +16289,12 @@
         "Agent"
       ],
       "compatibleWith": [],
-      "version": "5.22.0",
+      "version": "5.22.1",
       "parentPlugin": {
         "name": "skill-creator",
         "category": "skill-enhancers"
       },
-      "searchText": "agent-creator create production-grade agent .md files aligned with the current anthropic 17-field subagent schema. also validates existing agents against the marketplace compliance rules. use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". make sure to use this skill whenever creating agents/*.md files for plugins or standalone use. skill-enhancers read write edit glob grep bash(python:*) askuserquestion agent "
+      "searchText": "agent-creator create production-grade agent .md files aligned with the current anthropic subagent contract. also validates existing agents against the marketplace compliance rules. use when building custom subagents, reviewing agent quality, or creating parallel agent architectures for orchestrator skills. trigger with \"/agent-creator\", \"create an agent\", \"build a subagent\", or \"validate my agent\". make sure to use this skill whenever creating agents/*.md files for plugins or standalone use. skill-enhancers read write edit glob grep bash(python:*) askuserquestion agent "
     },
     {
       "type": "skill",

--- a/plugins/skill-enhancers/skill-creator/.claude-plugin/plugin.json
+++ b/plugins/skill-enhancers/skill-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-creator",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Create and validate production-grade agent skills with 100-point marketplace grading",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/skill-enhancers/skill-creator/.claude-plugin/plugin.json
+++ b/plugins/skill-enhancers/skill-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-creator",
-  "version": "5.22.1",
+  "version": "5.23.0",
   "description": "Create and validate production-grade agent skills with 100-point marketplace grading",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/skill-enhancers/skill-creator/package.json
+++ b/plugins/skill-enhancers/skill-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/skill-creator",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "Create and validate production-grade agent skills with 100-point marketplace grading",
   "keywords": [
     "skill-creation",

--- a/plugins/skill-enhancers/skill-creator/skills/agent-creator/SKILL.md
+++ b/plugins/skill-enhancers/skill-creator/skills/agent-creator/SKILL.md
@@ -18,7 +18,7 @@ description: 'Create production-grade agent .md files aligned with the current A
   '
 allowed-tools: Read,Write,Edit,Glob,Grep,Bash(python:*),AskUserQuestion,Agent
 argument-hint: "<create|validate> [agent path or requirements]"
-version: 5.22.1
+version: 5.23.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/plugins/skill-enhancers/skill-creator/skills/agent-creator/SKILL.md
+++ b/plugins/skill-enhancers/skill-creator/skills/agent-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-creator
 description: 'Create production-grade agent .md files aligned with the current Anthropic
-  17-field subagent schema.
+  subagent contract.
 
   Also validates existing agents against the marketplace compliance rules. Use when
   building custom
@@ -18,7 +18,7 @@ description: 'Create production-grade agent .md files aligned with the current A
   '
 allowed-tools: Read,Write,Edit,Glob,Grep,Bash(python:*),AskUserQuestion,Agent
 argument-hint: "<create|validate> [agent path or requirements]"
-version: 5.22.0
+version: 5.22.1
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:
@@ -32,14 +32,15 @@ compatibility: Designed for Claude Code
 ---
 # Agent Creator
 
-Creates spec-compliant agent .md files following the current Anthropic 17-field schema. Supports
-both creation of new agents and validation of existing ones.
+Creates spec-compliant agent .md files following Anthropic's current documented subagent
+frontmatter contract. Supports both creation of new agents and validation of existing ones.
 
 ## Overview
 
 Agent Creator fills the gap between ad-hoc agent files and production-grade agents that pass
-marketplace validation. It recognizes all 17 upstream fields, then layers the stricter Intent
-Solutions required set on top. It prevents
+marketplace validation. It distinguishes the 16 fields in Anthropic's public frontmatter table
+from runtime-recognized experimental options, then layers the stricter Intent Solutions required
+set on top. It prevents
 common mistakes (using `allowed-tools` instead of `disallowedTools`, adding invalid fields like
 `capabilities` or `expertise_level`), and produces agents with substantive body content that
 actually guides Claude's behavior.
@@ -48,8 +49,10 @@ Key difference from skill-creator: **agents support both `tools` (allowlist) AND
 (denylist)**. Skills use `allowed-tools` (allowlist) and, since schema 3.7.0, an optional
 kebab-case `disallowed-tools` denylist — a parallel field, not a unification. Agents also support
 `effort`, `maxTurns`, `skills`, `memory`, `isolation`, `permissionMode`, `background`, `color`, and
-`initialPrompt`, and `experimental` — fields that don't exist for skills. The agent body becomes the **system prompt**
-that drives the subagent — it does NOT receive the full Claude Code system prompt.
+`initialPrompt` — fields that don't exist for skills. Claude Code also recognizes a separately
+labeled runtime `experimental` object; do not present it as part of the public 16-field table.
+The agent body becomes the **system prompt** that drives the subagent — it does NOT receive the
+full Claude Code system prompt.
 
 **Field-naming warning:** Agents use camelCase `disallowedTools:` (canonical sub-agents spec);
 skills use kebab-case `disallowed-tools:` (schema 3.7.0+). The validator rejects either mismatch —
@@ -139,7 +142,7 @@ Generate the agent .md using the template from
 Use `Write` for a new definition and `Edit` for a targeted remediation of an
 existing definition; do not replace unrelated project content.
 
-**Frontmatter Rules (Anthropic 17-field schema):**
+**Frontmatter Rules (documented schema plus runtime extension):**
 
 See [Anthropic Agent Spec](references/anthropic-agent-spec.md) for the full official reference.
 
@@ -223,7 +226,7 @@ experimental:              # Claude Code v2.1.248+; optional
 
 ### Step 4: Validate the Agent
 
-Run validation against the Anthropic 17-field schema:
+Run validation against the documented Anthropic schema and the runtime extension allowlist:
 
 **Manual checklist:**
 
@@ -262,7 +265,7 @@ Test the agent by spawning it via the `Agent` tool:
 Provide a summary:
 
 - Agent name and file path
-- Frontmatter field count (of 17 upstream fields, plus the IS enterprise overlay)
+- Documented frontmatter fields used, plus any runtime extension and IS overlay fields used
 - Body line count
 - Sections present
 - Validation result (pass/fail with specific issues)
@@ -274,7 +277,7 @@ When the user wants to validate an existing agent:
 
 1. Locate the agent .md file
 2. Parse YAML frontmatter
-3. Check against the 17-field Anthropic schema:
+3. Check against the documented Anthropic schema and runtime extension allowlist:
    - `name` present and valid (1-64 chars, kebab-case)?
    - `description` present and valid (20-1536 chars; concise and selection-specific)?
    - Any invalid fields? (capabilities, expertise_level, activation_priority, etc.)
@@ -351,7 +354,7 @@ actionable).
 
 ## Resources
 
-- [Anthropic Agent Spec](references/anthropic-agent-spec.md) — Official 17-field schema from code.claude.com/docs/en/sub-agents
+- [Anthropic Agent Spec](references/anthropic-agent-spec.md) — documented 16-field table plus the separately labeled runtime extension
 - Agent template — Skeleton with placeholders
 - Frontmatter spec — Field reference (internal)
 - Source of truth — Canonical spec

--- a/plugins/skill-enhancers/skill-creator/skills/agent-creator/references/anthropic-agent-spec.md
+++ b/plugins/skill-enhancers/skill-creator/skills/agent-creator/references/anthropic-agent-spec.md
@@ -24,6 +24,7 @@ Only `name` and `description` are required.
 | `isolation` | No | `worktree` — run in temporary git worktree |
 | `color` | No | Display color: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` |
 | `initialPrompt` | No | Auto-submitted as first user turn when running as main agent via `--agent` |
+
 Total: 16 fields in Anthropic's public supported-frontmatter table.
 
 ## Runtime Experimental Extension

--- a/plugins/skill-enhancers/skill-creator/skills/agent-creator/references/anthropic-agent-spec.md
+++ b/plugins/skill-enhancers/skill-creator/skills/agent-creator/references/anthropic-agent-spec.md
@@ -2,7 +2,7 @@
 
 Source: https://code.claude.com/docs/en/sub-agents (fetched 2026-09-09)
 
-## Supported Frontmatter Fields
+## Documented Frontmatter Fields
 
 Only `name` and `description` are required.
 
@@ -24,9 +24,15 @@ Only `name` and `description` are required.
 | `isolation` | No | `worktree` — run in temporary git worktree |
 | `color` | No | Display color: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` |
 | `initialPrompt` | No | Auto-submitted as first user turn when running as main agent via `--agent` |
-| `experimental` | No | Experimental options; `cacheTtl` accepts `5m` or `1h` in Claude Code v2.1.248+ |
+Total: 16 fields in Anthropic's public supported-frontmatter table.
 
-Total: 17 official fields.
+## Runtime Experimental Extension
+
+Claude Code v2.1.248+ also recognizes an `experimental` object whose current
+`cacheTtl` value accepts `5m` or `1h`. This runtime extension is intentionally
+kept separate from the 16 fields in the public documentation table because
+experimental options can change or disappear without the stability expected of
+documented frontmatter.
 
 ## Key Facts
 

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/SKILL.md
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/SKILL.md
@@ -17,7 +17,7 @@ description: 'Create production-grade agent skills aligned with the 2026 AgentSk
   '
 argument-hint: "<create|validate|optimize> [skill-path]"
 allowed-tools: Read,Write,Edit,Glob,Grep,Bash(mkdir:*),Bash(chmod:*),Bash(python:*),Bash(claude:*),Agent,AskUserQuestion
-version: 5.22.0
+version: 5.23.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/skills/.curated/agent-creator/SKILL.md
+++ b/skills/.curated/agent-creator/SKILL.md
@@ -18,7 +18,7 @@ description: 'Create production-grade agent .md files aligned with the current A
   '
 allowed-tools: Read,Write,Edit,Glob,Grep,Bash(python:*),AskUserQuestion,Agent
 argument-hint: "<create|validate> [agent path or requirements]"
-version: 5.22.1
+version: 5.23.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/skills/.curated/agent-creator/SKILL.md
+++ b/skills/.curated/agent-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-creator
 description: 'Create production-grade agent .md files aligned with the current Anthropic
-  17-field subagent schema.
+  subagent contract.
 
   Also validates existing agents against the marketplace compliance rules. Use when
   building custom
@@ -18,7 +18,7 @@ description: 'Create production-grade agent .md files aligned with the current A
   '
 allowed-tools: Read,Write,Edit,Glob,Grep,Bash(python:*),AskUserQuestion,Agent
 argument-hint: "<create|validate> [agent path or requirements]"
-version: 5.22.0
+version: 5.22.1
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:
@@ -32,14 +32,15 @@ compatibility: Designed for Claude Code
 ---
 # Agent Creator
 
-Creates spec-compliant agent .md files following the current Anthropic 17-field schema. Supports
-both creation of new agents and validation of existing ones.
+Creates spec-compliant agent .md files following Anthropic's current documented subagent
+frontmatter contract. Supports both creation of new agents and validation of existing ones.
 
 ## Overview
 
 Agent Creator fills the gap between ad-hoc agent files and production-grade agents that pass
-marketplace validation. It recognizes all 17 upstream fields, then layers the stricter Intent
-Solutions required set on top. It prevents
+marketplace validation. It distinguishes the 16 fields in Anthropic's public frontmatter table
+from runtime-recognized experimental options, then layers the stricter Intent Solutions required
+set on top. It prevents
 common mistakes (using `allowed-tools` instead of `disallowedTools`, adding invalid fields like
 `capabilities` or `expertise_level`), and produces agents with substantive body content that
 actually guides Claude's behavior.
@@ -48,8 +49,10 @@ Key difference from skill-creator: **agents support both `tools` (allowlist) AND
 (denylist)**. Skills use `allowed-tools` (allowlist) and, since schema 3.7.0, an optional
 kebab-case `disallowed-tools` denylist — a parallel field, not a unification. Agents also support
 `effort`, `maxTurns`, `skills`, `memory`, `isolation`, `permissionMode`, `background`, `color`, and
-`initialPrompt`, and `experimental` — fields that don't exist for skills. The agent body becomes the **system prompt**
-that drives the subagent — it does NOT receive the full Claude Code system prompt.
+`initialPrompt` — fields that don't exist for skills. Claude Code also recognizes a separately
+labeled runtime `experimental` object; do not present it as part of the public 16-field table.
+The agent body becomes the **system prompt** that drives the subagent — it does NOT receive the
+full Claude Code system prompt.
 
 **Field-naming warning:** Agents use camelCase `disallowedTools:` (canonical sub-agents spec);
 skills use kebab-case `disallowed-tools:` (schema 3.7.0+). The validator rejects either mismatch —
@@ -139,7 +142,7 @@ Generate the agent .md using the template from
 Use `Write` for a new definition and `Edit` for a targeted remediation of an
 existing definition; do not replace unrelated project content.
 
-**Frontmatter Rules (Anthropic 17-field schema):**
+**Frontmatter Rules (documented schema plus runtime extension):**
 
 See [Anthropic Agent Spec](references/anthropic-agent-spec.md) for the full official reference.
 
@@ -223,7 +226,7 @@ experimental:              # Claude Code v2.1.248+; optional
 
 ### Step 4: Validate the Agent
 
-Run validation against the Anthropic 17-field schema:
+Run validation against the documented Anthropic schema and the runtime extension allowlist:
 
 **Manual checklist:**
 
@@ -262,7 +265,7 @@ Test the agent by spawning it via the `Agent` tool:
 Provide a summary:
 
 - Agent name and file path
-- Frontmatter field count (of 17 upstream fields, plus the IS enterprise overlay)
+- Documented frontmatter fields used, plus any runtime extension and IS overlay fields used
 - Body line count
 - Sections present
 - Validation result (pass/fail with specific issues)
@@ -274,7 +277,7 @@ When the user wants to validate an existing agent:
 
 1. Locate the agent .md file
 2. Parse YAML frontmatter
-3. Check against the 17-field Anthropic schema:
+3. Check against the documented Anthropic schema and runtime extension allowlist:
    - `name` present and valid (1-64 chars, kebab-case)?
    - `description` present and valid (20-1536 chars; concise and selection-specific)?
    - Any invalid fields? (capabilities, expertise_level, activation_priority, etc.)
@@ -351,7 +354,7 @@ actionable).
 
 ## Resources
 
-- [Anthropic Agent Spec](references/anthropic-agent-spec.md) — Official 17-field schema from code.claude.com/docs/en/sub-agents
+- [Anthropic Agent Spec](references/anthropic-agent-spec.md) — documented 16-field table plus the separately labeled runtime extension
 - Agent template — Skeleton with placeholders
 - Frontmatter spec — Field reference (internal)
 - Source of truth — Canonical spec

--- a/skills/.curated/agent-creator/references/anthropic-agent-spec.md
+++ b/skills/.curated/agent-creator/references/anthropic-agent-spec.md
@@ -24,6 +24,7 @@ Only `name` and `description` are required.
 | `isolation` | No | `worktree` — run in temporary git worktree |
 | `color` | No | Display color: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` |
 | `initialPrompt` | No | Auto-submitted as first user turn when running as main agent via `--agent` |
+
 Total: 16 fields in Anthropic's public supported-frontmatter table.
 
 ## Runtime Experimental Extension

--- a/skills/.curated/agent-creator/references/anthropic-agent-spec.md
+++ b/skills/.curated/agent-creator/references/anthropic-agent-spec.md
@@ -2,7 +2,7 @@
 
 Source: https://code.claude.com/docs/en/sub-agents (fetched 2026-09-09)
 
-## Supported Frontmatter Fields
+## Documented Frontmatter Fields
 
 Only `name` and `description` are required.
 
@@ -24,9 +24,15 @@ Only `name` and `description` are required.
 | `isolation` | No | `worktree` — run in temporary git worktree |
 | `color` | No | Display color: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan` |
 | `initialPrompt` | No | Auto-submitted as first user turn when running as main agent via `--agent` |
-| `experimental` | No | Experimental options; `cacheTtl` accepts `5m` or `1h` in Claude Code v2.1.248+ |
+Total: 16 fields in Anthropic's public supported-frontmatter table.
 
-Total: 17 official fields.
+## Runtime Experimental Extension
+
+Claude Code v2.1.248+ also recognizes an `experimental` object whose current
+`cacheTtl` value accepts `5m` or `1h`. This runtime extension is intentionally
+kept separate from the 16 fields in the public documentation table because
+experimental options can change or disappear without the stability expected of
+documented frontmatter.
 
 ## Key Facts
 

--- a/skills/.curated/skill-creator/SKILL.md
+++ b/skills/.curated/skill-creator/SKILL.md
@@ -17,7 +17,7 @@ description: 'Create production-grade agent skills aligned with the 2026 AgentSk
   '
 argument-hint: "<create|validate|optimize> [skill-path]"
 allowed-tools: Read,Write,Edit,Glob,Grep,Bash(mkdir:*),Bash(chmod:*),Bash(python:*),Bash(claude:*),Agent,AskUserQuestion
-version: 5.22.0
+version: 5.23.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:


### PR DESCRIPTION
Corrects the `agent-creator` surface after #1478 already separated the two creator paths. This PR does not change Google ADK scaffolding.

- keeps `agent-creator` focused on Claude Code subagent definitions
- keeps `/create-agent` as the distinct Google ADK application scaffold command
- distinguishes Anthropic’s 16 publicly documented frontmatter fields from Claude Code’s separately labeled runtime `experimental.cacheTtl` extension
- replaces the misleading `17-field schema` wording in the published skill and reference
- bumps `skill-creator` to 5.23.0 and regenerates the curated and marketplace projections

Local pre-CI validation:

- `agent-creator`: A94; all five Tier-2 checks GREEN
- unchanged Google ADK skill: A100; all five Tier-2 checks GREEN
- unchanged `/create-agent` command validation: PASS
- focused schema tests: 60 passed
- generated-content suite: 43 passed; two skill projections and the catalog projection exact
- curated mirror check: 2,566 promoted skills exact
- full-repository markdownlint: 0 issues
- strict Unicode and Prettier: PASS
- official `skills` CLI installed both then-public-main skills byte-exact

The local full Astro render reached route generation but stopped when the host filesystem hit ENOSPC. Required CI is the authoritative clean-build result for this head.

Bead: `claude-juoz.13`